### PR TITLE
Avoid self closing tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ iXBRLViewerPlugin/viewer/dist/ixbrl_viewer.js:	iXBRLViewerPlugin/viewer/src/*/*
 test: testplugin testviewer
 
 testplugin:
-	PYTHONPATH=Arelle python3 iXBRLViewerPlugin/tests/iXBRLViewerTests.py
+	nosetests3 tests.unit_tests
 
 testviewer:
 	npm run test

--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -20,7 +20,7 @@ import math
 import re
 import pycountry
 from arelle.ValidateXbrlCalcs import inferredDecimals
-
+from .xhtmlserialize import XHTMLSerializer
 
 class NamespaceMap:
     """
@@ -186,7 +186,6 @@ class IXBRLViewerBuilder:
         self.roleMap.getPrefix(XbrlConst.summationItem,"calc")
         self.roleMap.getPrefix(XbrlConst.parentChild,"pres")
 
-
         for f in dts.facts:
             if f.id is None:
                 f.set("id","ixv-%d" % (idGen))
@@ -239,7 +238,6 @@ class IXBRLViewerBuilder:
                 )
 
             self.taxonomyData["facts"][f.id] = factData
-
             self.addConcept(f.concept)
 
         self.taxonomyData["prefixes"] = self.nsmap.prefixmap
@@ -255,6 +253,7 @@ class IXBRLViewerBuilder:
                 child.append(etree.Comment("BEGIN IXBRL VIEWER EXTENSIONS"))
 
                 e = etree.fromstring("<script xmlns='http://www.w3.org/1999/xhtml' src='%s'  />" % scriptUrl)
+                # Don't self close
                 e.text = ''
                 child.append(e)
 
@@ -273,5 +272,5 @@ class IXBRLViewerBuilder:
         Save the iXBRL viewer
         """
         with open(outFile, "wb") as fout:
-            # Using "xml" permits self-closing tags which confuses an HTML DOM
-            fout.write(etree.tostring(xmlDocument, method="xml", encoding="utf-8", xml_declaration=True))
+            writer = XHTMLSerializer()
+            writer.serialize(xmlDocument)

--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -273,4 +273,4 @@ class IXBRLViewerBuilder:
         """
         with open(outFile, "wb") as fout:
             writer = XHTMLSerializer()
-            writer.serialize(xmlDocument)
+            writer.serialize(xmlDocument, fout)

--- a/iXBRLViewerPlugin/xhtmlserialize.py
+++ b/iXBRLViewerPlugin/xhtmlserialize.py
@@ -1,0 +1,37 @@
+# Copyright 2019 Workiva Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from lxml import etree
+import re
+
+class XHTMLSerializer:
+
+    selfClosableElements = ('area', 'base', 'br', 'col', 'hr', 'img', 'input', 'link', 'meta', 'param')
+
+    def _expandEmptyTags(self, xml):
+        """
+        Expand self-closing tags
+
+        Self-closing tags cause problems for XHTML documents when treated as
+        HTML.  Tags that are required to be empty (e.g. <br>) are left as
+        self-closing.
+        """
+        for e in xml.iter('*'):
+            m = re.match(r'\{http://www\.w3\.org/1999/xhtml\}(.*)', e.tag)
+            if m is not None and m[1] not in XHTMLSerializer.selfClosableElements and e.text is None:
+                e.text = ''
+
+    def serialize(self, xmlDocument, fout):
+        self._expandEmptyTags(xmlDocument)
+        fout.write(etree.tostring(xmlDocument, method="xml", encoding="utf-8", xml_declaration=True))

--- a/iXBRLViewerPlugin/xhtmlserialize.py
+++ b/iXBRLViewerPlugin/xhtmlserialize.py
@@ -17,7 +17,11 @@ import re
 
 class XHTMLSerializer:
 
-    selfClosableElements = ('area', 'base', 'br', 'col', 'hr', 'img', 'input', 'link', 'meta', 'param')
+    # From https://www.w3.org/TR/html401/index/elements.html
+    selfClosableElements = (
+        'area', 'base', 'basefont', 'br', 'col', 'frame', 'hr', 'img', 
+        'input', 'isindex', 'link', 'meta', 'param'
+    )
 
     def _expandEmptyTags(self, xml):
         """

--- a/tests/unit_tests/iXBRLViewerPlugin/mock_arelle.py
+++ b/tests/unit_tests/iXBRLViewerPlugin/mock_arelle.py
@@ -1,0 +1,26 @@
+from unittest.mock import Mock, patch
+import sys
+
+def qname_effect(prefix, namespaceURI, localName):
+    return Mock(
+        prefix=prefix,
+        namespaceURI=namespaceURI,
+        localName=localName
+    )
+
+def inferredDecimals_effect(fact):
+    return float("INF")
+
+def mock_arelle():
+
+    # Don't replace an existing mocked arelle, as otherwise @patch calls will
+    # patch the wrong Mock instance.
+    if 'arelle' not in sys.modules:
+        sys.modules['arelle'] = Mock()
+        sys.modules['arelle.XbrlConst'] = Mock()
+        sys.modules['arelle.ModelValue'] = Mock(
+            QName=qname_effect
+        )
+        sys.modules['arelle.ValidateXbrlCalcs'] = Mock(
+            inferredDecimals=inferredDecimals_effect
+        )

--- a/tests/unit_tests/iXBRLViewerPlugin/test_iXBRLViewer.py
+++ b/tests/unit_tests/iXBRLViewerPlugin/test_iXBRLViewer.py
@@ -3,30 +3,11 @@ import sys
 import unittest
 from collections import defaultdict
 from unittest.mock import Mock, patch
+from .mock_arelle import mock_arelle
 
-
-def qname_effect(prefix, namespaceURI, localName):
-    return Mock(
-        prefix=prefix,
-        namespaceURI=namespaceURI,
-        localName=localName
-    )
-
-def inferredDecimals_effect(fact):
-    return float("INF")
-
-
-sys.modules['arelle'] = Mock()
-sys.modules['arelle.XbrlConst'] = Mock()
-sys.modules['arelle.ModelValue'] = Mock(
-    QName=qname_effect
-)
-sys.modules['arelle.ValidateXbrlCalcs'] = Mock(
-    inferredDecimals=inferredDecimals_effect
-)
+mock_arelle()
 
 from iXBRLViewerPlugin.iXBRLViewer import NamespaceMap, IXBRLViewerBuilder
-
 
 class TestNamespaceMap(unittest.TestCase):
 

--- a/tests/unit_tests/iXBRLViewerPlugin/test_xhtmlserialize.py
+++ b/tests/unit_tests/iXBRLViewerPlugin/test_xhtmlserialize.py
@@ -1,0 +1,51 @@
+import lxml
+import sys
+import unittest
+from unittest.mock import Mock
+import io
+from .mock_arelle import mock_arelle
+
+mock_arelle()
+
+from iXBRLViewerPlugin.xhtmlserialize import XHTMLSerializer
+
+class TestXHTMLSerializer(unittest.TestCase):
+
+    def _html(self, s):
+        return '<html xmlns="http://www.w3.org/1999/xhtml"><head></head><body>%s</body></html>' % s
+
+    def _checkTagExpansion(self, html_in, html_out):
+        writer = XHTMLSerializer()
+        doc = lxml.etree.fromstring(self._html(html_in))
+        writer._expandEmptyTags(doc)
+        self.assertEqual(lxml.etree.tostring(doc, encoding="unicode"), self._html(html_out))
+
+    def test_expandEmptyTags(self):
+        self._checkTagExpansion('<div/>', '<div></div>')
+        self._checkTagExpansion('<div><span class="fish" /></div>', '<div><span class="fish"></span></div>')
+
+        # Non-expanding tags
+        self._checkTagExpansion('<br/>', '<br/>')
+        self._checkTagExpansion('<br />', '<br/>')
+        self._checkTagExpansion('<hr/>', '<hr/>')
+        self._checkTagExpansion('<img />', '<img/>')
+
+        # Mixed content
+        self._checkTagExpansion('<div>foo<p /><p>bar</p></div>', '<div>foo<p></p><p>bar</p></div>')
+
+        # Expanded tags that should be empty will be collapsed
+        self._checkTagExpansion('<br></br>', '<br/>')
+
+        # Only expand tags in the XHTML namespace
+        self._checkTagExpansion('<div xmlns="other" />', '<div xmlns="other"/>')
+
+    def test_serialize(self):
+        htmlsrc = self._html("<p>hello</p>")
+        doc = lxml.etree.fromstring(htmlsrc)
+        f = io.BytesIO()
+
+        writer = XHTMLSerializer()
+        writer.serialize(doc, f)
+
+        # XML declaration should be added.
+        self.assertEqual(f.getvalue().decode('utf-8'), "<?xml version='1.0' encoding='utf-8'?>\n" + htmlsrc)


### PR DESCRIPTION
Avoid self-closing tags for HTML elements that can have content (e.g. span and div).

Fixes XMAS-3986