### PR TITLE
Set iframe height to 0 rather than hiding to improve performance.

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -387,8 +387,8 @@ Viewer.prototype.selectDocument = function (docIndex) {
         .eq(docIndex)
         .addClass("active");
     this._iframes
-        .hide()
+        .height(0)
         .eq(docIndex)
-        .show();
+        .height("100%");
     this._setTitle(docIndex);
 }


### PR DESCRIPTION
This fixes issue 55 by reducing the height of iframes on inactive tabs to zero rather than actually hiding them.  This appears to give significantly better performance.

I've not noticed any negative side-effects, but I suspect that  memory usage may be worse on document sets with multiple large documents.