### PR TITLE
Remove ID attribute from JSON data <script> tag

### DIFF
--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -259,7 +259,7 @@ class IXBRLViewerBuilder:
 
                 # Putting this in the header can interfere with character set
                 # auto detection
-                e = etree.fromstring("<script xmlns='http://www.w3.org/1999/xhtml' type='application/json'></script>")
+                e = etree.fromstring("<script xmlns='http://www.w3.org/1999/xhtml' type='application/x.ixbrl-viewer+json'></script>")
                 e.text = taxonomyDataJSON
                 child.append(e)
                 child.append(etree.Comment("END IXBRL VIEWER EXTENSIONS"))

--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -259,7 +259,7 @@ class IXBRLViewerBuilder:
 
                 # Putting this in the header can interfere with character set
                 # auto detection
-                e = etree.fromstring("<script xmlns='http://www.w3.org/1999/xhtml' id='taxonomy-data' type='application/json'></script>")
+                e = etree.fromstring("<script xmlns='http://www.w3.org/1999/xhtml' type='application/json'></script>")
                 e.text = taxonomyDataJSON
                 child.append(e)
                 child.append(etree.Comment("END IXBRL VIEWER EXTENSIONS"))

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -15,7 +15,7 @@ limitations under the License.
 -->
 
 <div id="ixv" xmlns="http://www.w3.org/1999/xhtml">
-    <div class="loader">
+    <div class="loader loading">
        <span class="text">Loading iXBRL Viewer</span>
     </div>
     <div id="top-bar">

--- a/iXBRLViewerPlugin/viewer/src/js/index.js
+++ b/iXBRLViewerPlugin/viewer/src/js/index.js
@@ -41,6 +41,14 @@ function reparentDocument() {
 
 }
 
+function getTaxonomyData() {
+    var elt = document.body.lastElementChild;
+    if (elt.tagName.toUpperCase() != 'SCRIPT' || elt.getAttribute("type") != 'application/json') {
+        return null;
+    }
+    return elt.innerHTML;
+}
+
 $(function () {
     var inspector = new Inspector();
     setTimeout(function(){
@@ -53,7 +61,13 @@ $(function () {
             if (iframeDoc.readyState == 'complete' || iframeDoc.readyState == 'interactive') {
                 clearInterval(timer);
 
-                var report = new iXBRLReport(JSON.parse(document.getElementById('taxonomy-data').innerHTML));
+                var taxonomyData = getTaxonomyData();
+                if (taxonomyData !== null) {
+                    $('#ixv .loader .text').text("Error: Could not find viewer data");
+                    $('#ixv .loader').removeClass("loading");
+                    return;
+                }
+                var report = new iXBRLReport(JSON.parse(taxonomyData));
                 var viewer = new Viewer($('iframe'), report);
 
                 $('#ixv .loader .text').text("Building search index");

--- a/iXBRLViewerPlugin/viewer/src/js/index.js
+++ b/iXBRLViewerPlugin/viewer/src/js/index.js
@@ -42,11 +42,13 @@ function reparentDocument() {
 }
 
 function getTaxonomyData() {
-    var elt = document.body.lastElementChild;
-    if (elt.tagName.toUpperCase() != 'SCRIPT' || elt.getAttribute("type") != 'application/json') {
-        return null;
+    for (var i = document.body.children.length - 1; i >= 0; i--) {
+        var elt = document.body.children[i];
+        if (elt.tagName.toUpperCase() == 'SCRIPT' && elt.getAttribute("type") == 'application/x.ixbrl-viewer+json') {
+            return elt.innerHTML;
+        }
     }
-    return elt.innerHTML;
+    return null;
 }
 
 $(function () {
@@ -62,7 +64,7 @@ $(function () {
                 clearInterval(timer);
 
                 var taxonomyData = getTaxonomyData();
-                if (taxonomyData !== null) {
+                if (taxonomyData === null) {
                     $('#ixv .loader .text').text("Error: Could not find viewer data");
                     $('#ixv .loader').removeClass("loading");
                     return;

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -22,6 +22,7 @@
 @import "dialog.less";
 @import "menu.less";
 @import "accordian.less";
+@import "loader.less";
 @import (reference) "text-mixins.less";
 
 @top-bar-height: 35px;
@@ -591,59 +592,6 @@
     width: 100%;
     height: 200px;
     overflow-y: scroll;
-  }
-
-  .loader {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.85);
-    z-index: 10;
-  }
-
-  .loader .text {
-    padding-top: 80px;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translateX(-50%) translateY(-50%);
-    color: #fff;
-    font-size: large;
-    font-family: sans-serif;
-  }
-
-  .loader .text::after,
-  .loader .text::before {
-    margin: 0 0 0 -30px;
-    height: 60px;
-    width: 60px;
-    position: absolute;
-    content: '';
-    top: 0;
-    left: 50%;
-    border-radius: 500rem;
-    border-style: solid;
-    border-width: 3px;
-    box-shadow: 0 0 0 1px transparent;
-  }
-
-  .loader .text::before {
-    border: 3px solid rgba(255, 255, 255, 0.1);
-  }
-
-  .loader .text::after {
-    -webkit-animation: loader 0.6s linear;
-    animation: loader 0.6s linear;
-    -webkit-animation-iteration-count: infinite;
-    animation-iteration-count: infinite;
-    border-color: #fff transparent transparent;
-  }
-
-  @keyframes loader {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
   }
 
   .dialog-mask {

--- a/iXBRLViewerPlugin/viewer/src/less/loader.less
+++ b/iXBRLViewerPlugin/viewer/src/less/loader.less
@@ -1,0 +1,68 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ixv {
+  .loader {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.85);
+    z-index: 10;
+  }
+
+  .loader .text {
+    padding-top: 80px;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translateX(-50%) translateY(-50%);
+    color: #fff;
+    font-size: large;
+    font-family: sans-serif;
+  }
+
+  .loader.loading .text::after,
+  .loader.loading .text::before {
+    margin: 0 0 0 -30px;
+    height: 60px;
+    width: 60px;
+    position: absolute;
+    content: '';
+    top: 0;
+    left: 50%;
+    border-radius: 500rem;
+    border-style: solid;
+    border-width: 3px;
+    box-shadow: 0 0 0 1px transparent;
+  }
+
+  .loader.loading .text::before {
+    border: 3px solid rgba(255, 255, 255, 0.1);
+  }
+
+  .loader.loading .text::after {
+    -webkit-animation: loader 0.6s linear;
+    animation: loader 0.6s linear;
+    -webkit-animation-iteration-count: infinite;
+    animation-iteration-count: infinite;
+    border-color: #fff transparent transparent;
+  }
+
+  @keyframes loader {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+  }
+}

--- a/tests/unit_tests/iXBRLViewerPlugin/test_iXBRLViewer.py
+++ b/tests/unit_tests/iXBRLViewerPlugin/test_iXBRLViewer.py
@@ -291,7 +291,6 @@ class TestIXBRLViewer(unittest.TestCase):
         self.assertEqual(body[0].text, 'BEGIN IXBRL VIEWER EXTENSIONS')
         self.assertEqual(body[1].attrib.get('src'), js_uri)
         self.assertEqual(body[1].attrib.get('type'), 'text/javascript')
-        self.assertEqual(body[2].attrib.get('id'), 'taxonomy-data')
         self.assertEqual(body[2].attrib.get('type'), 'application/json')
         self.assertEqual(body[3].text, 'END IXBRL VIEWER EXTENSIONS')
 
@@ -308,6 +307,5 @@ class TestIXBRLViewer(unittest.TestCase):
         self.assertEqual(body[0].text, 'BEGIN IXBRL VIEWER EXTENSIONS')
         self.assertEqual(body[1].attrib.get('src'), js_uri)
         self.assertEqual(body[1].attrib.get('type'), 'text/javascript')
-        self.assertEqual(body[2].attrib.get('id'), 'taxonomy-data')
         self.assertEqual(body[2].attrib.get('type'), 'application/json')
         self.assertEqual(body[3].text, 'END IXBRL VIEWER EXTENSIONS')

--- a/tests/unit_tests/iXBRLViewerPlugin/test_iXBRLViewer.py
+++ b/tests/unit_tests/iXBRLViewerPlugin/test_iXBRLViewer.py
@@ -291,7 +291,7 @@ class TestIXBRLViewer(unittest.TestCase):
         self.assertEqual(body[0].text, 'BEGIN IXBRL VIEWER EXTENSIONS')
         self.assertEqual(body[1].attrib.get('src'), js_uri)
         self.assertEqual(body[1].attrib.get('type'), 'text/javascript')
-        self.assertEqual(body[2].attrib.get('type'), 'application/json')
+        self.assertEqual(body[2].attrib.get('type'), 'application/x.ixbrl-viewer+json')
         self.assertEqual(body[3].text, 'END IXBRL VIEWER EXTENSIONS')
 
     @patch('arelle.XbrlConst.conceptLabel', 'http://www.xbrl.org/2003/arcrole/concept-label')
@@ -307,5 +307,5 @@ class TestIXBRLViewer(unittest.TestCase):
         self.assertEqual(body[0].text, 'BEGIN IXBRL VIEWER EXTENSIONS')
         self.assertEqual(body[1].attrib.get('src'), js_uri)
         self.assertEqual(body[1].attrib.get('type'), 'text/javascript')
-        self.assertEqual(body[2].attrib.get('type'), 'application/json')
+        self.assertEqual(body[2].attrib.get('type'), 'application/x.ixbrl-viewer+json')
         self.assertEqual(body[3].text, 'END IXBRL VIEWER EXTENSIONS')


### PR DESCRIPTION
ID attribute on script tag is invalid according to the iXBRL/XHTML schema.  We now locate the taxonomy data by its position in the document, and report an error in the loading mask if the element is not what we expect.

Fixes #30 