### PR TITLE
Fact deep link

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/index.js
+++ b/iXBRLViewerPlugin/viewer/src/js/index.js
@@ -81,6 +81,9 @@ $(function () {
                         $('#ixv').css("pointer-events", "auto");
                     });
                     $('#ixv .loader').remove();
+
+                    /* Focus on fact specified in URL fragment, if any */
+                    inspector.handleFactDeepLink();
                 },0);
 
 

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -71,14 +71,16 @@ Inspector.prototype.setViewer = function (viewer) {
     $('#top-bar .document-title').text(this._viewer.getTitle());
 }
 
-/* 
+/*
  * Check for fragment identifier pointing to a specific fact and select it if
  * present.
  */
 Inspector.prototype.handleFactDeepLink = function () {
     if (location.hash.startsWith("#f-")) {
-        var factId = location.hash.slice(3);
-        this._viewer.showAndSelectFact(this._report.getFactById(factId));
+        var fact = this._report.getFactById(location.hash.slice(3));
+        if (fact !== null) {
+            this._viewer.showAndSelectFact(fact);
+        }
     }
 }
 

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -14,7 +14,6 @@
 
 import $ from 'jquery'
 import { formatNumber, wrapLabel } from "./util.js";
-
 import { ReportSearch } from "./search.js";
 import { Calculation } from "./calculations.js";
 import { IXBRLChart } from './chart.js';
@@ -70,6 +69,23 @@ Inspector.prototype.setViewer = function (viewer) {
     $('#ixbrl-search').change(function () { inspector.search($(this).val()) });
 
     $('#top-bar .document-title').text(this._viewer.getTitle());
+}
+
+/* 
+ * Check for fragment identifier pointing to a specific fact and select it if
+ * present.
+ */
+Inspector.prototype.handleFactDeepLink = function () {
+    if (location.hash.startsWith("#f-")) {
+        var factId = location.hash.slice(3);
+        this._viewer.showAndSelectFact(this._report.getFactById(factId));
+    }
+}
+
+Inspector.prototype.updateURLFragment = function () {
+    if (this._currentFact) {
+        location.hash = "#f-" + this._currentFact.id;
+    }
 }
 
 Inspector.prototype.buildDisplayOptionsMenu = function () {
@@ -323,8 +339,7 @@ Inspector.prototype.update = function () {
         this.getPeriodIncrease(fact);
 
     }
-    
-
+    this.updateURLFragment();
 }
 
 Inspector.prototype.selectFact = function (id) {

--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -67,8 +67,13 @@ iXBRLReport.prototype.languageNames = function() {
 }
 
 iXBRLReport.prototype.getFactById = function(id) {
-    if (!this._facts[id]) {
-        this._facts[id] = new Fact(this, id);
+    if (!this._facts.hasOwnProperty(id)) {
+        if (this.data.facts.hasOwnProperty(id)) {
+            this._facts[id] = new Fact(this, id);
+        }
+        else {
+            this._facts[id] = null;
+        }
     }
     return this._facts[id];
 }

--- a/iXBRLViewerPlugin/viewer/src/js/report.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.test.js
@@ -40,18 +40,49 @@ var testReportData = {
                 }
             }
         }
+    },
+
+    "facts": {
+        "f1": {
+            "d": -3,
+            "v": 1000,
+            "a": {
+                "c": "eg:Concept1",
+                "u": "iso4217:USD",
+                "p": "2018-01-01/2019-01-01",
+            }
+        }
     }
 };
 
 
-test("Language options", () => {
+describe("Language options", () => {
     var testReport = new iXBRLReport(testReportData);
-    var al = testReport.availableLanguages();
-    expect(al).toHaveLength(3);
-    expect(al).toEqual(expect.arrayContaining(["en", "en-us", "en-gb"]));
+    test("Available languages", () => {
+        var al = testReport.availableLanguages();
+        expect(al).toHaveLength(3);
+        expect(al).toEqual(expect.arrayContaining(["en", "en-us", "en-gb"]));
+    });
 
-    var ln = testReport.languageNames();
-    expect(Object.keys(ln)).toHaveLength(2);
-    expect(ln['en']).toBe("English");
-    expect(ln['en-us']).toBe("English (US)");
+    test("Names for available languages", () => {
+        var ln = testReport.languageNames();
+        expect(Object.keys(ln)).toHaveLength(2);
+        expect(ln['en']).toBe("English");
+        expect(ln['en-us']).toBe("English (US)");
+    });
+});
+
+describe("Fetching facts", () => {
+    var testReport = new iXBRLReport(testReportData);
+
+    test("Successful", () => {
+        var f = testReport.getFactById("f1");
+        expect(f).not.toBeNull();
+        expect(f.decimals()).toEqual(-3);
+    });
+
+    test("Non-existent fact", () => {
+        var f = testReport.getFactById("fact-does-not-exist");
+        expect(f).toBeNull();
+    });
 });

--- a/iXBRLViewerPlugin/viewer/src/js/util.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.js
@@ -78,6 +78,5 @@ export function wrapLabel(str, maxwidth){
 }
 
 export function escapeRegex(text) {
-  return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+    return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
 }
-


### PR DESCRIPTION
If the URL to the viewer contains a fragment identifier starting with "#f-" treat the remainder as a fact ID and focus the viewer on that fact when opening the viewer, e.g.:

   https://example.com/mydocument-viewer.html#f-fact1

The fragment identifier is updated whenever a fact is selected.

This allows deep linking to facts within a report - potentially useful where the viewer is hosted on a website/intranet and users want to share links to specific facts, or where you are reviewing a 
validation report and want to be able to link to relevant facts in context.