### PR TITLE
Show all facts when selecting a nested tag

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/html/fact-details.html
+++ b/iXBRLViewerPlugin/viewer/src/html/fact-details.html
@@ -1,0 +1,54 @@
+<!--
+Copyright 2019 Workiva Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<div class="fact-details">
+  <h4>Concept</h4>
+  <div class="std-label"></div>
+  <div class="documentation"></div>
+  <h4>Dimensions</h4>
+  <div id="dimensions"></div>
+  <table class="fact-properties">
+    <tr class="period">
+      <th>Date</th>
+      <td></td>
+    </tr>
+    <tr class="value">
+      <th>Fact Value</th>
+      <td><span class="value"></span> <span class="show-all">[...]</span></td>
+    </tr>
+    <tr class="accuracy">
+      <th>Accuracy</th>
+      <td></td>
+    </tr>
+    <tr class="change">
+      <th>Change</th>
+      <td></td>
+    </tr>
+    <tr class="entity-identifier">
+      <th>Entity</th>
+      <td></td>
+    </tr>
+    <tr class="concept">
+      <th>Concept</th>
+      <td></td>
+    </tr>
+  </table>
+  <div class="duplicates">
+    <span class="prev"></span> 
+    <span class="text"></span> 
+    <span class="next"></span>
+  </div>
+</div>

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -44,47 +44,11 @@ limitations under the License.
           </div>
           <div class="collapsible-section">
               <div class="fact-inspector collapsible-body">
-                  <div class="fact-details">
-                     <h4>Concept</h4>
-                     <div class="std-label"></div>
-                     <div class="documentation"></div>
-                     <h4>Dimensions</h4>
-                     <div id="dimensions"></div>
-                     <table class="fact-properties">
-                       <tr class="period">
-                           <th>Date</th>
-                           <td></td>
-                       </tr>
-                       <tr class="value">
-                           <th>Fact Value</th>
-                           <td><span class="value"></span> <span class="show-all">[...]</span></td>
-                       </tr>
-                       <tr class="accuracy">
-                           <th>Accuracy</th>
-                           <td></td>
-                       </tr>
-                       <tr class="change">
-                           <th>Change</th>
-                           <td></td>
-                       </tr>
-                       <tr class="entity-identifier">
-                            <th>Entity</th>
-                            <td></td>
-                        </tr>
-                       <tr class="concept">
-                            <th>Concept</th>
-                            <td></td>
-                        </tr>
-                     </table>
-
-                     <div class="duplicates"><span class="prev"></span> <span class="text"></span> <span class="next"></span></div>
-               
-                   </div>
-                   <div class="no-fact-selected">
-                     <span>No fact selected</span>
-                   </div>
-               </div>
-            </div>
+                <div class="no-fact-selected">
+                  <span>No fact selected</span>
+                </div>
+             </div>
+           </div>
            <div class="collapsible-section">
                <h3 class="search-header collapsible-header">Search</h3>
                <div class="search collapsible-body">

--- a/iXBRLViewerPlugin/viewer/src/js/accordian.js
+++ b/iXBRLViewerPlugin/viewer/src/js/accordian.js
@@ -14,27 +14,40 @@
 
 import $ from 'jquery'
 
-export function Accordian() {
+export function Accordian(options) {
     this._contents = $('<div class="accordian"></div>');
+    this.onSelect = $.Callbacks();
+    this.options = options || {};
+    if (this.options.onSelect) {
+        this.onSelect.add(options.onSelect);
+    }
 }
 
-Accordian.prototype.addCard = function(title, body, selected) {
+Accordian.prototype.addCard = function(title, body, selected, data) {
+    var a = this;
     var card = $('<div class="card"></div>')
         .append($('<div class="title"></div>')
             .append(title)
             .click(function () {
                 var thisCard = $(this).closest(".card");
                 if (thisCard.hasClass("active")) {
-                    thisCard.removeClass("active");
+                    if (!options.alwaysOpen) {
+                        thisCard.removeClass("active");
+                    }
                 }
                 else {
                     thisCard.closest(".accordian").find(".card").removeClass("active");
                     thisCard.addClass("active");
+                    a.onSelect.fire(thisCard.data("accordian-card-id"));
                 }
             })
         )
         .append($('<div class="body"></div>').append(body))
         .appendTo(this._contents);
+
+    if (data !== null) {
+        card.data("accordian-card-id", data); 
+    }
 
     if (selected) {
         card.addClass("active");
@@ -42,5 +55,11 @@ Accordian.prototype.addCard = function(title, body, selected) {
 }
 
 Accordian.prototype.contents = function () {
+    if (this.options.alwaysOpen && this._contents.find(".card.active").length == 0) {
+        this._contents.find(".card").first().addClass("active");
+    }
+    if (this.options.dissolveSingle && this._contents.children().length == 1) {
+        return this._contents.children().first().find(".body");
+    }
     return this._contents;
 }

--- a/iXBRLViewerPlugin/viewer/src/js/aspect.js
+++ b/iXBRLViewerPlugin/viewer/src/js/aspect.js
@@ -56,7 +56,7 @@ Aspect.prototype.equalTo = function(a) {
 Aspect.prototype.valueLabel = function(rolePrefix) {
     /* Taxonomy-defined dimension, treat as explicit - or concept */
     if (this._aspect.indexOf(":") > -1 || this._aspect == 'c') {
-        return this._report.getLabel(this._value, rolePrefix);
+        return this._report.getLabel(this._value, rolePrefix) || this._value;
     }
     else if (this._aspect == 'u') {
         if (this._value === null) {

--- a/iXBRLViewerPlugin/viewer/src/js/factset.js
+++ b/iXBRLViewerPlugin/viewer/src/js/factset.js
@@ -65,11 +65,13 @@ FactSet.prototype.minimallyUniqueLabel = function(fact) {
                 for (var i = 0; i < this._facts.length; i++) {
                     var fid = this._facts[i].id;
                     var l = allLabels[fid][j];
+                    var ul = uniqueLabels[fid] || [];
                     if (l !== null) {
-                        uniqueLabels[fid] = (uniqueLabels[fid] === undefined ? l : uniqueLabels[fid] + ", " + l);
+                        ul.push(l);
                     }
-                    if (uniqueLabels[fid] !== undefined) {
-                        uniqueLabelsByLabel[uniqueLabels[fid]] = true;
+                    if (ul.length > 0) {
+                        uniqueLabels[fid] = ul;
+                        uniqueLabelsByLabel[ul.join(", ")] = true;
                     }
                 } 
                 /* We have as many different labels as facts - we're done */
@@ -84,11 +86,13 @@ FactSet.prototype.minimallyUniqueLabel = function(fact) {
         if (Object.keys(uniqueLabels).length < this._facts.length) {
             for (var i = 0; i < this._facts.length; i++) {
                 var fid = this._facts[i].id;
-                uniqueLabels[fid] = uniqueLabels[fid] ? allLabels[fid][0] + ', ' + uniqueLabels[fid] : allLabels[fid][0];
+                var ul = uniqueLabels[fid] || [];
+                ul.unshift(allLabels[fid][0]);
+                uniqueLabels[fid] = ul;
             }
         }
 
         this._minimallyUniqueLabels = uniqueLabels;
     }
-    return this._minimallyUniqueLabels[fact.id];
+    return this._minimallyUniqueLabels[fact.id].join(", ");
 }

--- a/iXBRLViewerPlugin/viewer/src/js/factset.js
+++ b/iXBRLViewerPlugin/viewer/src/js/factset.js
@@ -1,0 +1,71 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export function FactSet(facts) {
+    this._facts = facts;
+}
+
+FactSet.prototype._allDimensions = function() {
+    var dims = {};
+    for (var i = 0; i < this._facts.length; i++) {
+        var dd = Object.keys(this._facts[i].dimensions());
+        for (var j = 0; j < dd.length; j++) {
+            dims[dd[j]] = 1;
+        }
+    }
+    return Object.keys(dims);
+}
+
+FactSet.prototype.minimallyUniqueLabel = function(fact) {
+    if (!this._minimallyUniqueLabels) {
+        var allLabels = {};
+        var allDims = this._allDimensions();
+        /* Assemble a map of arrays of all aspect labels for all facts, in a
+         * consistent order */
+        for (var i = 0; i < this._facts.length; i++) {
+            var f = this._facts[i];
+            allLabels[f.id] = [ f.getLabel(), f.period().toString() ];
+            for (var j = 0; j < allDims.length; j++) {
+                var dd = f.dimensions()[allDims[j]];
+                allLabels[f.id].push(dd ? dd.valueLabel : "");
+            }
+        }
+        /* Iterate each aspect label and compare that label across all facts in
+         * the set */
+        var uniqueLabels = {};
+        for (var j = 0; j < allDims.length + 2; j++) {
+            var labelMap = {};
+            for (var i = 0; i < this._facts.length; i++) {
+                labelMap[allLabels[this._facts[i].id][j]] = true;
+            }
+
+            /* We have at least some differences, so include this label */
+            var uniqueLabelsByLabel = {};
+            if (Object.keys(labelMap).length > 1) {
+                for (var i = 0; i < this._facts.length; i++) {
+                    var fid = this._facts[i].id;
+                    var l = allLabels[fid][j];
+                    uniqueLabels[fid] = (uniqueLabels[fid] === undefined ? l : uniqueLabels[fid] + ", " + l);
+                    uniqueLabelsByLabel[uniqueLabels[fid]] = true;
+                } 
+                /* We have as many different labels as facts - we're done */
+                if (Object.keys(uniqueLabelsByLabel).length == this._facts.length) {
+                    break;
+                }
+            }
+        }
+        this._minimallyUniqueLabels = uniqueLabels;
+    }
+    return this._minimallyUniqueLabels[fact.id];
+}

--- a/iXBRLViewerPlugin/viewer/src/js/factset.js
+++ b/iXBRLViewerPlugin/viewer/src/js/factset.js
@@ -46,32 +46,31 @@ FactSet.prototype.minimallyUniqueLabel = function(fact) {
             allLabels[f.id] = [];
             for (var j = 0; j < allDims.length; j++) {
                 var dd = f.aspects()[allDims[j]];
-                allLabels[f.id].push(dd ? dd.valueLabel() : "");
+                allLabels[f.id].push(dd ? dd.valueLabel() : null);
             }
         }
         /* Iterate each aspect label and compare that label across all facts in
          * the set */
         var uniqueLabels = {};
-        var haveEmptyLabels;
-        for (var j = 0; j < allDims.length + 2; j++) {
+        for (var j = 0; j < allDims.length; j++) {
             var labelMap = {};
             for (var i = 0; i < this._facts.length; i++) {
                 labelMap[allLabels[this._facts[i].id][j]] = true;
             }
 
             var uniqueLabelsByLabel = {};
-            haveEmptyLabels = false;
             if (Object.keys(labelMap).length > 1) {
                 /* We have at least two different labels, so include this
                  * aspect in the label for all facts in the set */
                 for (var i = 0; i < this._facts.length; i++) {
                     var fid = this._facts[i].id;
                     var l = allLabels[fid][j];
-                    uniqueLabels[fid] = (uniqueLabels[fid] === undefined ? l : uniqueLabels[fid] + ", " + l);
-                    if (uniqueLabels[fid] === "") {
-                        haveEmptyLabels = true;
+                    if (l !== null) {
+                        uniqueLabels[fid] = (uniqueLabels[fid] === undefined ? l : uniqueLabels[fid] + ", " + l);
                     }
-                    uniqueLabelsByLabel[uniqueLabels[fid]] = true;
+                    if (uniqueLabels[fid] !== undefined) {
+                        uniqueLabelsByLabel[uniqueLabels[fid]] = true;
+                    }
                 } 
                 /* We have as many different labels as facts - we're done */
                 if (Object.keys(uniqueLabelsByLabel).length == this._facts.length) {
@@ -79,8 +78,10 @@ FactSet.prototype.minimallyUniqueLabel = function(fact) {
                 }
             }
         }
-        /* If any label is empty, add the concept label onto the start of all of them */
-        if (haveEmptyLabels) {
+
+        /* If any label is empty, add the concept label onto the start of all
+         * of them */
+        if (Object.keys(uniqueLabels).length < this._facts.length) {
             for (var i = 0; i < this._facts.length; i++) {
                 var fid = this._facts[i].id;
                 uniqueLabels[fid] = uniqueLabels[fid] ? allLabels[fid][0] + ', ' + uniqueLabels[fid] : allLabels[fid][0];

--- a/iXBRLViewerPlugin/viewer/src/js/factset.js
+++ b/iXBRLViewerPlugin/viewer/src/js/factset.js
@@ -38,21 +38,21 @@ FactSet.prototype._allDimensions = function() {
 FactSet.prototype.minimallyUniqueLabel = function(fact) {
     if (!this._minimallyUniqueLabels) {
         var allLabels = {};
-        var allDims = ["c", "p"].concat(this._allDimensions());
+        var allAspects = ["c", "p"].concat(this._allDimensions());
         /* Assemble a map of arrays of all aspect labels for all facts, in a
          * consistent order */
         for (var i = 0; i < this._facts.length; i++) {
             var f = this._facts[i];
             allLabels[f.id] = [];
-            for (var j = 0; j < allDims.length; j++) {
-                var dd = f.aspects()[allDims[j]];
+            for (var j = 0; j < allAspects.length; j++) {
+                var dd = f.aspects()[allAspects[j]];
                 allLabels[f.id].push(dd ? dd.valueLabel() : null);
             }
         }
         /* Iterate each aspect label and compare that label across all facts in
          * the set */
         var uniqueLabels = {};
-        for (var j = 0; j < allDims.length; j++) {
+        for (var j = 0; j < allAspects.length; j++) {
             var labelMap = {};
             for (var i = 0; i < this._facts.length; i++) {
                 labelMap[allLabels[this._facts[i].id][j]] = true;

--- a/iXBRLViewerPlugin/viewer/src/js/factset.js
+++ b/iXBRLViewerPlugin/viewer/src/js/factset.js
@@ -22,7 +22,7 @@ FactSet.prototype._allDimensions = function() {
     for (var i = 0; i < this._facts.length; i++) {
         var dd = Object.keys(this._facts[i].dimensions());
         for (var j = 0; j < dd.length; j++) {
-            dims[dd[j]] = 1;
+            dims[dd[j]] = true;
         }
     }
     return Object.keys(dims);

--- a/iXBRLViewerPlugin/viewer/src/js/factset.js
+++ b/iXBRLViewerPlugin/viewer/src/js/factset.js
@@ -16,6 +16,7 @@ export function FactSet(facts) {
     this._facts = facts;
 }
 
+/* Returns the union of dimensions present on facts in the set */
 FactSet.prototype._allDimensions = function() {
     var dims = {};
     for (var i = 0; i < this._facts.length; i++) {
@@ -27,6 +28,13 @@ FactSet.prototype._allDimensions = function() {
     return Object.keys(dims);
 }
 
+/* Returns the "minimally unique" label for the specified fact in the set.
+ * 
+ * Minimally unique means that we include the value for just enough dimensions
+ * to generate labels that are unique within the set.
+ *
+ * In order to generate the best labels, we try concept and period first.
+ */
 FactSet.prototype.minimallyUniqueLabel = function(fact) {
     if (!this._minimallyUniqueLabels) {
         var allLabels = {};
@@ -51,10 +59,11 @@ FactSet.prototype.minimallyUniqueLabel = function(fact) {
                 labelMap[allLabels[this._facts[i].id][j]] = true;
             }
 
-            /* We have at least two different labels, so include this label */
             var uniqueLabelsByLabel = {};
             haveEmptyLabels = false;
             if (Object.keys(labelMap).length > 1) {
+                /* We have at least two different labels, so include this
+                 * aspect in the label for all facts in the set */
                 for (var i = 0; i < this._facts.length; i++) {
                     var fid = this._facts[i].id;
                     var l = allLabels[fid][j];

--- a/iXBRLViewerPlugin/viewer/src/js/factset.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/factset.test.js
@@ -46,6 +46,10 @@ var testReportData = {
                 }
             }
         },
+        "eg:Concept4": {
+            "labels": {
+            }
+        },
         "eg:Dimension1": {
             "labels": {
                 "std": {
@@ -172,4 +176,38 @@ describe("Minimally unique labels (dimensional)", () => {
     expect(fs.minimallyUniqueLabel(f4)).toEqual("Concept 1");
   });
 
+});
+
+describe("Minimally unique labels (duplicate facts)", () => {
+  var report = testReport({ 
+      "f1": testFact({"c": "eg:Concept1", "p": "2018-01-01", "eg:Dimension1": "eg:DimensionValue1"}),
+      "f2": testFact({"c": "eg:Concept1", "p": "2018-01-01", "eg:Dimension1": "eg:DimensionValue1"}),
+  });
+
+  var f1 = new Fact(report, "f1");
+  var f2 = new Fact(report, "f2");
+
+  test("Two facts, all aspects the same", () => {
+    var fs = new FactSet([ f1, f2 ]);
+    expect(fs._allDimensions()).toEqual(["eg:Dimension1"]);
+    expect(fs.minimallyUniqueLabel(f1)).toEqual("Concept 1");
+    expect(fs.minimallyUniqueLabel(f2)).toEqual("Concept 1");
+  });
+});
+
+describe("Minimally unique labels (missing labels)", () => {
+  var report = testReport({ 
+      "f1": testFact({"c": "eg:Concept1", "p": "2018-01-01" }),
+      "f2": testFact({"c": "eg:Concept4", "p": "2018-01-01" }),
+  });
+
+  var f1 = new Fact(report, "f1");
+  var f2 = new Fact(report, "f2");
+
+  test("Two facts, one has no label", () => {
+    var fs = new FactSet([ f1, f2 ]);
+    expect(fs._allDimensions()).toEqual([]);
+    expect(fs.minimallyUniqueLabel(f1)).toEqual("Concept 1");
+    expect(fs.minimallyUniqueLabel(f2)).toEqual("eg:Concept4");
+  });
 });

--- a/iXBRLViewerPlugin/viewer/src/js/factset.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/factset.test.js
@@ -1,0 +1,175 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Fact } from "./fact.js";
+import { FactSet } from "./factset.js";
+import { iXBRLReport } from "./report.js";
+
+var i = 0;
+
+var testReportData = {
+    "prefixes": {
+        "eg": "http://www.example.com",
+        "iso4217": "http://www.xbrl.org/2003/iso4217",
+        "e": "http://example.com/entity",
+    },
+    "concepts": {
+        "eg:Concept1": {
+            "labels": {
+                "std": {
+                    "en": "Concept 1"
+                }
+            }
+        },
+        "eg:Concept2": {
+            "labels": {
+                "std": {
+                    "en": "Concept 2"
+                }
+            }
+        },
+        "eg:Concept3": {
+            "labels": {
+                "std": {
+                    "en": "Concept 3"
+                }
+            }
+        },
+        "eg:Dimension1": {
+            "labels": {
+                "std": {
+                    "en": "Dimension 1"
+                }
+            }
+        },
+        "eg:Dimension2": {
+            "labels": {
+                "std": {
+                    "en": "Dimension 2"
+                }
+            }
+        },
+        "eg:DimensionValue1": {
+            "labels": {
+                "std": {
+                    "en": "Dimension Value 1"
+                }
+            }
+        },
+        "eg:DimensionValue2": {
+            "labels": {
+                "std": {
+                    "en": "Dimension Value 2"
+                }
+            }
+        }
+    },
+    "facts": {
+    }
+};
+
+function testReport(facts) {
+    // Deep copy of standing data
+    var data = JSON.parse(JSON.stringify(testReportData));
+    data.facts = facts;
+    var report = new iXBRLReport(data);
+    return report;
+}
+
+function testFact(aspectData) {
+    var factData = { "a": aspectData };
+    return factData;
+}
+
+describe("Minimally unique labels (non-dimensional)", () => {
+  var report = testReport({ 
+      "f1": testFact({"c": "eg:Concept1", "p": "2018-01-01"}),
+      "f2": testFact({"c": "eg:Concept2", "p": "2018-01-01"}),
+      "f3": testFact({"c": "eg:Concept2", "p": "2019-01-01"}),
+      "f4": testFact({"c": "eg:Concept2", "p": "2019-01-01"}),
+  });
+
+  var f1 = new Fact(report, "f1");
+  var f2 = new Fact(report, "f2");
+  var f3 = new Fact(report, "f3");
+  var f4 = new Fact(report, "f3");
+
+  test("Different concept", () => {
+    var fs = new FactSet([ f1, f2 ]);
+    expect(fs._allDimensions()).toEqual([]);
+    expect(fs.minimallyUniqueLabel(f1)).toEqual("Concept 1");
+    expect(fs.minimallyUniqueLabel(f2)).toEqual("Concept 2");
+  });
+
+  test("Different period", () => {
+    var fs = new FactSet([ f2, f3 ]);
+    expect(fs._allDimensions()).toEqual([]);
+    expect(fs.minimallyUniqueLabel(f2)).toEqual("31 Dec 2017");
+    expect(fs.minimallyUniqueLabel(f3)).toEqual("31 Dec 2018");
+  });
+
+  test("Different concept and period, concept takes precedence", () => {
+    var fs = new FactSet([ f1, f4 ]);
+    expect(fs._allDimensions()).toEqual([]);
+    expect(fs.minimallyUniqueLabel(f1)).toEqual("Concept 1");
+    expect(fs.minimallyUniqueLabel(f4)).toEqual("Concept 2");
+  });
+
+  test("Mix of period and concept differences", () => {
+    var fs = new FactSet([ f1, f2, f3 ]);
+    expect(fs._allDimensions()).toEqual([]);
+    expect(fs.minimallyUniqueLabel(f1)).toEqual("Concept 1, 31 Dec 2017");
+    expect(fs.minimallyUniqueLabel(f2)).toEqual("Concept 2, 31 Dec 2017");
+    expect(fs.minimallyUniqueLabel(f3)).toEqual("Concept 2, 31 Dec 2018");
+  });
+});
+
+describe("Minimally unique labels (dimensional)", () => {
+  var report = testReport({ 
+      "f1": testFact({"c": "eg:Concept1", "p": "2018-01-01", "eg:Dimension1": "eg:DimensionValue1"}),
+      "f2": testFact({"c": "eg:Concept1", "p": "2018-01-01", "eg:Dimension1": "eg:DimensionValue2"}),
+      "f3": testFact({"c": "eg:Concept1", "p": "2019-01-01", "eg:Dimension1": "eg:DimensionValue2"}),
+      "f4": testFact({"c": "eg:Concept1", "p": "2018-01-01" }),
+  });
+
+  var f1 = new Fact(report, "f1");
+  var f2 = new Fact(report, "f2");
+  var f3 = new Fact(report, "f3");
+  var f4 = new Fact(report, "f4");
+
+  test("Same concept & period, different dimension value", () => {
+    var fs = new FactSet([ f1, f2 ]);
+    expect(fs._allDimensions()).toEqual(["eg:Dimension1"]);
+    expect(fs.minimallyUniqueLabel(f1)).toEqual("Dimension Value 1");
+    expect(fs.minimallyUniqueLabel(f2)).toEqual("Dimension Value 2");
+  });
+
+  test("Different period, different dimension value", () => {
+    var fs = new FactSet([ f1, f3 ]);
+    expect(fs._allDimensions()).toEqual(["eg:Dimension1"]);
+    /* Different period takes precedence */
+    expect(fs.minimallyUniqueLabel(f1)).toEqual("31 Dec 2017");
+    expect(fs.minimallyUniqueLabel(f3)).toEqual("31 Dec 2018");
+  });
+
+  test("Dimension present on one fact only", () => {
+    var fs = new FactSet([ f1, f4 ]);
+    expect(fs._allDimensions()).toEqual(["eg:Dimension1"]);
+    /* Concept is included even though it's the same across all to avoid an
+     * empty label */
+    expect(fs.minimallyUniqueLabel(f1)).toEqual("Concept 1, Dimension Value 1");
+    expect(fs.minimallyUniqueLabel(f4)).toEqual("Concept 1");
+  });
+
+});

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -313,8 +313,8 @@ Inspector.prototype.update = function () {
             alwaysOpen: true,
             dissolveSingle: true,
         });
-        var fs = new FactSet(this._currentFactSet);
-        $.each(inspector._currentFactSet, function (i, fact) {
+        var fs = new FactSet(this._currentFactList);
+        $.each(inspector._currentFactList, function (i, fact) {
             var factHTML = $(require('../html/fact-details.html')); 
             $('.std-label', factHTML).text(fact.getLabel("std", true) || fact.conceptName());
             $('.documentation', factHTML).text(fact.getLabel("doc") || "");
@@ -385,16 +385,22 @@ Inspector.prototype.update = function () {
     this.updateURLFragment();
 }
 
-Inspector.prototype.selectFact = function (id, factIdSet) {
+/*
+ * Callback used to select facts when clicked in the viewer.
+ *
+ * Takes an ID of the fact to be selected, and an optional list of IDs for all
+ * facts that the click corresponds to (i.e. when there are nested facts)
+ */
+Inspector.prototype.selectFact = function (id, factIdList) {
     this._currentFact = this._report.getFactById(id);
-    if (factIdSet) {
-        this._currentFactSet = [];
-        for (var i = 0; i < factIdSet.length; i++) {
-            this._currentFactSet.push(this._report.getFactById(factIdSet[i]));
+    if (factIdList) {
+        this._currentFactList = [];
+        for (var i = 0; i < factIdList.length; i++) {
+            this._currentFactList.push(this._report.getFactById(factIdList[i]));
         }
     }
     else {
-        this._currentFactSet = [this._currentFact];
+        this._currentFactList = [this._currentFact];
     }
     this.update();
 }

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -339,7 +339,7 @@ Inspector.prototype.update = function () {
             for (var d in dims) {
                 var h = $('<div class="dimension"></div>')
                     .text(fact.report().getLabel(d, "std", true) || d)
-                    .appendTo('#dimensions', factHTML);
+                    .appendTo($('#dimensions', factHTML));
                 if (fact.isNumeric()) {
                     h.append(
                         $("<span></span>") 
@@ -350,10 +350,6 @@ Inspector.prototype.update = function () {
                             })
                     )
                 }
-                $('<div class="dimension-value"></div>')
-                    .text(this._report.getLabel(dims[d], "std", true) || dims[d])
-                    .appendTo('#dimensions', factHTML);
-                
             }
             a.addCard(
                 fs.minimallyUniqueLabel(fact),

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -357,7 +357,7 @@ Inspector.prototype.update = function () {
             }
             a.addCard(
                 fs.minimallyUniqueLabel(fact),
-                factHTML, 
+                factHTML.children(), 
                 fact.id == inspector._currentFact.id, 
                 fact.id
             );

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -127,7 +127,7 @@ Viewer.prototype._bindHandlers = function () {
     $('.ixbrl-element', this._contents)
         .click(function (e) {
             e.stopPropagation();
-            viewer.selectElement($(this));
+            viewer.selectElementByClick($(this));
         })
         .mouseenter(function (e) { viewer._mouseEnter($(this)) })
         .mouseleave(function (e) { viewer._mouseLeave($(this)) });
@@ -177,11 +177,29 @@ Viewer.prototype.showAndSelectElement = function(e) {
     this.selectElement(e);
 }
 
-Viewer.prototype.selectElement = function (e) {
+/*
+ * Update the currently highlighted fact, but do not trigger a change in the
+ * inspector.
+ * 
+ * Used to switch facts when the selection corresponds to multiple facts.
+ */
+Viewer.prototype.highlightElement = function (e) {
     e.closest("body").find(".ixbrl-element").removeClass("ixbrl-selected").removeClass("ixbrl-related").removeClass("ixbrl-linked-highlight");
     e.addClass("ixbrl-selected");
+}
+
+Viewer.prototype.selectElement = function (e, eltSet) {
+    this.highlightElement(e);
     var id = e.data('ivid');
-    this.onSelect.fire(id);
+    this.onSelect.fire(id, eltSet);
+}
+
+Viewer.prototype.selectElementByClick = function (e) {
+    var eltSet = [];
+    e.parents(".ixbrl-element").addBack().each(function () { 
+        eltSet.unshift($(this).data('ivid')); 
+    });
+    this.selectElement(e, eltSet);
 }
 
 Viewer.prototype._mouseEnter = function (e) {
@@ -219,6 +237,10 @@ Viewer.prototype.elementsForFacts = function (facts) {
     var ids = $.map(facts, function (f) { return f.id });
     var elements = $('.ixbrl-element', this._contents).filter(function () { return $.inArray($(this).data('ivid'), ids ) > -1 });
     return elements;
+}
+
+Viewer.prototype.highlightFact = function(fact) {
+    this.highlightElement(this.elementForFact(fact));
 }
 
 Viewer.prototype.showAndSelectFact = function (fact) {

--- a/iXBRLViewerPlugin/viewer/src/less/accordian.less
+++ b/iXBRLViewerPlugin/viewer/src/less/accordian.less
@@ -1,0 +1,51 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.accordian .card {
+  margin-top: 0.4rem;
+  background-color: #f9f9f9;
+
+  .body {
+    display: none;
+    padding-left: 1.6rem;
+    padding-right: 1.6rem;
+    padding-bottom: 0.8rem;
+
+    & > h4:first-child {
+      margin-top: 0.8rem;
+    }
+  }
+
+  .title {
+    padding: 1.2rem 1.6rem;
+    cursor: pointer;
+    line-height: 1.8rem;
+
+    &:hover {
+      background-color: #f3f3f3;
+    }
+  }
+
+  &.active {
+    background-color: #f3f3f3;
+
+    .title {
+      font-weight: bold;
+    }
+
+    .body {
+      display: block;
+    }
+  }
+}

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -21,6 +21,7 @@
 @import "chart.less";
 @import "dialog.less";
 @import "menu.less";
+@import "accordian.less";
 @import (reference) "text-mixins.less";
 
 @top-bar-height: 35px;
@@ -510,39 +511,6 @@
 
           tr:hover td {
             .linked-highlight-cell();
-          }
-        }
-      }
-
-      .accordian .card {
-        margin-top: 0.4rem;
-        background-color: #f9f9f9;
-
-        .body {
-          display: none;
-          padding-left: 1.6rem;
-          padding-right: 1.6rem;
-        }
-
-        .title {
-          padding: 1.2rem 1.6rem;
-          cursor: pointer;
-          line-height: 1.8rem;
-
-          &:hover {
-            background-color: #f3f3f3;
-          }
-        }
-
-        &.active {
-          background-color: #f3f3f3;
-
-          .title {
-            font-weight: bold;
-          }
-
-          .body {
-            display: block;
           }
         }
       }

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -430,10 +430,6 @@
       }
     }
 
-    .fact-details {
-      display: none;
-    }
-
     .no-fact-selected {
       width: 100%;
       padding: 50px 0;


### PR DESCRIPTION
If a piece of text has been tagged more than once, clicking on it will now show all facts which it forms a part of in an accordian.

The code will generate a minimally unique label for each fact in the set to use as a title for the accordian.  It runs through each dimension on the facts, and adds the value for that dimension for all facts if there are any differences between the facts.  It does this as many times as necessary to get unique labels for each fact.  The first dimension it tries is "concept", an the second is "period".  This means that for common cases, the facts will be labelled by just concept, or just period.

The use of the accordian here is perhaps a little suspect, as the subsequent sections (references and calculations) are linked to the individual facts, and so will change if you switch between the different cards in the accordian.