### PR TITLE
Table export: Cope with tables with hidden cells

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/tableExport.js
+++ b/iXBRLViewerPlugin/viewer/src/js/tableExport.js
@@ -39,6 +39,7 @@ TableExport.addHandles = function (iframe, report) {
 TableExport.prototype._getRawTable = function (table) {
     var table = this._table;
     var report = this._report;
+    var maxRowLength = 0;
     var rows = [];
     table.find("tr:visible").each(function () {
         var row = [];
@@ -84,8 +85,17 @@ TableExport.prototype._getRawTable = function (table) {
                 row.push({ type: "static", value: v});
             }
         });
+        if (row.length > maxRowLength) {
+            maxRowLength = row.length;
+        }
         rows.push(row);
     });
+    for (var i = 0; i < rows.length; i++) {
+        var row = rows[i];
+        while (row.length < maxRowLength) {
+            row.push({ type: "static", value: "" });
+        }
+    }
     return rows;
 }
 

--- a/iXBRLViewerPlugin/viewer/src/js/tableExport.js
+++ b/iXBRLViewerPlugin/viewer/src/js/tableExport.js
@@ -142,10 +142,6 @@ TableExport.prototype._getConstantAspectsForSlice = function (slice, aspects) {
     return constantAspects;
 }
 
-TableExport.prototype._getColumnSlice = function (x) {
-
-}
-
 TableExport.prototype._writeTable = function (data) {
     var wb = new Excel.Workbook();
     var ws = wb.addWorksheet('Table');

--- a/iXBRLViewerPlugin/viewer/src/js/tableExport.js
+++ b/iXBRLViewerPlugin/viewer/src/js/tableExport.js
@@ -40,9 +40,9 @@ TableExport.prototype._getRawTable = function (table) {
     var table = this._table;
     var report = this._report;
     var rows = [];
-    table.find("tr").each(function () {
+    table.find("tr:visible").each(function () {
         var row = [];
-        $(this).find("td, th").each(function () {
+        $(this).find("td:visible, th:visible").each(function () {
             var colspan = $(this).attr("colspan");
             if (colspan) {
                 for (var i=0; i < colspan-1; i++) {


### PR DESCRIPTION
This fixes a bug where table export failed due to hidden cells.  These were previously included in the table data, leading to uneven row lengths, which the code did not cope with gracefully.

This also adds code to pad out any short rows, in order to be more tolerant of badly designed tables.