### PR TITLE
Issue 12 build fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,10 @@ dev: iXBRLViewerPlugin/viewer/dist/ixbrl_viewer.dev.js
 prod: iXBRLViewerPlugin/viewer/dist/ixbrl_viewer.js
 
 iXBRLViewerPlugin/viewer/dist/ixbrl_viewer.dev.js:	iXBRLViewerPlugin/viewer/src/*/*
-	cd iXBRLViewerPlugin/viewer && npx webpack --config webpack.dev.js --optimize-minimize
+	npm run dev
 
 iXBRLViewerPlugin/viewer/dist/ixbrl_viewer.js:	iXBRLViewerPlugin/viewer/src/*/*
-	cd iXBRLViewerPlugin/viewer && npx webpack --config webpack.prod.js --optimize-minimize
+	npm run prod
 
 test: testplugin testviewer
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ the ixbrlviewer file.
 
 1. Install npm. Instructions can be found here: https://www.npmjs.com/get-npm
 2. Install the dependencies for javascript by running: `npm install`
-3. run `make prod`. This will create the ixbrlviewer.js in the iXBRLViewerPlugin/viewer/dist directory.
+3. run `npm run dev`. This will create the ixbrlviewer.js in the iXBRLViewerPlugin/viewer/dist directory.
 
 ## Installing the Arelle plugin
 

--- a/README.md
+++ b/README.md
@@ -37,12 +37,16 @@ the ixbrlviewer file.
 ## Installing the Arelle plugin
 
 1. Clone the [iXBRL Viewer git repository][ixbrlviewer-github].
-2. Download [Arelle][arelle-git] and start the GUI.
-3. Select **Manage Plugins** from the **Help** menu.
-4. Press **Browse** under "Find plug-in modules".  
-5. Browse to the **iXBRLViewerPlugin** directory within your checkout of the iXBRL Viewer git repository and select the **\_\_init\_\_.py** file within it.
-6. Press **Close** and then **Yes** when prompted to restart Arelle.
-7. You should now have a **Save iXBRL Viewer instance** on the **Tools** menu.
+2. Download [Arelle][arelle-git].  **Note that the plugin does not currently work with the release builds of Arelle**.  Arelle must be installed from source so that it uses your system installation of Python.
+3. Install dependencies by opening a command window and running:
+```
+py -3 -mpip install openPyXL lxml isodate numpy pycountry
+```
+4. Open Arelle and select **Manage Plugins** from the **Help** menu.
+5. Press **Browse** under "Find plug-in modules".  
+6. Browse to the **iXBRLViewerPlugin** directory within your checkout of the iXBRL Viewer git repository and select the **\_\_init\_\_.py** file within it.
+7. Press **Close** and then **Yes** when prompted to restart Arelle.
+8. You should now have a **Save iXBRL Viewer instance** on the **Tools** menu.
 
 [ixbrlviewer-github]: https://github.com/Workiva/ixbrl-viewer
 [arelle-git]: https://github.com/Arelle/Arelle

--- a/iXBRLViewerPlugin/viewer/webpack.common.js
+++ b/iXBRLViewerPlugin/viewer/webpack.common.js
@@ -13,8 +13,11 @@
 // limitations under the License.
 
 const webpack = require('webpack');
+const path = require('path');
+
 module.exports = {
   entry: './src/js/index.js',
+  context: path.resolve(__dirname),
   module: {
     rules: [
                 {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "dev": "webpack --config iXBRLViewerPlugin/viewer/webpack.dev.js",
+    "prod": "webpack --config iXBRLViewerPlugin/viewer/webpack.prod.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Resolves the issues reported on issue 12 with the viewer not building on Windows.
Now uses scripts in package.json to perform the build.
Updated build documentation to use "npm run ... " rather than "make ...".
Also added note about not using the release builds of Arelle due to missing library dependency.