### PR TITLE
Add border to LHS of inspector

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -392,6 +392,7 @@
     bottom: 0;
     box-sizing: border-box;
     overflow: hidden;
+    border-left: @simple-border;
 
     a {
       text-decoration: none;


### PR DESCRIPTION
Add a border to the left hand side of the inspector.  This provides visual separation between the document and the inspector on very short documents, where there is no scroll bar shown, or on platforms with scroll bars that aren't always visible, or don't run the full height of the screen (e.g. firefox on Linux).

On a normal length document on Chrome (on Linux, at least), the new border is pretty much invisible.