### PR TITLE
XHTML support

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -14,13 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<div id="ixv">
+<div id="ixv" xmlns="http://www.w3.org/1999/xhtml">
     <div class="loader">
        <span class="text">Loading iXBRL Viewer</span>
     </div>
     <div id="top-bar">
       <div class="header">
-         <img src="../img/inline-viewer.svg" >
+         <img src="../img/inline-viewer.svg" />
       </div>
       <div class="document-title"></div>
       <div class="menu" id='display-options-menu'>
@@ -89,7 +89,7 @@ limitations under the License.
                <h3 class="search-header collapsible-header">Search</h3>
                <div class="search collapsible-body">
                  <div class="search-input">
-                 <input type="text" id="ixbrl-search">
+                     <input type="text" id="ixbrl-search" />
                  </div>
                  <div class="scrollable">
                      <table class="results" >

--- a/iXBRLViewerPlugin/viewer/src/js/accordian.js
+++ b/iXBRLViewerPlugin/viewer/src/js/accordian.js
@@ -15,12 +15,12 @@
 import $ from 'jquery'
 
 export function Accordian() {
-    this._contents = $('<div class="accordian">');
+    this._contents = $('<div class="accordian"></div>');
 }
 
 Accordian.prototype.addCard = function(title, body, selected) {
-    var card = $('<div class="card">')
-        .append($('<div class="title">')
+    var card = $('<div class="card"></div>')
+        .append($('<div class="title"></div>')
             .append(title)
             .click(function () {
                 var thisCard = $(this).closest(".card");
@@ -33,7 +33,7 @@ Accordian.prototype.addCard = function(title, body, selected) {
                 }
             })
         )
-        .append($('<div class="body">').append(body))
+        .append($('<div class="body"></div>').append(body))
         .appendTo(this._contents);
 
     if (selected) {

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -24,7 +24,7 @@ import { Accordian } from './accordian.js';
 
 export function Inspector() {
     /* Insert HTML and CSS styles into body */
-    $(require('html-loader!../html/inspector.html')).prependTo('body');
+    $(require('../html/inspector.html')).prependTo('body');
     var inspector_css = require('css-loader!less-loader!../less/inspector.less').toString(); 
     $('<style id="ixv-style"></style>')
         .prop("type", "text/css")

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -26,7 +26,7 @@ export function Inspector() {
     /* Insert HTML and CSS styles into body */
     $(require('html-loader!../html/inspector.html')).prependTo('body');
     var inspector_css = require('css-loader!less-loader!../less/inspector.less').toString(); 
-    $('<style id="ixv-style">')
+    $('<style id="ixv-style"></style>')
         .prop("type", "text/css")
         .text(inspector_css)
         .appendTo('head');
@@ -116,13 +116,13 @@ Inspector.prototype.search = function (s) {
     viewer.clearRelatedHighlighting();
     $.each(results, function (i,r) {
         if (i < 100) {
-            var row = $('<tr>')
+            var row = $('<tr></tr>')
                 .click(function () { viewer.showAndSelectFact(r.fact) })
                 .mouseenter(function () { viewer.linkedHighlightFact(r.fact); })
                 .mouseleave(function () { viewer.clearLinkedHighlightFact(r.fact); })
                 .data('ivid', r.fact.id)
                 .appendTo($("tbody", table));
-            $('<td>')
+            $('<td></td>')
                 .text(r.fact.getLabel("std")) // + " (" + r.score + ")" );
                 .appendTo(row);
         }
@@ -138,13 +138,13 @@ Inspector.prototype._referencesHTML = function (fact) {
     var c = fact.concept();
     var a = new Accordian();
     $.each(fact.concept().references(), function (i,r) {
-        var title = $("<span>").text(r[0].value);
-        var body =  $('<table class="fact-properties"><tbody>')
+        var title = $("<span></span>").text(r[0].value);
+        var body =  $('<table class="fact-properties"><tbody></tbody></table>')
         var tbody = body.find("tbody");
         $.each(r, function (j,p) {
             var row = $("<tr>")
-                .append($("<th>").text(p.part))
-                .append($("<td>").text(p.value))
+                .append($("<th></th>").text(p.part))
+                .append($("<td></td>").text(p.value))
                 .appendTo(tbody);
             if (p.part == 'URI') {
                 row.addClass("uri");
@@ -174,12 +174,12 @@ Inspector.prototype._calculationHTML = function (fact, elr) {
         var label = report.getRoleLabel(rolePrefix, inspector._viewerOptions);
 
         var rCalc = calc.resolvedCalculation(e);
-        var calcBody = $('<div>');
+        var calcBody = $('<div></div>');
         $.each(rCalc, function (i, r) {
             var itemHTML = $("<div></div>")
                 .addClass("item")
-                .append($("<span>").addClass("weight").text(r.weightSign + " "))
-                .append($("<span>").addClass("concept-name").text(report.getLabel(r.concept, "std")))
+                .append($("<span></span>").addClass("weight").text(r.weightSign + " "))
+                .append($("<span></span>").addClass("concept-name").text(report.getLabel(r.concept, "std")))
                 .appendTo(calcBody);
 
             if (r.facts) {
@@ -191,12 +191,12 @@ Inspector.prototype._calculationHTML = function (fact, elr) {
                 $.each(r.facts, function (k,f) { viewer.highlightRelatedFact(f); });
             }
         });
-        $("<div>").addClass("item").addClass("total")
-            .append($("<span>").addClass("weight"))
-            .append($("<span>").addClass("concept-name").text(fact.getLabel("std")))
+        $("<div></div>").addClass("item").addClass("total")
+            .append($("<span></span>").addClass("weight"))
+            .append($("<span></span>").addClass("concept-name").text(fact.getLabel("std")))
             .appendTo(calcBody);
 
-        a.addCard($("<span>").text(label), calcBody, e == elr);
+        a.addCard($("<span></span>").text(label), calcBody, e == elr);
 
     });
     return a.contents();
@@ -290,8 +290,8 @@ Inspector.prototype._updateEntityIdentifier = function (fact) {
     var cell = $('tr.entity-identifier td');
     cell.empty();
     if (url) {
-        $('<span>').text('['+Identifiers.identifierNameForFact(fact) + "] ").appendTo(cell)
-        $('<a target="_blank">').attr('href',url).text(fact.identifier().localname).appendTo(cell)
+        $('<span></span>').text('['+Identifiers.identifierNameForFact(fact) + "] ").appendTo(cell)
+        $('<a target="_blank"></a>').attr('href',url).text(fact.identifier().localname).appendTo(cell)
     }
     else {
         cell.text(fact.f.a.e);
@@ -310,7 +310,7 @@ Inspector.prototype.update = function () {
         $('tr.period td')
             .text(fact.periodString())
             .append(
-                $("<span>") 
+                $("<span></span>") 
                     .addClass("analyse")
                     .text("")
                     .click(function () {
@@ -326,10 +326,10 @@ Inspector.prototype.update = function () {
         var dims = fact.dimensions();
         for (var d in dims) {
             (function(d) {
-                $('<div class="dimension">')
+                $('<div class="dimension"></div>')
                     .text(fact.report().getLabel(d, "std", true) || d)
                     .append(
-                        $("<span>") 
+                        $("<span></span>") 
                             .addClass("analyse")
                             .text("")
                             .click(function () {
@@ -338,7 +338,7 @@ Inspector.prototype.update = function () {
                     )
                     .appendTo('#dimensions');
             })(d); 
-            $('<div class="dimension-value">')
+            $('<div class="dimension-value"></div>')
                 .text(this._report.getLabel(dims[d], "std", true) || dims[d])
                 .appendTo('#dimensions');
             

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -28,7 +28,6 @@ export function Viewer(iframe, report) {
     this._applyStyles();
     this._bindHandlers();
     this.scale = 1;
-    
 }
 
 function localName(e) {
@@ -65,22 +64,11 @@ Viewer.prototype._preProcessiXBRL = function(n, inHidden) {
         node = $(n).parent();
     }
     node.addClass("ixbrl-element").data('ivid',n.getAttribute("id"));
-    //var elt;
     if (localName(n.nodeName) == 'NONFRACTION') {
       $(node).addClass("ixbrl-element-nonfraction");
-      /*
-      if(inHidden) {
-        elt = $(n).parent().clone();
-      }
-      */
     }
     if (localName(n.nodeName) == 'NONNUMERIC') {
       $(node).addClass("ixbrl-element-nonfraction");
-      /*
-      if(inHidden) {
-        elt = $(n).parent().clone();
-      }
-      */
     }
     if (elt) {
       var concept = n.getAttribute("name");
@@ -138,9 +126,7 @@ Viewer.prototype._bindHandlers = function () {
     $('#iframe-container .zoom-out').click(function () { viewer.zoomOut() });
 
     TableExport.addHandles(this._contents, this._report);
-
 }
-
 
 Viewer.prototype.selectNextTag = function () {
     this._selectAdjacentTag(1);
@@ -273,4 +259,3 @@ Viewer.prototype.clearLinkedHighlightFact = function (f) {
 Viewer.prototype.getTitle = function () {
     return $('head title', this._contents).text();
 }
-

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -43,7 +43,8 @@ function localName(e) {
 
 Viewer.prototype._preProcessiXBRL = function(n, inHidden) {
   var elt;
-  if(n.nodeType == 1 && (localName(n.nodeName) == 'NONNUMERIC' || localName(n.nodeName) == 'NONFRACTION')) {
+  var name = localName(n.nodeName).toUpperCase();
+  if(n.nodeType == 1 && (name == 'NONNUMERIC' || name == 'NONFRACTION')) {
     var node = $(n).closest("td,th").eq(0);
     if (node.length == 1) {
         var regex = "^[^0-9A-Za-z]*" + escapeRegex($(n).text()) + "[^0-9A-Za-z]*$";

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -116,6 +116,7 @@
             position: absolute;
             top: 0;
             left: 0;
+            bottom: 0;
             img {
                 height: 100%;
             }

--- a/iXBRLViewerPlugin/viewer/webpack.common.js
+++ b/iXBRLViewerPlugin/viewer/webpack.common.js
@@ -19,6 +19,17 @@ module.exports = {
                 {
                     test: /\.(woff(2)?|ttf|eot|svg|png)(\?v=\d+\.\d+\.\d+)?$/,
                     use: "base64-inline-loader"
+                },
+                {
+                    test: /\.html$/,
+                    use: [ { 
+                        loader: "html-loader",
+                        options: {
+                            minimize: true,
+                            removeAttributeQuotes: false,
+                            keepClosingSlash: true
+                        }
+                    }]
                 }
             ]
 


### PR DESCRIPTION
Make the viewer work when treated as XHTML.  iXBRL filings are often served with an XHTML extension or content type, which will put the browser into standards compliant rendering mode, and enforce XML validity.  

For most filings the rendering mode makes little or no difference, but for others it can substantially affect the rendering.

This PR makes the viewer itself XHTML valid, which means that it can be served using an XHTML extension/mime-type, with the result that the iXBRL file will also be treated as XHTML.

The SEC serves iXBRL with a .htm extension, so it is treated as HTML, but UK Companies House use .xhtml.