### PR TITLE
Fix undefined documentation label

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/fact.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.test.js
@@ -447,3 +447,23 @@ describe("Unit aspect handling", () => {
         expect(f.unit()).toBeUndefined();
     });
 });
+
+describe("Get Label", () => {
+    var f = testFact({
+            "d": -3,
+            "v": 1000,
+            "a": {
+                "c": "eg:Concept1",
+                "u": "iso4217:USD", 
+                "p": "2018-01-01/2019-01-01",
+            }});
+
+    test("Get standard label", () => {
+        expect(f.getLabel("std")).toEqual("English label")
+    });
+
+    test("Get non-existent label", () => {
+        expect(f.getLabel("doc")).toBeUndefined();
+    });
+
+});

--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -34,16 +34,21 @@ iXBRLReport.prototype.getLabel = function(c, rolePrefix, showPrefix, viewerOptio
         return undefined;
     }
     else {
+        var label;
+        if (lang && labels[lang]) {
+            label = labels[lang];
+        }
+        else {
+            label = labels["en"] || labels["en-us"];
+        }
+        if (label === undefined) {
+            return undefined;
+        }
         var s = '';
         if (showPrefix && this._viewerOptions.showPrefixes) {
             s = "(" + this.qname(c).prefix + ") ";
         }
-        if (lang && labels[lang]) {
-            s += labels[lang];
-        }
-        else {
-            s += labels["en"] || labels["en-us"];
-        }
+        s += label;
         return s;
     }
 }


### PR DESCRIPTION
Attempting to get a non-existent label was returning "undefined" as a string rather than a value, causing "undefined" to be displayed as the label.

This fixes that, so the documentation label is not shown at all in this case.

On behalf of XII.