### PR TITLE
XMAS-5683 - Fix local build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ADD . /build/
 # with the tagged version number from GIT_TAG or `0.0.0` if GIT_TAG is not set
 ARG VERSION=${GIT_TAG:-0.0.0}
 RUN echo "Version = $VERSION"
-RUN sed -i s/@VERSION@/$VERSION/ setup.py package.json
+RUN sed -i s/0.0.0/$VERSION/ setup.py package.json
 
 # build ixbrlviewer.js
 RUN apt-get update && apt-get install -y curl && \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ixbrl-viewer",
-  "version": "@VERSION@",
+  "version": "0.0.0",
   "description": "iXBRL Viewer",
   "main": "iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js",
   "directories": {

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='ixbrl_viewer',
-    version='@VERSION@',
+    version='0.0.0',
     description='The Workiva iXBRL Viewer allows iXBRL reports to be viewed interactively in a web browser',
     long_description=open('README.md').read(),
     url='https://github.com/workiva/ixbrl-viewer',


### PR DESCRIPTION
#### Description
- Fixed local build by updating substitution strings in package.json, setup.py and Dockerfile
- Add .gitignore to help cleanup the repo

#### Testing
- Run workiva-build-cli locally and verify that the build correctly substitutes the `0.0.0` string during the build when GIT_TAG is not set and when it is set.

**review**:
@Workiva/xmas