### PR TITLE
XMAS-4131 Allow postMessage() events to navigate to a Fact by identifier

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -226,9 +226,9 @@ Viewer.prototype.showAndSelectFact = function (fact) {
 }
 
 Viewer.prototype.showAndSelectFactById = function (factId) {
-    let fact = this.elementForFactId(factId);
-    if(fact) {
-        this.showAndSelectElement(fact);
+    let element = this.elementForFactId(factId);
+    if(element) {
+        this.showAndSelectElement(element);
     }
 }
 

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -145,7 +145,7 @@ Viewer.prototype.handleMessage = function (event) {
     var jsonString = event.originalEvent.data;
     var data = JSON.parse(jsonString);
 
-    if(data.task == 'SHOW_FACT') {
+    if (data.task == 'SHOW_FACT') {
         var factId = data.factId;
         this.showAndSelectFactById(factId);
     }
@@ -226,9 +226,9 @@ Viewer.prototype.showAndSelectFact = function (fact) {
 }
 
 Viewer.prototype.showAndSelectFactById = function (factId) {
-    let element = this.elementForFactId(factId);
-    if(element) {
-        this.showAndSelectElement(element);
+    let fact = this.elementForFactId(factId);
+    if (fact) {
+        this.showAndSelectElement(fact);
     }
 }
 

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -135,7 +135,23 @@ Viewer.prototype._bindHandlers = function () {
     $('#iframe-container .zoom-in').click(function () { viewer.zoomIn() });
     $('#iframe-container .zoom-out').click(function () { viewer.zoomOut() });
 
+    // Listen to messages posted to this window
+    $(window).on("message", function(e) { viewer.handleMessage(e) });
+
     TableExport.addHandles(this._contents, this._report);
+}
+
+Viewer.prototype.handleMessage = function (event) {
+    var jsonString = event.originalEvent.data;
+    var data = JSON.parse(jsonString);
+
+    if(data.task == 'SHOW_FACT') {
+        var factId = data.factId;
+        this.showAndSelectFactById(factId);
+    }
+    else {
+        console.log("Not handling unsupported task message: " + jsonString);
+    }
 }
 
 Viewer.prototype.selectNextTag = function () {
@@ -192,7 +208,11 @@ Viewer.prototype.clearRelatedHighlighting = function (f) {
 }
 
 Viewer.prototype.elementForFact = function (fact) {
-    return $('.ixbrl-element', this._contents).filter(function () { return $(this).data('ivid') == fact.id }).first();
+    return this.elementForFactId(fact.id);
+}
+
+Viewer.prototype.elementForFactId = function (factId) {
+    return $('.ixbrl-element', this._contents).filter(function () { return $(this).data('ivid') == factId }).first();
 }
 
 Viewer.prototype.elementsForFacts = function (facts) {
@@ -203,6 +223,13 @@ Viewer.prototype.elementsForFacts = function (facts) {
 
 Viewer.prototype.showAndSelectFact = function (fact) {
     this.showAndSelectElement(this.elementForFact(fact));
+}
+
+Viewer.prototype.showAndSelectFactById = function (factId) {
+    let fact = this.elementForFactId(factId);
+    if(fact) {
+        this.showAndSelectElement(fact);
+    }
 }
 
 Viewer.prototype.highlightAllTags = function (on, namespaceGroups) {
@@ -221,7 +248,6 @@ Viewer.prototype.highlightAllTags = function (on, namespaceGroups) {
         });
     }
     else {
-        //$(".ixbrl-element", this._contents).removeClass("ixbrl-highlight");
         $(".ixbrl-element", this._contents).removeClass (function (i, className) {
             return (className.match (/(^|\s)ixbrl-highlight\S*/g) || []).join(' ');
         });


### PR DESCRIPTION
Listen to `postMessage()` in order for the ixbrl viewer to be driven by consumers without requiring consumers to have direct access to the javascript source code.

This adds handling for showing a Fact by identifier.

It does this by listening to `window.onMessage`. Integrators can call window `postMessage(msg, origin)`.

The format of this message is JSON. The only handled message introduced in this PR is of the following format:
```
{
  "task": "SHOW_FACT",
  "factId": "the fact id"
}
```

Invalid JSON message will throw an exception
A JSON message that does not define a 'task' attribute or does not have a task value of "SHOW_FACT" will be ignored.
An invalid factId will be ignored.



This can be tested [by downloading this zip](https://drive.google.com/open?id=1nJrbVuhVI3wfpaYMZJ5OAy4Q14P5vy57), generating ixbrlviewer.dev.js from this repo and replacing the file in the zip folder. Then open blackline-report.html.  You should then be able to regression-test the viewer itself there, plus click on Fact lines that are Updated or Added, and it *should* scroll to and select the corresponding Fact in the ixbrl viewer.