### PR TITLE
XMAS-3575 - Tolerate missing unit on numeric facts

### DIFF
--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -211,6 +211,12 @@ class IXBRLViewerBuilder:
                     # XXX does not support complex units
                     unit = self.nsmap.qname(f.unit.measures[0][0])
                     aspects["u"] = unit
+                else:
+                    # The presence of the unit aspect is used by the viewer to
+                    # identify numeric facts.  If the fact has no unit (invalid
+                    # XBRL, but we want to support it for draft documents),
+                    # include the unit aspect with a null value.
+                    aspects["u"] = None
                 d = inferredDecimals(f)
                 if d != float("INF") and not math.isnan(d):
                     factData["d"] = d

--- a/iXBRLViewerPlugin/viewer/src/js/aspect.js
+++ b/iXBRLViewerPlugin/viewer/src/js/aspect.js
@@ -59,6 +59,9 @@ Aspect.prototype.valueLabel = function(rolePrefix) {
         return this._report.getLabel(this._value, rolePrefix);
     }
     else if (this._aspect == 'u') {
+        if (this._value === null) {
+            return "<NOUNIT>";
+        }
         var qname = this._report.qname(this._value);
         if (qname.namespace == "http://www.xbrl.org/2003/iso4217") {
             if (qname.localname == 'GBP') {

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -96,7 +96,7 @@ Fact.prototype.readableValue = function() {
 }
 
 Fact.prototype.unit = function() {
-    if (this.f.a.u) {
+    if (this.isNumeric()) {
         return this.aspect("u");
     }
     else {
@@ -105,7 +105,7 @@ Fact.prototype.unit = function() {
 }
 
 Fact.prototype.isNumeric = function () {
-    return this.unit() !== undefined;
+    return this.f.a.u !== undefined;
 }
 
 Fact.prototype.dimensions = function () {
@@ -120,7 +120,7 @@ Fact.prototype.dimensions = function () {
 
 Fact.prototype.isMonetaryValue = function () {
     var unit = this.unit();
-    if (!unit) {
+    if (!unit || unit.value() === null) {
         return false;
     }
     var q = this.report().qname(unit.value());

--- a/iXBRLViewerPlugin/viewer/src/js/fact.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.test.js
@@ -420,3 +420,30 @@ describe("Readable value", () => {
 
     });
 });
+
+describe("Unit aspect handling", () => {
+
+    test("Numeric, missing unit", () => {    
+        var f = testFact({
+            "v": "1234",
+            "a": {  
+                "u": null
+            }
+        });
+        expect(f.isNumeric()).toBeTruthy();
+        expect(f.unit()).not.toBeUndefined();
+        expect(f.isMonetaryValue()).toBeFalsy();
+        expect(f.unit().value()).toBeNull();
+        expect(f.unit().valueLabel()).toBe("<NOUNIT>");
+    });
+
+    test("Non-numeric, no unit", () => {    
+        var f = testFact({
+            "v": "1234",
+            "a": {  
+            }
+        });
+        expect(f.isNumeric()).toBeFalsy();
+        expect(f.unit()).toBeUndefined();
+    });
+});

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -308,8 +308,9 @@ Inspector.prototype.update = function () {
         $('.documentation').text(fact.getLabel("doc") || "");
         $('tr.concept td').text(fact.conceptName());
         $('tr.period td')
-            .text(fact.periodString())
-            .append(
+            .text(fact.periodString());
+        if (fact.isNumeric()) {
+            $('tr.period td').append(
                 $("<span></span>") 
                     .addClass("analyse")
                     .text("")
@@ -317,6 +318,7 @@ Inspector.prototype.update = function () {
                         inspector._chart.analyseDimension(fact,["p"])
                     })
             );
+        }
         this._updateEntityIdentifier(fact);
         this.updateCalculation(fact);
         $('div.references').empty().append(this._referencesHTML(fact));
@@ -325,19 +327,19 @@ Inspector.prototype.update = function () {
         $('#dimensions').empty();
         var dims = fact.dimensions();
         for (var d in dims) {
-            (function(d) {
-                $('<div class="dimension"></div>')
-                    .text(fact.report().getLabel(d, "std", true) || d)
-                    .append(
-                        $("<span></span>") 
-                            .addClass("analyse")
-                            .text("")
-                            .click(function () {
-                                inspector._chart.analyseDimension(fact,[d])
-                            })
-                    )
-                    .appendTo('#dimensions');
-            })(d); 
+            var h = $('<div class="dimension"></div>')
+                .text(fact.report().getLabel(d, "std", true) || d)
+                .appendTo('#dimensions');
+            if (fact.isNumeric()) {
+                h.append(
+                    $("<span></span>") 
+                        .addClass("analyse")
+                        .text("")
+                        .click(function () {
+                            inspector._chart.analyseDimension(fact,[d])
+                        })
+                )
+            }
             $('<div class="dimension-value"></div>')
                 .text(this._report.getLabel(dims[d], "std", true) || dims[d])
                 .appendTo('#dimensions');


### PR DESCRIPTION
Allow numeric facts to have a unit of "null" so that we can load draft documents, even though this is technically invalid XBRL.  The presence of the unit aspect is used by the viewer to identify numeric facts, so the plugin now uses a unit of "null" in the JSON for this case.  Fixes XMAS 3575.