### PR TITLE
Remove parent-child relationship information

### DIFF
--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -157,7 +157,7 @@ class IXBRLViewerBuilder:
 
         for baseSetKey, baseSetModelLinks  in self.dts.baseSets.items():
             arcrole, ELR, linkqname, arcqname = baseSetKey
-            if (arcrole == XbrlConst.parentChild or arcrole == XbrlConst.summationItem) and ELR is not None:
+            if arcrole == XbrlConst.summationItem and ELR is not None:
                 self.addELR(ELR)
                 rr = dict()
                 relSet = self.dts.relationshipSet(arcrole, ELR)

--- a/tests/unit_tests/iXBRLViewerPlugin/test_iXBRLViewer.py
+++ b/tests/unit_tests/iXBRLViewerPlugin/test_iXBRLViewer.py
@@ -199,7 +199,7 @@ class TestIXBRLViewer(unittest.TestCase):
             pass
 
         baseSets = defaultdict(list)
-        baseSets[('http://www.xbrl.org/2003/arcrole/parent-child', 'ELR', 'linkqname', 'arcqname')] = []
+        baseSets[('http://www.xbrl.org/2003/arcrole/summation-item', 'ELR', 'linkqname', 'arcqname')] = []
 
         roleTypes = defaultdict(list)
         roleTypes['ELR'] = [Mock(definition = "ELR Label")]
@@ -255,8 +255,8 @@ class TestIXBRLViewer(unittest.TestCase):
     def test_getRelationships_returns_a_rel(self):
         result = self.builder_1.getRelationships()
         roleMap = self.builder_1.roleMap
-        pcPrefix = roleMap.getPrefix('http://www.xbrl.org/2003/arcrole/parent-child')
-        self.assertTrue(result.get(pcPrefix).get(roleMap.getPrefix('ELR')).get('us-gaap:from_concept'))
+        siPrefix = roleMap.getPrefix('http://www.xbrl.org/2003/arcrole/summation-item')
+        self.assertTrue(result.get(siPrefix).get(roleMap.getPrefix('ELR')).get('us-gaap:from_concept'))
 
     def test_addELR_no_definition(self):
         """


### PR DESCRIPTION
This removes parent-child relationship information from the taxonomy data included in the viewer files.  This information was not being used by the viewer, and was adding a substantial amount of size to the file, as information (labels, references) about all concepts in the presentation tree is also included.

This is particularly relevant on UK filings which do not use extensions and so include the base taxonomy presentation linkbase which covers all concepts in the taxonomy.

If we re-add this in the future, we should make it more selective (e.g. excluding ELRs which don't have any concepts, and not including labels/references for unused concepts).