### PR TITLE
Fix period change NaN

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -73,7 +73,6 @@ Inspector.prototype.initialize = function (report) {
     });
 }
 
-
 Inspector.prototype.setViewer = function (viewer) {
     this._viewer = viewer;
     var inspector = this;
@@ -279,6 +278,24 @@ Inspector.prototype.viewerMouseLeave = function (id) {
     $('#inspector .search .results tr').removeClass('linked-highlight');
 }
 
+Inspector.prototype.describeChange = function (oldFact, newFact) {
+    if (newFact.value() > 0 == oldFact.value() > 0) {
+        var x = (newFact.value() - oldFact.value()) * 100 / oldFact.value();
+        var t;
+        if (x >= 0) {
+            t = formatNumber(x,1) + "% increase on ";
+        }
+        else {
+            t = formatNumber(-1 * x,1) + "% decrease on ";
+        }
+        return t;
+    }
+    else {
+        return "From " + oldFact.readableValue() + " in "; 
+    }
+
+}
+
 Inspector.prototype.getPeriodIncrease = function (fact) {
     var viewer = this._viewer;
     var inspector = this;
@@ -295,21 +312,7 @@ Inspector.prototype.getPeriodIncrease = function (fact) {
         var s = "";
         if (mostRecent) {
             var allMostRecent = this._report.getAlignedFacts(mostRecent);
-            if (fact.value() > 0 == mostRecent.value() > 0) {
-                var x = (fact.value() - mostRecent.value()) * 100 / mostRecent.value();
-                var t;
-                if (x > 0) {
-                    t = formatNumber(x,1) + "% increase on ";
-                }
-                else {
-                    t = formatNumber(-1 * x,1) + "% decrease on ";
-                }
-                s = $("<span>").text(t);
-            }
-            else {
-                s = $("<span>").text("From " + mostRecent.readableValue() + " in "); 
-            }
-
+            s = $("<span></span>").text(this.describeChange(mostRecent, fact));
             $("<span></span>").text(mostRecent.periodString())
             .addClass("year-on-year-fact-link")
             .appendTo(s)

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -279,7 +279,7 @@ Inspector.prototype.viewerMouseLeave = function (id) {
 }
 
 Inspector.prototype.describeChange = function (oldFact, newFact) {
-    if (newFact.value() > 0 == oldFact.value() > 0) {
+    if (newFact.value() > 0 == oldFact.value() > 0 && Math.abs(oldFact.value()) + Math.abs(newFact.value()) > 0) {
         var x = (newFact.value() - oldFact.value()) * 100 / oldFact.value();
         var t;
         if (x >= 0) {

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.test.js
@@ -1,0 +1,109 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Inspector } from "./inspector.js";
+import { Fact } from "./fact.js";
+import { iXBRLReport } from "./report.js";
+
+function TestInspector() {
+
+}
+
+TestInspector.prototype = Object.create(Inspector.prototype);
+
+var testReportData = {
+    "prefixes": {
+        "eg": "http://www.example.com",
+        "iso4217": "http://www.xbrl.org/2003/iso4217",
+        "e": "http://example.com/entity",
+    },
+    "concepts": {
+        "eg:Concept1": {
+            "labels": {
+                "std": {
+                    "en": "English label"
+                }
+            }
+        },
+        "eg:Concept2": {
+            "labels": {
+                "std": {
+                    "en": "English label for concept two"
+                }
+            }
+        },
+        "eg:Concept3": {
+            "labels": {
+                "std": {
+                    "en": "English label for concept three"
+                }
+            }
+        }
+    },
+    "facts": {
+    }
+};
+
+function testReport(facts, ixData) {
+    // Deep copy of standing data
+    var data = JSON.parse(JSON.stringify(testReportData));
+    data.facts = facts;
+    var report = new iXBRLReport(data);
+    report.setIXNodeMap(ixData);
+    return report;
+}
+
+function fromFact(value) {
+    var factData = {
+                "v": value,
+                "a": {
+                    "c": "eg:Concept1",
+                    "u": "iso4217:USD", 
+                    "p": "2017-01-01/2018-01-01",
+                }};
+    return new Fact(testReport({"f1": factData}, {"f1": {} }), "f1");
+}
+
+function toFact(value) {
+    var factData = {
+                "v": value,
+                "a": {
+                    "c": "eg:Concept1",
+                    "u": "iso4217:USD", 
+                    "p": "2018-01-01/2019-01-01",
+                }};
+    return new Fact(testReport({"f1": factData}, {"f1": {} }), "f1");
+}
+
+describe("Describe changes", () => {
+    var insp = new TestInspector();
+
+    test("Simple changes", () => {
+        expect(insp.describeChange(fromFact(1000), toFact(2000))).toBe("100.0% increase on ");
+        expect(insp.describeChange(fromFact(2000), toFact(1000))).toBe("50.0% decrease on ");
+        expect(insp.describeChange(fromFact(1000), toFact(1000))).toBe("0.0% increase on ");
+    });
+
+    test("Sign changes", () => {
+        expect(insp.describeChange(fromFact(1000), toFact(-1000))).toBe("From US $ 1000 in ");
+        expect(insp.describeChange(fromFact(-1000000), toFact(1000))).toBe("From US $ -1000000 in ");
+    });
+
+    test("From zero", () => {
+        expect(insp.describeChange(fromFact(0), toFact(1000))).toBe("From US $ 0 in ");
+        expect(insp.describeChange(fromFact(0), toFact(0))).toBe("From US $ 0 in ");
+    });
+
+
+});

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.test.js
@@ -100,10 +100,9 @@ describe("Describe changes", () => {
         expect(insp.describeChange(fromFact(-1000000), toFact(1000))).toBe("From US $ -1000000 in ");
     });
 
-    test("From zero", () => {
+    test("From/to zero", () => {
         expect(insp.describeChange(fromFact(0), toFact(1000))).toBe("From US $ 0 in ");
         expect(insp.describeChange(fromFact(0), toFact(0))).toBe("From US $ 0 in ");
+        expect(insp.describeChange(fromFact(1000), toFact(0))).toBe("From US $ 1000 in ");
     });
-
-
 });


### PR DESCRIPTION
This fixes a bug whereby a fact that is 0 in both current and prior period was reported as "NaN% decrease on ..."

It is now reported as "from 0 in ..."
