### PR TITLE
XMAS-3842 - Fix for facts with HTML content

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -21,6 +21,7 @@ import $ from 'jquery'
 
 export function Fact(report, factId) {
     this.f = report.data.facts[factId];
+    this._ixData = report.getIXDataForFact(factId);
     this._report = report;
     this.id = factId;
 }
@@ -80,12 +81,7 @@ Fact.prototype.readableValue = function() {
             v = formatNumber(v,d) + " " + this.unit().valueLabel();
         }
     }
-    /* If the text value appears to start with an HTML tag, treat as HTML and
-     * use the text content as the value.  It would be better to apply this
-     * based on data type, but we don't currently have access to that in the
-     * report data.
-     */
-    else if (v.match(/^[\s\u00a0]*<([a-zA-Z_][\w.-]*:)?[a-zA-Z_][\w.-]*(\s|>|\/>)/)) {
+    else if (this.escaped()) {
         var html = $("<div>").append($($.parseHTML(v, null, false)));
         /* Insert an extra space at the beginning and end of block elements to
          * preserve separation of sections of text. */
@@ -229,5 +225,6 @@ Fact.prototype.identifier = function () {
     return this._report.qname(this.f.a.e);
 }
 
-
-
+Fact.prototype.escaped = function () {
+    return this._ixData.escape;
+}

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -85,7 +85,7 @@ Fact.prototype.readableValue = function() {
      * based on data type, but we don't currently have access to that in the
      * report data.
      */
-    else if (v.match(/^[\s\u00a0]*<[A-Za-z]/)) {
+    else if (v.match(/^[\s\u00a0]*<([a-zA-Z_][\w.-]*:)?[a-zA-Z_][\w.-]*(\s|>|\/>)/)) {
         var html = $("<div>").append($($.parseHTML(v, null, false)));
         /* Insert an extra space at the beginning and end of block elements to
          * preserve separation of sections of text. */

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -80,6 +80,21 @@ Fact.prototype.readableValue = function() {
             v = formatNumber(v,d) + " " + this.unit().valueLabel();
         }
     }
+    /* If the text value appears to start with an HTML tag, treat as HTML and
+     * use the text content as the value.  It would be better to apply this
+     * based on data type, but we don't currently have access to that in the
+     * report data.
+     */
+    else if (v.match(/^\s*<[A-Za-z]/)) {
+        var html = $($.parseHTML(v, null, false));
+        /* Insert an extra space at the end of block elements to preserve
+         * separation of sections of text. */
+        html
+            .find("p, td, th, h1, h2, h3, h4, ol, ul, pre, blockquote, dl, div")
+            .append(document.createTextNode(" "));
+        /* Replace nbsp with normal space to avoid double spaces in the output */
+        v = html.text().replace(/\u00a0/g, " ");
+    }
     return v;
 }
 

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -85,15 +85,16 @@ Fact.prototype.readableValue = function() {
      * based on data type, but we don't currently have access to that in the
      * report data.
      */
-    else if (v.match(/^\s*<[A-Za-z]/)) {
-        var html = $($.parseHTML(v, null, false));
-        /* Insert an extra space at the end of block elements to preserve
-         * separation of sections of text. */
+    else if (v.match(/^[\s\u00a0]*<[A-Za-z]/)) {
+        var html = $("<div>").append($($.parseHTML(v, null, false)));
+        /* Insert an extra space at the beginning and end of block elements to
+         * preserve separation of sections of text. */
         html
             .find("p, td, th, h1, h2, h3, h4, ol, ul, pre, blockquote, dl, div")
-            .append(document.createTextNode(" "));
-        /* Replace nbsp with normal space to avoid double spaces in the output */
-        v = html.text().replace(/\u00a0/g, " ");
+            .append(document.createTextNode(' '))
+            .prepend(document.createTextNode(' '));
+        /* Replace runs of whitespace (including nbsp) with a single space */
+        v = html.text().replace(/[\u00a0\s]+/g, " ").trim();
     }
     return v;
 }

--- a/iXBRLViewerPlugin/viewer/src/js/fact.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.test.js
@@ -360,6 +360,27 @@ describe("Readable value", () => {
 
         expect(testFact({ "v": ".<b>foo</b>" }).readableValue())
             .toBe(".<b>foo</b>");
+    });
+
+    test("Detect and strip HTML tags - check QName detection", () => {
+        expect(testFact({ "v": "<xhtml:b>foo</xhtml:b>" }).readableValue())
+            .toBe("foo");
+
+        expect(testFact({ "v": '<xhtml:span style="font-weight: bold">foo</xhtml:span>' }).readableValue())
+            .toBe("foo");
+
+        /* Not a QName */
+        expect(testFact({ "v": "<1b>foo</1b>" }).readableValue())
+            .toBe("<1b>foo</1b>");
+
+        /* Not a QName */
+        expect(testFact({ "v": "<b:b:b>foo</b:b:b>" }).readableValue())
+            .toBe("<b:b:b>foo</b:b:b>");
+    });
+
+    test("Detect and strip HTML tags - start with a self-closing tag", () => {
+        expect(testFact({ "v": "<div/><b>bar</b>" }).readableValue())
+            .toBe("bar");
 
     });
 
@@ -374,6 +395,11 @@ describe("Readable value", () => {
 
         expect(testFact({ "v": "<p>foo</p><p>bar</p>" }).readableValue())
             .toBe("foo bar");
+
+        /* This should really return "foo bar", but we don't correctly detect
+         * block tags in prefixed XHTML */
+        expect(testFact({ "v": '<xhtml:p xmlns:xhtml="https://www.w3.org/1999/xhtml/">foo</xhtml:p><xhtml:p>bar</xhtml:p>' }).readableValue())
+            .toBe("foobar");
 
         expect(testFact({ "v": "<table><tr><td>cell1</td><td>cell2</td></tr></table>" })
             .readableValue())

--- a/iXBRLViewerPlugin/viewer/src/js/fact.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.test.js
@@ -56,6 +56,7 @@ function testReport(facts) {
 }
 
 function testFact(factData) {
+    factData.a = factData.a || {};
     return new Fact(testReport({"f1": factData}), "f1");
 }
 
@@ -310,6 +311,60 @@ describe("Readable accuracy", () => {
             "d": 2,
             "a": { "u": "iso4217:GBP" }
         }).readableAccuracy()).toBe("2 (pence)");
+
+    });
+});
+
+
+describe("Readable value", () => {
+
+    test("Simple string", () => {
+
+        expect(testFact({ "v": "abc" }).readableValue()).toBe("abc");
+
+        expect(testFact({ "v": "abc <i>italic</i>" }).readableValue()).toBe("abc <i>italic</i>");
+        expect(testFact({ "v": "a > b" }).readableValue()).toBe("a > b");
+
+    });
+
+    test("Detect and strip HTML tags", () => {
+
+        expect(testFact({ "v": "<b>foo</b>" }).readableValue())
+            .toBe("foo");
+
+        expect(testFact({ "v": "    <b>foo</b>bar" }).readableValue())
+            .toBe("foobar");
+
+        expect(testFact({ "v": "\u00a0<b>foo</b>" }).readableValue())
+            .toBe("foo");
+
+        expect(testFact({ "v": ".<b>foo</b>" }).readableValue())
+            .toBe(".<b>foo</b>");
+
+    });
+
+    test("Text in consecutive inline elements should be contiguous", () => {
+
+        expect(testFact({ "v": "<b>foo</b><i>bar</i>" }).readableValue())
+            .toBe("foobar");
+
+    });
+
+    test("Text in block/table elements should be separated.", () => {
+
+        expect(testFact({ "v": "<p>foo</p><p>bar</p>" }).readableValue())
+            .toBe("foo bar");
+
+        expect(testFact({ "v": "<table><tr><td>cell1</td><td>cell2</td></tr></table>" })
+            .readableValue())
+            .toBe("cell1 cell2");
+
+    });
+
+    test("Whitespace normalisation", () => {
+
+        expect(testFact({ "v": "<p>bar  foo</p> <p>bar</p>" }).readableValue())
+            .toBe("bar foo bar");
 
     });
 });

--- a/iXBRLViewerPlugin/viewer/src/js/fact.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.test.js
@@ -48,16 +48,19 @@ var testReportData = {
     }
 };
 
-function testReport(facts) {
+function testReport(facts, ixData) {
     // Deep copy of standing data
     var data = JSON.parse(JSON.stringify(testReportData));
     data.facts = facts;
-    return new iXBRLReport(data);
+    var report = new iXBRLReport(data);
+    report.setIXData(ixData);
+    return report;
 }
 
-function testFact(factData) {
+function testFact(factData, ixData) {
     factData.a = factData.a || {};
-    return new Fact(testReport({"f1": factData}), "f1");
+    ixData = ixData || {};
+    return new Fact(testReport({"f1": factData}, {"f1": ixData }), "f1");
 }
 
 describe("Simple fact properties", () => {
@@ -347,61 +350,64 @@ describe("Readable value", () => {
 
     });
 
-    test("Detect and strip HTML tags", () => {
+    test("Strip HTML tags and normalise whitespace", () => {
 
-        expect(testFact({ "v": "<b>foo</b>" }).readableValue())
+        expect(testFact({ "v": "<b>foo</b>" }, {"escape": true }).readableValue())
             .toBe("foo");
 
-        expect(testFact({ "v": "    <b>foo</b>bar" }).readableValue())
+        expect(testFact({ "v": "    <b>foo</b>bar" }, {"escape": true }).readableValue())
             .toBe("foobar");
 
-        expect(testFact({ "v": "\u00a0<b>foo</b>" }).readableValue())
+        expect(testFact({ "v": "\u00a0<b>foo</b>" }, {"escape": true }).readableValue())
             .toBe("foo");
 
-        expect(testFact({ "v": ".<b>foo</b>" }).readableValue())
-            .toBe(".<b>foo</b>");
     });
 
-    test("Detect and strip HTML tags - check QName detection", () => {
-        expect(testFact({ "v": "<xhtml:b>foo</xhtml:b>" }).readableValue())
-            .toBe("foo");
+    test("Don't strip non-escaped facts", () => {
 
-        expect(testFact({ "v": '<xhtml:span style="font-weight: bold">foo</xhtml:span>' }).readableValue())
-            .toBe("foo");
+        expect(testFact({ "v": "\u00a0<b>foo</b>" }, {"escape": false }).readableValue())
+            .toBe("\u00a0<b>foo</b>");
+        
+        expect(testFact({ "v": "\u00a0<b>foo</b>" }, {  }).readableValue())
+            .toBe("\u00a0<b>foo</b>");
 
-        /* Not a QName */
-        expect(testFact({ "v": "<1b>foo</1b>" }).readableValue())
-            .toBe("<1b>foo</1b>");
-
-        /* Not a QName */
-        expect(testFact({ "v": "<b:b:b>foo</b:b:b>" }).readableValue())
-            .toBe("<b:b:b>foo</b:b:b>");
     });
 
-    test("Detect and strip HTML tags - start with a self-closing tag", () => {
-        expect(testFact({ "v": "<div/><b>bar</b>" }).readableValue())
-            .toBe("bar");
+    test("Detect and strip HTML tags - XHTML tags and attributes", () => {
+        expect(testFact({ "v": "<xhtml:b>foo</xhtml:b>" }, {"escape": true }).readableValue())
+            .toBe("foo");
 
+        expect(testFact({ "v": '<xhtml:span style="font-weight: bold">foo</xhtml:span>' }, {"escape": true }).readableValue())
+            .toBe("foo");
+    });
+
+    test("Detect and strip HTML tags - check behaviour with invalid HTML", () => {
+        /* Invalid HTML  */
+        expect(testFact({ "v": "<b:b:b>foo</b:b:b>" }, {"escape": true }).readableValue())
+            .toBe("foo");
+
+        expect(testFact({ "v": "<foo<bar>baz</bar>" }, {"escape": true }).readableValue())
+            .toBe("baz");
     });
 
     test("Text in consecutive inline elements should be contiguous", () => {
 
-        expect(testFact({ "v": "<b>foo</b><i>bar</i>" }).readableValue())
+        expect(testFact({ "v": "<b>foo</b><i>bar</i>" }, {"escape":true }).readableValue())
             .toBe("foobar");
 
     });
 
     test("Text in block/table elements should be separated.", () => {
 
-        expect(testFact({ "v": "<p>foo</p><p>bar</p>" }).readableValue())
+        expect(testFact({ "v": "<p>foo</p><p>bar</p>" }, {"escape":true }).readableValue())
             .toBe("foo bar");
 
         /* This should really return "foo bar", but we don't correctly detect
          * block tags in prefixed XHTML */
-        expect(testFact({ "v": '<xhtml:p xmlns:xhtml="https://www.w3.org/1999/xhtml/">foo</xhtml:p><xhtml:p>bar</xhtml:p>' }).readableValue())
+        expect(testFact({ "v": '<xhtml:p xmlns:xhtml="https://www.w3.org/1999/xhtml/">foo</xhtml:p><xhtml:p>bar</xhtml:p>' }, {"escape":true }).readableValue())
             .toBe("foobar");
 
-        expect(testFact({ "v": "<table><tr><td>cell1</td><td>cell2</td></tr></table>" })
+        expect(testFact({ "v": "<table><tr><td>cell1</td><td>cell2</td></tr></table>" }, {"escape":true })
             .readableValue())
             .toBe("cell1 cell2");
 
@@ -409,7 +415,7 @@ describe("Readable value", () => {
 
     test("Whitespace normalisation", () => {
 
-        expect(testFact({ "v": "<p>bar  foo</p> <p>bar</p>" }).readableValue())
+        expect(testFact({ "v": "<p>bar  foo</p> <p>bar</p>" }, {"escape":true }).readableValue())
             .toBe("bar foo bar");
 
     });

--- a/iXBRLViewerPlugin/viewer/src/js/fact.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.test.js
@@ -318,6 +318,26 @@ describe("Readable accuracy", () => {
 
 describe("Readable value", () => {
 
+    test("Monetary value", () => {
+
+        expect(testFact({ "v": "10", a: { u: "iso4217:USD" } }).readableValue())
+            .toBe("US $ 10");
+
+        expect(testFact({ "v": "10", a: { u: "iso4217:GBP" } }).readableValue())
+            .toBe("£ 10");
+
+        expect(testFact({ "v": "10000", d: 2, a: { u: "iso4217:GBP" } }).readableValue())
+            .toBe("£ 10,000.00");
+
+    });
+
+    test("Other numeric", () => {
+
+        expect(testFact({ "v": "10", d: -2, a: { u: "xbrli:foo" } }).readableValue())
+            .toBe("10 xbrli:foo");
+
+    });
+
     test("Simple string", () => {
 
         expect(testFact({ "v": "abc" }).readableValue()).toBe("abc");

--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -20,7 +20,9 @@ import $ from 'jquery'
 
 export function iXBRLReport (data) {
     this.data = data;
+    this._viewerFactData = {};
     this._facts = {};
+    this._ixData = {};
     this._viewerOptions = new ViewerOptions();
 }
 
@@ -76,6 +78,17 @@ iXBRLReport.prototype.getFactById = function(id) {
         }
     }
     return this._facts[id];
+}
+
+/*
+ * Set additional information about facts obtained from parsing the iXBRL.
+ */
+iXBRLReport.prototype.setIXData = function(ixData) {
+    this._ixData = ixData;
+}
+
+iXBRLReport.prototype.getIXDataForFact = function(factId) {
+    return this._ixData[factId] || {};
 }
 
 iXBRLReport.prototype.facts = function() {

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -24,7 +24,9 @@ export function Viewer(iframe, report) {
     this.onMouseEnter = $.Callbacks();
     this.onMouseLeave = $.Callbacks();
 
+    this._factData = {};
     this._preProcessiXBRL($("body", iframe.contents()).get(0));
+    report.setIXData(this._factData);
     this._applyStyles();
     this._bindHandlers();
     this.scale = 1;
@@ -69,6 +71,9 @@ Viewer.prototype._preProcessiXBRL = function(n, inHidden) {
     }
     if (localName(n.nodeName) == 'NONNUMERIC') {
       $(node).addClass("ixbrl-element-nonfraction");
+      if (n.hasAttribute('escape') && n.getAttribute('escape').match(/^(true|1)$/)) {
+          this._setFactData(n.getAttribute('id'), 'escape', true);
+      }
     }
     if (elt) {
       var concept = n.getAttribute("name");
@@ -85,6 +90,11 @@ Viewer.prototype._preProcessiXBRL = function(n, inHidden) {
   for (var i=0; i < n.childNodes.length; i++) {
     this._preProcessiXBRL(n.childNodes[i], inHidden);
   }
+}
+
+Viewer.prototype._setFactData = function (id, prop, value) {
+    this._factData[id] = this._factData[id] || {};
+    this._factData[id][prop] = value;
 }
 
 Viewer.prototype._applyStyles = function () {


### PR DESCRIPTION
If a fact appears to contain escaped HTML tags, show just the text content of that HTML, rather than the HTML source.  This fixes XMAS-3842.

A fact is determined to contain HTML if it starts with optional whitespace, followed by "<", QName, then ">", "/>" or space.

Ideally we'd check the fact datatype too, but we don't currently have access to datatype information in the viewer, and the chance (and downside) of a false positive seems minimal.