### PR TITLE
Improve search performance

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -97,18 +97,20 @@ Inspector.prototype.search = function (s) {
     $('tr', table).remove();
     viewer.clearRelatedHighlighting();
     $.each(results, function (i,r) {
-        viewer.highlightRelatedFact(r.fact);
-        var row = $('<tr>')
-            .click(function () { viewer.showAndSelectFact(r.fact) })
-            .mouseenter(function () { viewer.linkedHighlightFact(r.fact); })
-            .mouseleave(function () { viewer.clearLinkedHighlightFact(r.fact); })
-            .data('ivid', r.fact.id)
-            .appendTo($("tbody", table));
-        $('<td>')
-            .text(r.fact.getLabel("std")) // + " (" + r.score + ")" );
-            .appendTo(row);
+        if (i < 100) {
+            var row = $('<tr>')
+                .click(function () { viewer.showAndSelectFact(r.fact) })
+                .mouseenter(function () { viewer.linkedHighlightFact(r.fact); })
+                .mouseleave(function () { viewer.clearLinkedHighlightFact(r.fact); })
+                .data('ivid', r.fact.id)
+                .appendTo($("tbody", table));
+            $('<td>')
+                .text(r.fact.getLabel("std")) // + " (" + r.score + ")" );
+                .appendTo(row);
+        }
 
     });
+    viewer.highlightRelatedFacts($.map(results, function (r) { return r.fact } ));
     
 }
 

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -201,7 +201,6 @@ Viewer.prototype.elementForFact = function (fact) {
 Viewer.prototype.elementsForFacts = function (facts) {
     var ids = $.map(facts, function (f) { return f.id });
     var elements = $('.ixbrl-element', this._contents).filter(function () { return $.inArray($(this).data('ivid'), ids ) > -1 });
-    console.log(elements);
     return elements;
 }
 

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -186,12 +186,23 @@ Viewer.prototype.highlightRelatedFact = function (f) {
     e.addClass("ixbrl-related");
 }
 
+Viewer.prototype.highlightRelatedFacts = function (facts) {
+    this.elementsForFacts(facts).addClass("ixbrl-related");
+}
+
 Viewer.prototype.clearRelatedHighlighting = function (f) {
     $(".ixbrl-related", this._contents).removeClass("ixbrl-related");
 }
 
 Viewer.prototype.elementForFact = function (fact) {
     return $('.ixbrl-element', this._contents).filter(function () { return $(this).data('ivid') == fact.id }).first();
+}
+
+Viewer.prototype.elementsForFacts = function (facts) {
+    var ids = $.map(facts, function (f) { return f.id });
+    var elements = $('.ixbrl-element', this._contents).filter(function () { return $.inArray($(this).data('ivid'), ids ) > -1 });
+    console.log(elements);
+    return elements;
 }
 
 Viewer.prototype.showAndSelectFact = function (fact) {


### PR DESCRIPTION
Substantially improve search performance by highlighting facts in the iXBRL document in a single pass, rather than individually.  Previously searches with a large number of results on a large document could lead to the UI locking up for a number of seconds.

This also limits the number of results shown to 100, although this could safely be higher with the above fix.