### PR TITLE
Sort files in ixds alphabetically when converting samples

### DIFF
--- a/samples/build-viewer.py
+++ b/samples/build-viewer.py
@@ -40,6 +40,7 @@ class CntlrCreateViewer(Cntlr.Cntlr):
     def createViewer(self, f, scriptUrl=None, outPath=None):
         if os.path.isdir(f):
             files = glob.glob(os.path.join(f, "*.xhtml")) + glob.glob(os.path.join(f, "*.html")) + glob.glob(os.path.join(f, "*.htm"))
+            files.sort()
             if len(files) > 1:
                 f = os.path.join(f, inlineXbrlDocumentSet.IXDS_SURROGATE) + inlineXbrlDocumentSet.IXDS_DOC_SEPARATOR.join(files)
             elif len(files) == 1:


### PR DESCRIPTION
File order is significant when assembling viewers for document sets because a) the first file is treated as the "entry point" that pulls in all other files in the set and b) it controls the order of the tabs.

The is no standard iXBRL manifest that provides an ordering.  Previously sample files were being created in whatever order Python's glob() function was returning them, making it OS-dependent which order the set was assembled.  This PR sorts the files alphabetically, which at least gives us stable ordering and actually seems to give a good order for SEC document sets (at least on the examples seen so far).