### PR TITLE
Font size/style fixes

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/index.js
+++ b/iXBRLViewerPlugin/viewer/src/js/index.js
@@ -34,6 +34,9 @@ function reparentDocument() {
      * the body tag in an HTML DOM, so move them so that they are */
     $('body script').appendTo($('body'));
     $('body').children().not("script").not('#ixv').not(iframeContainer).appendTo($(iframe).contents().find('body'));
+
+    /* Avoid any inline styles on the old body interfering with the inspector */
+    $('body').removeAttr('style');
     return iframe;
 
 }

--- a/iXBRLViewerPlugin/viewer/src/less/core.less
+++ b/iXBRLViewerPlugin/viewer/src/less/core.less
@@ -17,7 +17,5 @@ html {
 }
 
 body {
-    font-size: 1.4rem;
     margin: 0;
-    .default-font();
 }

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -26,8 +26,12 @@
 @powered-by-footer-height: 30px;
 
 #ixv {
-    font-size: 1.4rem;
-    .default-font();
+    /* Specify these here, not on body in case the iXBRL document has its own
+     * style attribute */
+    &, table {
+        .default-font();
+        .text-md();
+    }
 
     #ixv-progress {
         position: fixed; 

--- a/iXBRLViewerPlugin/viewer/src/less/text-mixins.less
+++ b/iXBRLViewerPlugin/viewer/src/less/text-mixins.less
@@ -19,3 +19,7 @@
 .text-sm {
     font-size: 1.2rem;
 }
+
+.text-md {
+    font-size: 1.4rem;
+}


### PR DESCRIPTION
* Ensure that tables use the correct size font.
* Explicitly delete any style attribute on the body tag once the
contents have been copied into the iframe to avoid any interference with
the viewer.
* Declare font styles on #ixv not body, so that they're correct even
before the iXBRL is reparented and any body@style attribute deleted.