### PR TITLE
Add scroll bar to menu if list of options is too long

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -25,7 +25,9 @@ limitations under the License.
       <div class="document-title"></div>
       <div class="menu" id='display-options-menu'>
         <div class="title">Display Options</div>
-        <div class="content"></div>
+        <div class="content-container">
+          <div class="content"></div>
+        </div>
       </div>
     </div>
     <div id="inspector">

--- a/iXBRLViewerPlugin/viewer/src/js/menu.js
+++ b/iXBRLViewerPlugin/viewer/src/js/menu.js
@@ -18,12 +18,16 @@ export function Menu(elt) {
     this._elt = elt;
     var menu = this;
 
-    elt.find(".title").click(function () {
-        elt.find(".content").toggle();
+    elt.find(".title").click(function (e) {
+        elt.find(".content-container").toggle();
+        /* Stop an opening click from also being treated as an "out-of-menu"
+         * closing click */
+        e.stopPropagation();
     });
 
     $('html').click(function(event) {
-        if (elt.find($(event.target)).length === 0) {
+        if ($(".content",elt).find($(event.target)).length === 0) {
+            console.log("closing");
             menu.close();
         }
     });
@@ -34,7 +38,7 @@ Menu.prototype.reset = function() {
 }
 
 Menu.prototype.close = function() {
-    this._elt.find(".content").hide();
+    this._elt.find(".content-container").hide();
 }
 
 Menu.prototype.addCheckboxItem = function(name, callback) {

--- a/iXBRLViewerPlugin/viewer/src/less/menu.less
+++ b/iXBRLViewerPlugin/viewer/src/less/menu.less
@@ -32,36 +32,42 @@
         left: 3px;
       }
 
-      .content {
-        line-height: initial;
-        position: absolute;
+      .content-container {
+        position: fixed;
         top: @top-bar-height;
         right: 0;
-        background: #fff;
-        z-index: 5;
-        border: solid 1px @border-grey;
+        bottom: 0;
         display: none;
 
-        .group {
-          border-bottom: solid 1px @border-grey;
-          border-top: solid 1px @border-grey;
-        }
+        .content {
+          line-height: initial;
+          background: #fff;
+          z-index: 5;
+          border: solid 1px @border-grey;
+          max-height: 100%;
+          overflow-y: scroll;
 
-        .item {
-          position: relative;
-          padding: 10px 25px 10px 30px;
-          white-space: nowrap;
-
-          &:hover {
-            background: @border-grey;
+          .group {
+            border-bottom: solid 1px @border-grey;
+            border-top: solid 1px @border-grey;
           }
 
-          &.checkbox.checked::before {
-            .icon-tick();
+          .item {
+            position: relative;
+            padding: 10px 25px 10px 30px;
+            white-space: nowrap;
 
-            position: absolute;
-            top: 12px;
-            left: 9px;
+            &:hover {
+              background: @border-grey;
+            }
+
+            &.checkbox.checked::before {
+              .icon-tick();
+
+              position: absolute;
+              top: 12px;
+              left: 9px;
+            }
           }
         }
       }


### PR DESCRIPTION
If the report includes a very large number of languages, they may not fit on the page.  This commit adds a scroll bar in this case.

On behalf of XII.