### PR TITLE
Fix display of decimal numbers with infinite decimals

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -71,14 +71,21 @@ Fact.prototype.readableValue = function() {
     var v = this.f.v;
     if (this.isNumeric()) {
         var d = this.decimals();
-        if (d < 0) {
-            d = 0;
-        }
-        if (this.isMonetaryValue()) {
-            v = this.unit().valueLabel() + " " + formatNumber(v,d);
+        var formattedNumber;
+        if (d === undefined) {
+            formattedNumber= v;
         }
         else {
-            v = formatNumber(v,d) + " " + this.unit().valueLabel();
+            if (d < 0) {
+                d = 0;
+            }
+            formattedNumber = formatNumber(v,d);
+        }
+        if (this.isMonetaryValue()) {
+            v = this.unit().valueLabel() + " " + formattedNumber;
+        }
+        else {
+            v = formattedNumber + " " + this.unit().valueLabel();
         }
     }
     else if (this.escaped()) {

--- a/iXBRLViewerPlugin/viewer/src/js/fact.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.test.js
@@ -104,6 +104,25 @@ describe("Simple fact properties", () => {
         expect(f.conceptQName().namespace).toEqual("http://www.example.com");
     });
 
+    test("Numeric (infinite precision)", () => {
+        var f = testFact({
+                "v": 0.0125,
+                "a": {
+                    "c": "eg:Concept1",
+                    "u": "eg:USD", 
+                    "p": "2018-01-01/2019-01-01",
+                }});
+        expect(f.value()).toEqual(0.0125);
+        expect(f.decimals()).toBeUndefined();
+        expect(f.isNumeric()).toBeTruthy();
+        expect(f.isMonetaryValue()).toBeFalsy();
+        expect(f.readableValue()).toEqual("0.0125 eg:USD");
+        expect(f.unit().value()).toEqual("eg:USD");
+        expect(f.conceptQName().prefix).toEqual("eg");
+        expect(f.conceptQName().localname).toEqual("Concept1");
+        expect(f.conceptQName().namespace).toEqual("http://www.example.com");
+    });
+
     test("String", () => {
         var f = testFact({
                 "v": "abcdef",


### PR DESCRIPTION
Infinite decimals was incorrectly treated as zero decimals when deciding how many decimal places to display, causing numbers with a decimal part to be truncated (e.g. 0.0125 displayed as "0")
With this fix, the viewer will show whatever digits are present.