### PR TITLE
EUR currency symbol support

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/aspect.js
+++ b/iXBRLViewerPlugin/viewer/src/js/aspect.js
@@ -70,6 +70,9 @@ Aspect.prototype.valueLabel = function(rolePrefix) {
             else if (qname.localname == 'USD') {
                 return "US $";
             }
+            else if (qname.localname == 'EUR') {
+                return "€";
+            }
         }
         return this._value;
     }

--- a/iXBRLViewerPlugin/viewer/src/js/aspect.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/aspect.test.js
@@ -58,6 +58,12 @@ test("Unit aspects label - known currency", () => {
     expect(unitAspect.valueLabel()).toBe("£");  
 });
 
+test("Unit aspects label - known currency (EUR)", () => {
+    var unitAspect = new Aspect("u", "iso4217:EUR", testReport);
+    expect(unitAspect.label()).toBe("Unit");  
+    expect(unitAspect.valueLabel()).toBe("€");  
+});
+
 test("Unit aspects label - unknown currency", () => {
     var unitAspect = new Aspect("u", "iso4217:ZAR", testReport);
     expect(unitAspect.label()).toBe("Unit");  


### PR DESCRIPTION
Where facts are using Euros, display a Euro symbol (€) rather than iso4217:EUR.