### PR TITLE
Fix UI for truncation of text in the inspector

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -271,16 +271,16 @@ Inspector.prototype._updateValue = function (fact, showAll, context) {
         var fullLabel = v;
         var vv = wrapLabel(v, 120);
         if (vv.length > 1) {
-            $('#inspector tr.value', context).addClass("truncated");
-            $('#inspector tr.value .show-all', context).off().click(function () { inspector._updateValue(fact, true); });
+            $('tr.value', context).addClass("truncated");
+            $('tr.value .show-all', context).off().click(function () { inspector._updateValue(fact, true); });
         }
         else {
-            $('#inspector tr.value', context).removeClass('truncated');
+            $('tr.value', context).removeClass('truncated');
         }
         v = vv[0];
     }
     else {
-        $('#inspector tr.value', context).removeClass('truncated');
+        $('tr.value', context).removeClass('truncated');
     }
 
     $('tr.value td .value', context).text(v);


### PR DESCRIPTION
If you select a text fact with a large amount of text, it should appear truncated in the inspector with an ellipsis button that will show the full text.

The changes for to add support for nested facts stopped the ellipsis from ever being displayed.  This is now fixed.