### PR TITLE
Issue 57 highlight all facts performance

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -21,7 +21,7 @@ import $ from 'jquery'
 
 export function Fact(report, factId) {
     this.f = report.data.facts[factId];
-    this._ixData = report.getIXDataForFact(factId);
+    this._ixNode = report.getIXDataForFact(factId);
     this._report = report;
     this.id = factId;
 }
@@ -233,5 +233,5 @@ Fact.prototype.identifier = function () {
 }
 
 Fact.prototype.escaped = function () {
-    return this._ixData.escape;
+    return this._ixNode.escaped;
 }

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -21,7 +21,7 @@ import $ from 'jquery'
 
 export function Fact(report, factId) {
     this.f = report.data.facts[factId];
-    this._ixNode = report.getIXDataForFact(factId);
+    this._ixNode = report.getIXNodeForFactId(factId);
     this._report = report;
     this.id = factId;
 }

--- a/iXBRLViewerPlugin/viewer/src/js/fact.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.test.js
@@ -53,7 +53,7 @@ function testReport(facts, ixData) {
     var data = JSON.parse(JSON.stringify(testReportData));
     data.facts = facts;
     var report = new iXBRLReport(data);
-    report.setIXData(ixData);
+    report.setIXNodeMap(ixData);
     return report;
 }
 
@@ -371,20 +371,20 @@ describe("Readable value", () => {
 
     test("Strip HTML tags and normalise whitespace", () => {
 
-        expect(testFact({ "v": "<b>foo</b>" }, {"escape": true }).readableValue())
+        expect(testFact({ "v": "<b>foo</b>" }, {"escaped": true }).readableValue())
             .toBe("foo");
 
-        expect(testFact({ "v": "    <b>foo</b>bar" }, {"escape": true }).readableValue())
+        expect(testFact({ "v": "    <b>foo</b>bar" }, {"escaped": true }).readableValue())
             .toBe("foobar");
 
-        expect(testFact({ "v": "\u00a0<b>foo</b>" }, {"escape": true }).readableValue())
+        expect(testFact({ "v": "\u00a0<b>foo</b>" }, {"escaped": true }).readableValue())
             .toBe("foo");
 
     });
 
     test("Don't strip non-escaped facts", () => {
 
-        expect(testFact({ "v": "\u00a0<b>foo</b>" }, {"escape": false }).readableValue())
+        expect(testFact({ "v": "\u00a0<b>foo</b>" }, {"escaped": false }).readableValue())
             .toBe("\u00a0<b>foo</b>");
         
         expect(testFact({ "v": "\u00a0<b>foo</b>" }, {  }).readableValue())
@@ -393,40 +393,40 @@ describe("Readable value", () => {
     });
 
     test("Detect and strip HTML tags - XHTML tags and attributes", () => {
-        expect(testFact({ "v": "<xhtml:b>foo</xhtml:b>" }, {"escape": true }).readableValue())
+        expect(testFact({ "v": "<xhtml:b>foo</xhtml:b>" }, {"escaped": true }).readableValue())
             .toBe("foo");
 
-        expect(testFact({ "v": '<xhtml:span style="font-weight: bold">foo</xhtml:span>' }, {"escape": true }).readableValue())
+        expect(testFact({ "v": '<xhtml:span style="font-weight: bold">foo</xhtml:span>' }, {"escaped": true }).readableValue())
             .toBe("foo");
     });
 
     test("Detect and strip HTML tags - check behaviour with invalid HTML", () => {
         /* Invalid HTML  */
-        expect(testFact({ "v": "<b:b:b>foo</b:b:b>" }, {"escape": true }).readableValue())
+        expect(testFact({ "v": "<b:b:b>foo</b:b:b>" }, {"escaped": true }).readableValue())
             .toBe("foo");
 
-        expect(testFact({ "v": "<foo<bar>baz</bar>" }, {"escape": true }).readableValue())
+        expect(testFact({ "v": "<foo<bar>baz</bar>" }, {"escaped": true }).readableValue())
             .toBe("baz");
     });
 
     test("Text in consecutive inline elements should be contiguous", () => {
 
-        expect(testFact({ "v": "<b>foo</b><i>bar</i>" }, {"escape":true }).readableValue())
+        expect(testFact({ "v": "<b>foo</b><i>bar</i>" }, {"escaped":true }).readableValue())
             .toBe("foobar");
 
     });
 
     test("Text in block/table elements should be separated.", () => {
 
-        expect(testFact({ "v": "<p>foo</p><p>bar</p>" }, {"escape":true }).readableValue())
+        expect(testFact({ "v": "<p>foo</p><p>bar</p>" }, {"escaped":true }).readableValue())
             .toBe("foo bar");
 
         /* This should really return "foo bar", but we don't correctly detect
          * block tags in prefixed XHTML */
-        expect(testFact({ "v": '<xhtml:p xmlns:xhtml="https://www.w3.org/1999/xhtml/">foo</xhtml:p><xhtml:p>bar</xhtml:p>' }, {"escape":true }).readableValue())
+        expect(testFact({ "v": '<xhtml:p xmlns:xhtml="https://www.w3.org/1999/xhtml/">foo</xhtml:p><xhtml:p>bar</xhtml:p>' }, {"escaped":true }).readableValue())
             .toBe("foobar");
 
-        expect(testFact({ "v": "<table><tr><td>cell1</td><td>cell2</td></tr></table>" }, {"escape":true })
+        expect(testFact({ "v": "<table><tr><td>cell1</td><td>cell2</td></tr></table>" }, {"escaped":true })
             .readableValue())
             .toBe("cell1 cell2");
 
@@ -434,7 +434,7 @@ describe("Readable value", () => {
 
     test("Whitespace normalisation", () => {
 
-        expect(testFact({ "v": "<p>bar  foo</p> <p>bar</p>" }, {"escape":true }).readableValue())
+        expect(testFact({ "v": "<p>bar  foo</p> <p>bar</p>" }, {"escaped":true }).readableValue())
             .toBe("bar foo bar");
 
     });

--- a/iXBRLViewerPlugin/viewer/src/js/ixnode.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixnode.js
@@ -1,0 +1,21 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+export function IXNode(node) {
+    this.domNode = node;
+    this.escaped = false;
+    this.continuations = [];
+}
+

--- a/iXBRLViewerPlugin/viewer/src/js/ixnode.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixnode.js
@@ -21,9 +21,10 @@
  * The domNode property is the "containing" element which will either be an
  * inserted div or span wrapper, or the nearest enclosing td or th.
  */
-export function IXNode(node) {
+export function IXNode(node, docIndex) {
     this.domNode = node;
     this.escaped = false;
     this.continuations = [];
+    this.docIndex = docIndex;
 }
 

--- a/iXBRLViewerPlugin/viewer/src/js/ixnode.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixnode.js
@@ -13,6 +13,14 @@
 // limitations under the License.
 
 
+/*
+ * Object to hold information related to iXBRL nodes in the HTML document.
+ * May correspond to either a nonNumeric/nonFraction element, or a continuation
+ * element.
+ * 
+ * The domNode property is the "containing" element which will either be an
+ * inserted div or span wrapper, or the nearest enclosing td or th.
+ */
 export function IXNode(node) {
     this.domNode = node;
     this.escaped = false;

--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -20,9 +20,8 @@ import $ from 'jquery'
 
 export function iXBRLReport (data) {
     this.data = data;
-    this._viewerFactData = {};
     this._facts = {};
-    this._ixData = {};
+    this._ixNodeMap = {};
     this._viewerOptions = new ViewerOptions();
 }
 
@@ -88,12 +87,12 @@ iXBRLReport.prototype.getFactById = function(id) {
 /*
  * Set additional information about facts obtained from parsing the iXBRL.
  */
-iXBRLReport.prototype.setIXData = function(ixData) {
-    this._ixData = ixData;
+iXBRLReport.prototype.setIXNodeMap = function(ixData) {
+    this._ixNodeMap = ixData;
 }
 
-iXBRLReport.prototype.getIXDataForFact = function(factId) {
-    return this._ixData[factId] || {};
+iXBRLReport.prototype.getIXNodeForFactId = function(factId) {
+    return this._ixNodeMap[factId] || {};
 }
 
 iXBRLReport.prototype.facts = function() {

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -58,9 +58,15 @@ Viewer.prototype._buildContinuationMap = function() {
             var nextId = id;
             while (this._continuedAtMap[nextId].continuedAt !== undefined) {
                 nextId = this._continuedAtMap[nextId].continuedAt;
-                this._continuedAtMap[nextId] = this._continuedAtMap[nextId] || {};
-                this._continuedAtMap[nextId].continuationOf = id;
-                parts.push(nextId);
+                if (this._getFactData(nextId, "domnode")) {
+                    this._continuedAtMap[nextId] = this._continuedAtMap[nextId] || {};
+                    this._continuedAtMap[nextId].continuationOf = id;
+                    parts.push(nextId);
+                }
+                else {
+                    console.log("Unresolvable continuedAt reference: " + nextId);
+                    break;
+                }
             }
             this._setFactData(id, "continuations", parts);
         }

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -110,6 +110,7 @@ Viewer.prototype._preProcessiXBRL = function(n, docIndex, inHidden) {
     }
     var id = n.getAttribute("id");
     node.addClass("ixbrl-element").data('ivid',id);
+    this._setFactData(id, 'domnode', node.get(0));
     this._docIndexesByFactId[id] = docIndex;
     if (n.getAttribute("continuedAt")) {
         this._continuedAtMap[id] = { 
@@ -289,11 +290,14 @@ Viewer.prototype.elementForFact = function (fact) {
 }
 
 Viewer.prototype.elementForFactId = function (factId) {
-    return $('.ixbrl-element', this._contents).filter(function () { return $(this).data('ivid') == factId }).first();
+    return $(this._getFactData(factId, 'domnode'));
 }
 
 Viewer.prototype.elementsForFactIds = function (ids) {
-    return $('.ixbrl-element', this._contents).filter(function () { return $.inArray($(this).data('ivid'), ids ) > -1 });
+    var viewer = this;
+    return $($.map(ids, function (id, n) {
+        return viewer._getFactData(id, 'domnode');
+    }));
 }
 
 Viewer.prototype.elementsForFacts = function (facts) {

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -33,7 +33,7 @@ export function Viewer(iframes, report) {
         viewer._preProcessiXBRL($(this).contents().find("body").get(0), n)
     });
     this._buildContinuationMap();
-    report.setIXData(this._ixNodeMap);
+    report.setIXNodeMap(this._ixNodeMap);
     this._applyStyles();
     this._bindHandlers();
     this.scale = 1;

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -27,7 +27,6 @@ export function Viewer(iframes, report) {
 
     this._ixNodeMap = {};
     this._continuedAtMap = {};
-    this._docIndexesByFactId = {};
     var viewer = this;
     iframes.each(function (n) { 
         viewer._preProcessiXBRL($(this).contents().find("body").get(0), n)
@@ -117,9 +116,8 @@ Viewer.prototype._preProcessiXBRL = function(n, docIndex, inHidden) {
     }
     var id = n.getAttribute("id");
     node.addClass("ixbrl-element").data('ivid',id);
-    var ixn = new IXNode(node.get(0));
+    var ixn = new IXNode(node.get(0), docIndex);
     this._ixNodeMap[id] = ixn;
-    this._docIndexesByFactId[id] = docIndex;
     if (n.getAttribute("continuedAt")) {
         this._continuedAtMap[id] = { 
             "isFact": name != 'CONTINUATION',
@@ -384,7 +382,7 @@ Viewer.prototype._setTitle = function (docIndex) {
 }
 
 Viewer.prototype.showDocumentForFactId = function(factId) {
-    this.selectDocument(this._docIndexesByFactId[factId]);
+    this.selectDocument(this._ixNodeMap[factId].docIndex);
 }
 
 Viewer.prototype.selectDocument = function (docIndex) {


### PR DESCRIPTION
On some documents (e.g. the Summit Materials filing) selecting "highlight all facts" causes the UI to hang.  This is because the code was previously filtering the DOM each in order to find the relevant DOM node(s) for a given fact ID.  This PR fixes this by maintaining a map of fact IDs to DOM nodes.  The code is also refactored to store other information related to iXBRL elements (continuations, escaped flags, document index) in a single map on an "IXNode" object. 

Fixes Issue 57.