### PR TITLE
Footnote support

### DIFF
--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -245,9 +245,8 @@ class IXBRLViewerBuilder:
 
             frels = self.footnoteRelationshipSet.fromModelObject(f)
             if frels:
-                factData["fn"] = []
                 for frel in frels:
-                    factData["fn"].append(frel.toModelObject.id)
+                    factData.setdefault("fn", []).append(frel.toModelObject.id)
 
             self.taxonomyData["facts"][f.id] = factData
             self.addConcept(f.concept)

--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -21,6 +21,7 @@ import math
 import re
 import pycountry
 from arelle.ValidateXbrlCalcs import inferredDecimals
+from arelle.ModelRelationshipSet import ModelRelationshipSet
 from .xhtmlserialize import XHTMLSerializer
 import os
 
@@ -75,6 +76,7 @@ class IXBRLViewerBuilder:
             "languages": {},
             "facts": {},
         }
+        self.footnoteRelationshipSet = ModelRelationshipSet(dts, "XBRL-footnotes")
 
     def lineWrap(self, s, n = 80):
         return "\n".join([s[i:i+n] for i in range(0, len(s), n)])
@@ -240,6 +242,12 @@ class IXBRLViewerBuilder:
                     self.dateFormat(f.context.startDatetime.isoformat()),
                     self.dateFormat(f.context.endDatetime.isoformat())
                 )
+
+            frels = self.footnoteRelationshipSet.fromModelObject(f)
+            if frels:
+                factData["fn"] = []
+                for frel in frels:
+                    factData["fn"].append(frel.toModelObject.id)
 
             self.taxonomyData["facts"][f.id] = factData
             self.addConcept(f.concept)

--- a/iXBRLViewerPlugin/viewer/src/html/footnote-details.html
+++ b/iXBRLViewerPlugin/viewer/src/html/footnote-details.html
@@ -1,0 +1,8 @@
+<div>
+  <table class="fact-properties">
+    <tr class="value">
+      <th>Footnote</th>
+      <td><span class="value"></span> <span class="show-all">[...]</span></td>
+    </tr>
+  </table>
+</div>

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -51,7 +51,7 @@ limitations under the License.
             <input id="ixbrl-search" type="text" />
           </div>
         </div>
-        <div class="fact-details no-fact-selected">
+        <div class="inspector-body">
           <div class="no-fact-overlay">
             <div class="no-fact-overlay-icon"></div>
             <p class="title">No Fact Selected</p>
@@ -60,35 +60,37 @@ limitations under the License.
             <div class="fact-inspector collapsible-body">
             </div>
           </div>
-          <div class="collapsible-section">
-             <h3 class="collapsible-header">References</h3>
-             <div class="collapsible-body references">
-             </div>
-          </div>
-          <div class="collapsible-section">
-                 <h3 class="collapsible-header">Calculations</h3>
-                 <div class="collapsible-body calculations">
-                   <div class="tree"></div>
-                 </div>
-          </div>
-          <div class="collapsible-section">
-                 <h3 class="collapsible-header">Footnotes</h3>
-                 <div class="collapsible-body footnotes">
-                 </div>
-          </div>
-        </div>
-        <div class="footnote-details">
-            <div class="inspector-section">
-                <h4 >Associated facts</h4>
-                <div class="footnote-facts fact-list"></div>
+          <div class="fact-details no-fact-selected">
+            <div class="collapsible-section">
+               <h3 class="collapsible-header">References</h3>
+               <div class="collapsible-body references">
+               </div>
             </div>
-        </div>
-        <div class="search-results">
-          <div class="scrollable results fact-list">
+            <div class="collapsible-section">
+                   <h3 class="collapsible-header">Calculations</h3>
+                   <div class="collapsible-body calculations">
+                     <div class="tree"></div>
+                   </div>
+            </div>
+            <div class="collapsible-section">
+                   <h3 class="collapsible-header">Footnotes</h3>
+                   <div class="collapsible-body footnotes">
+                   </div>
+            </div>
           </div>
-          <div class="search-overlay">
-              <div class="search-overlay-icon"></div>
-              <div class="search-overlay-text"><p class="title">Fact Search</p><p class="text">Please enter some search terms</p></div>
+          <div class="footnote-details">
+              <div class="inspector-section">
+                  <h4 >Associated facts</h4>
+                  <div class="footnote-facts fact-list"></div>
+              </div>
+          </div>
+          <div class="search-results">
+            <div class="scrollable results fact-list">
+            </div>
+            <div class="search-overlay">
+                <div class="search-overlay-icon"></div>
+                <div class="search-overlay-text"><p class="title">Fact Search</p><p class="text">Please enter some search terms</p></div>
+            </div>
           </div>
         </div>
       </div>

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -34,7 +34,8 @@ limitations under the License.
       <div class="inspector-content">
         <div id="ixbrl-controls-top">
           <div class="title">
-            <h1 >Fact Properties</h1>
+            <h1 class="fact-properties">Fact Properties</h1>
+            <h1 class="footnote-properties">Footnote Properties</h1>
             <div class="back">
             </div>
           </div>

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -78,11 +78,11 @@ limitations under the License.
           </div>
         </div>
         <div class="footnote-details">
-          <div class="collapsible-section">
-                 <h3 class="collapsible-header">Associated facts</h3>
-                 <div class="collapsible-body footnote-facts fact-list">
-                 </div>
-          </div>
+            <div class="inspector-section">
+                <h4 >Associated facts</h4>
+                <div class="footnote-facts fact-list">
+                </div>
+            </div>
         </div>
         <div class="search-results">
           <div class="scrollable results fact-list">

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -80,8 +80,7 @@ limitations under the License.
         <div class="footnote-details">
             <div class="inspector-section">
                 <h4 >Associated facts</h4>
-                <div class="footnote-facts fact-list">
-                </div>
+                <div class="footnote-facts fact-list"></div>
             </div>
         </div>
         <div class="search-results">

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -73,15 +73,16 @@ limitations under the License.
                    </div>
             </div>
             <div class="collapsible-section">
-                   <h3 class="collapsible-header">Footnotes</h3>
-                   <div class="collapsible-body footnotes">
-                   </div>
+               <h3 class="collapsible-header">Footnotes</h3>
+               <div class="collapsible-body footnotes">
+               </div>
             </div>
           </div>
           <div class="footnote-details">
-              <div class="inspector-section">
-                  <h4 >Associated facts</h4>
-                  <div class="footnote-facts fact-list"></div>
+              <div class="collapsible-section">
+                  <h3 class="collapsible-header">Associated facts</h3>
+                   <div class="collapsible-body footnote-facts fact-list">
+                   </div>
               </div>
           </div>
           <div class="search-results">

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -70,6 +70,11 @@ limitations under the License.
                    <div class="tree"></div>
                  </div>
           </div>
+          <div class="collapsible-section">
+                 <h3 class="collapsible-header">Footnotes</h3>
+                 <div class="collapsible-body footnotes">
+                 </div>
+          </div>
         </div>
         <div class="search-results">
           <div class="scrollable results">

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -77,8 +77,15 @@ limitations under the License.
                  </div>
           </div>
         </div>
+        <div class="footnote-details">
+          <div class="collapsible-section">
+                 <h3 class="collapsible-header">Associated facts</h3>
+                 <div class="collapsible-body footnote-facts fact-list">
+                 </div>
+          </div>
+        </div>
         <div class="search-results">
-          <div class="scrollable results">
+          <div class="scrollable results fact-list">
           </div>
           <div class="search-overlay">
               <div class="search-overlay-icon"></div>

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -22,7 +22,7 @@ import $ from 'jquery'
 
 export function Fact(report, factId) {
     this.f = report.data.facts[factId];
-    this._ixNode = report.getIXNodeForFactId(factId);
+    this._ixNode = report.getIXNodeForItemId(factId);
     this._report = report;
     this.id = factId;
 }
@@ -238,5 +238,5 @@ Fact.prototype.escaped = function () {
 }
 
 Fact.prototype.footnotes = function () {
-    return $.map(this.f.fn || [], (fn, i) => this._report.getFactById(fn));
+    return $.map(this.f.fn || [], (fn, i) => this._report.getItemById(fn));
 }

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -17,6 +17,7 @@ import { QName } from "./qname.js"
 import { Aspect } from "./aspect.js";
 import { Period } from './period.js';
 import { formatNumber } from "./util.js";
+import { Footnote } from "./footnote.js";
 import $ from 'jquery'
 
 export function Fact(report, factId) {
@@ -234,4 +235,8 @@ Fact.prototype.identifier = function () {
 
 Fact.prototype.escaped = function () {
     return this._ixNode.escaped;
+}
+
+Fact.prototype.footnotes = function () {
+    return $.map(this.f.fn || [], (fn, i) => new Footnote(fn));
 }

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -238,5 +238,5 @@ Fact.prototype.escaped = function () {
 }
 
 Fact.prototype.footnotes = function () {
-    return $.map(this.f.fn || [], (fn, i) => new Footnote(fn));
+    return $.map(this.f.fn || [], (fn, i) => this._report.getFactById(fn));
 }

--- a/iXBRLViewerPlugin/viewer/src/js/footnote.js
+++ b/iXBRLViewerPlugin/viewer/src/js/footnote.js
@@ -23,5 +23,5 @@ Footnote.prototype.addFact = function (f) {
 }
 
 Footnote.prototype.textContent = function () {
-    return this._ixNode.wrapperNode.text();
+    return this._ixNode.textContent();
 }

--- a/iXBRLViewerPlugin/viewer/src/js/footnote.js
+++ b/iXBRLViewerPlugin/viewer/src/js/footnote.js
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export function Footnote(report, footnoteId) {
+export function Footnote(report, footnoteId, title) {
     this.id = footnoteId;
     this.facts = [];
+    this.title = title;
     this._ixNode = report.getIXNodeForItemId(footnoteId);
 }
 

--- a/iXBRLViewerPlugin/viewer/src/js/footnote.js
+++ b/iXBRLViewerPlugin/viewer/src/js/footnote.js
@@ -1,0 +1,17 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export function Footnote(footnoteId) {
+    this.id = footnoteId;
+}

--- a/iXBRLViewerPlugin/viewer/src/js/footnote.js
+++ b/iXBRLViewerPlugin/viewer/src/js/footnote.js
@@ -14,4 +14,9 @@
 
 export function Footnote(footnoteId) {
     this.id = footnoteId;
+    this.facts = [];
+}
+
+Footnote.prototype.addFact = function (f) {
+    this.facts.push(f); 
 }

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -409,8 +409,8 @@ Inspector.prototype._selectionSummaryAccordian = function() {
         dissolveSingle: true,
     });
 
-    var fs = new FactSet(this._currentFactList);
-    $.each(this._currentFactList, (i, fact) => {
+    var fs = new FactSet(this._currentItemList);
+    $.each(this._currentItemList, (i, fact) => {
         var factHTML;
         var title = fs.minimallyUniqueLabel(fact);
         if (fact instanceof Fact) {
@@ -514,22 +514,22 @@ Inspector.prototype.update = function () {
 /*
  * Select a fact or footnote from the report.
  *
- * Takes an ID to select.  If the item is a fact, an optional list of
- * "alternate" facts may be specified, which will be presented in an accordian.
- * This is used when the user clicks on a nested fact in the viewer, so that
- * all facts corresponding to the area clicked are shown.
+ * Takes an ID of the item to select.  An optional list of "alternate"
+ * fact/footnotes may be specified, which will be presented in an accordian.
+ * This is used when the user clicks on a nested fact/footnote in the viewer,
+ * so that all items corresponding to the area clicked are shown.
  *
- * If factIdList is omitted, the currently selected fact list is reset to just
- * the primary fact.
+ * If itemIdList is omitted, the currently selected item list is reset to just
+ * the primary item.
  */
-Inspector.prototype.selectItem = function (id, factIdList) {
-    if (factIdList === undefined) {
-        this._currentFactList = [ this._report.getItemById(id) ];
+Inspector.prototype.selectItem = function (id, itemIdList) {
+    if (itemIdList === undefined) {
+        this._currentItemList = [ this._report.getItemById(id) ];
     }
     else {
-        this._currentFactList = [];
-        for (var i = 0; i < factIdList.length; i++) {
-            this._currentFactList.push(this._report.getItemById(factIdList[i]));
+        this._currentItemList = [];
+        for (var i = 0; i < itemIdList.length; i++) {
+            this._currentItemList.push(this._report.getItemById(itemIdList[i]));
         }
     }
     this.switchItem(id);
@@ -546,7 +546,7 @@ Inspector.prototype.selectItem = function (id, factIdList) {
 Inspector.prototype.switchItem = function (id) {
     this._currentItem = this._report.getItemById(id);
     this._viewer.showItemById(id);
-    this._viewer.highlightFact(id);
+    this._viewer.highlightItem(id);
     this.update();
 }
 

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -150,7 +150,7 @@ Inspector.prototype.factListRow = function(f) {
         .mouseleave(() => this._viewer.clearLinkedHighlightFact(f))
         .data('ivid', f.id);
     $('<div class="title"></div>')
-        .text(f.getLabel("std"))
+        .text(f.getLabel("std") || f.conceptName())
         .appendTo(row);
     $('<div class="dimension"></div>')
         .text(f.period().toString())

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -196,6 +196,10 @@ Inspector.prototype.updateCalculation = function (fact, elr) {
     $('.calculations .tree').empty().append(this._calculationHTML(fact, elr));
 }
 
+Inspector.prototype.updateFootnotes = function (fact) {
+    $('.footnotes').empty().append(this._footnotesHTML(fact));
+}
+
 Inspector.prototype._referencesHTML = function (fact) {
     var c = fact.concept();
     var a = new Accordian();
@@ -262,6 +266,19 @@ Inspector.prototype._calculationHTML = function (fact, elr) {
 
     });
     return a.contents();
+}
+
+Inspector.prototype._footnotesHTML = function (fact) {
+    var html = $("<ul></ul>");
+    $.each(fact.footnotes(), (n, fn) => {
+        $("<li></li>")
+            .appendTo(html)
+            .text(fn.id)
+            .mouseenter(() => { this._viewer.linkedHighlightFact(fn); })
+            .mouseleave(() => { this._viewer.clearLinkedHighlightFact(fn); })
+            .click(() => { this.selectFact(fn.id); });
+    });
+    return html;
 }
 
 Inspector.prototype.viewerMouseEnter = function (id) {
@@ -431,6 +448,7 @@ Inspector.prototype.update = function () {
 
         a.contents().appendTo('#inspector .fact-inspector');
         this.updateCalculation(cf);
+        this.updateFootnotes(cf);
         $('div.references').empty().append(this._referencesHTML(cf));
         $('#inspector .search-results .result').removeClass('selected');
         $('#inspector .search-results .result').filter(function () { return $(this).data('ivid') == cf.id }).addClass('selected');

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -22,6 +22,8 @@ import { Identifiers } from './identifiers.js';
 import { Menu } from './menu.js';
 import { Accordian } from './accordian.js';
 import { FactSet } from './factset.js';
+import { Fact } from './fact.js';
+import { Footnote } from './footnote.js';
 
 export function Inspector(iv) {
     /* Insert HTML and CSS styles into body */
@@ -387,7 +389,12 @@ Inspector.prototype._updateEntityIdentifier = function (fact, context) {
 Inspector.prototype.update = function () {
     var inspector = this;
     var cf = inspector._currentFact;
-    if (cf) {
+    if (!cf) {
+        $('#inspector').removeClass('footnote-mode');
+        $('#inspector .fact-details').addClass('no-fact-selected');
+    } 
+    else if (cf instanceof Fact) {
+        $('#inspector').removeClass('footnote-mode');
         $('#inspector .fact-details').removeClass('no-fact-selected');
         $('#inspector .fact-inspector').empty();
         var a = new Accordian({
@@ -469,8 +476,8 @@ Inspector.prototype.update = function () {
         this.getPeriodIncrease(cf);
 
     }
-    else {
-        $('#inspector .fact-details').addClass('no-fact-selected');
+    else if (cf instanceof Footnote) {
+        $('#inspector').addClass('footnote-mode');
     }
     this.updateURLFragment();
 }

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -283,9 +283,9 @@ Inspector.prototype._footnotesHTML = function (fact) {
             .addClass("block-list-item")
             .appendTo(html)
             .text(t)
-            .mouseenter(() => { this._viewer.linkedHighlightFact(fn); })
-            .mouseleave(() => { this._viewer.clearLinkedHighlightFact(fn); })
-            .click(() => { this.selectItem(fn.id); });
+            .mouseenter(() => this._viewer.linkedHighlightFact(fn))
+            .mouseleave(() => this._viewer.clearLinkedHighlightFact(fn))
+            .click(() => this.selectItem(fn.id));
     });
     return html;
 }
@@ -342,9 +342,9 @@ Inspector.prototype.getPeriodIncrease = function (fact) {
             $("<span></span>").text(mostRecent.periodString())
             .addClass("year-on-year-fact-link")
             .appendTo(s)
-            .click(function () { inspector.selectItem(mostRecent.id) })
-            .mouseenter(function () {  $.each(allMostRecent, function (i,f) { viewer.linkedHighlightFact(f);} ) })
-            .mouseleave(function () {  $.each(allMostRecent, function (i,f) { viewer.clearLinkedHighlightFact(f);} ) });
+            .click(() => inspector.selectItem(mostRecent.id))
+            .mouseenter(() => $.each(allMostRecent, (i,f) => viewer.linkedHighlightFact(f)))
+            .mouseleave(() => $.each(allMostRecent, (i,f) => viewer.clearLinkedHighlightFact(f)));
 
         }
         else {
@@ -413,9 +413,7 @@ Inspector.prototype.update = function () {
         $('#inspector .fact-details').removeClass('no-fact-selected');
         $('#inspector .fact-inspector').empty();
         var a = new Accordian({
-            onSelect: function (id) { 
-                inspector.switchItem(id);
-            }, 
+            onSelect: (id) => inspector.switchItem(id),
             alwaysOpen: true,
             dissolveSingle: true,
         });
@@ -485,8 +483,8 @@ Inspector.prototype.update = function () {
         }
         $('.duplicates .text').text((n + 1) + " of " + ndup);
         var viewer = this._viewer;
-        $('.duplicates .prev').off().click(function () { inspector.selectItem(duplicates[(n+ndup-1) % ndup].id)});
-        $('.duplicates .next').off().click(function () { inspector.selectItem(duplicates[(n+1) % ndup].id)});
+        $('.duplicates .prev').off().click(() => inspector.selectItem(duplicates[(n+ndup-1) % ndup].id));
+        $('.duplicates .next').off().click(() => inspector.selectItem(duplicates[(n+1) % ndup].id));
 
         this.getPeriodIncrease(cf);
 

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -521,9 +521,12 @@ Inspector.prototype.selectItem = function (id, factIdList) {
 }
 
 /*
- * Switches the currently selected fact.  Unlike selectItem, this does not
- * change the current list of "alternate" facts.  The fact "id" must be in the
- * current fact list.
+ * Switches the currently selected item.  Unlike selectItem, this does not
+ * change the current list of "alternate" items.  
+ *
+ * For facts, the "id" must be in the current alternate fact list.
+ *
+ * For footnotes, we currently only support a single footnote being selected.
  */
 Inspector.prototype.switchItem = function (id) {
     this._currentItem = this._report.getItemById(id);

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -491,7 +491,7 @@ Inspector.prototype.update = function () {
     }
     else if (cf instanceof Footnote) {
         $('#inspector').addClass('footnote-mode');
-        $('#inspector .footnote-details .footnote-facts').html(this._footnoteFactsHTML());
+        $('#inspector .footnote-details .footnote-facts').empty().append(this._footnoteFactsHTML());
     }
     this.updateURLFragment();
 }

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -395,8 +395,14 @@ Inspector.prototype._footnoteFactsHTML = function() {
     return html;
 }
 
+/* 
+ * Build an accordian containing a summary of all nested facts/footnotes
+ * corresponding to the current viewer selection.
+ */
 Inspector.prototype._selectionSummaryAccordian = function() {
     var cf = this._currentItem;
+
+    // dissolveSingle => title not shown if only one item in accordian
     var a = new Accordian({
         onSelect: (id) => this.switchItem(id),
         alwaysOpen: true,

--- a/iXBRLViewerPlugin/viewer/src/js/ixnode.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixnode.js
@@ -22,6 +22,9 @@
  * which will either be an inserted div or span wrapper, or the nearest
  * enclosing td or th.
  */
+
+var docOrderindex = 0;
+
 export function IXNode(id, wrapperNode, docIndex) {
     this.wrapperNode = wrapperNode;
     this.escaped = false;
@@ -29,6 +32,7 @@ export function IXNode(id, wrapperNode, docIndex) {
     this.docIndex = docIndex;
     this.footnote = false;
     this.id = id;
+    this.docOrderindex = docOrderindex++;
 }
 
 IXNode.prototype.continuationIds = function () {

--- a/iXBRLViewerPlugin/viewer/src/js/ixnode.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixnode.js
@@ -27,5 +27,6 @@ export function IXNode(wrapperNode, docIndex) {
     this.escaped = false;
     this.continuations = [];
     this.docIndex = docIndex;
+    this.footnote = false;
 }
 

--- a/iXBRLViewerPlugin/viewer/src/js/ixnode.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixnode.js
@@ -22,11 +22,21 @@
  * which will either be an inserted div or span wrapper, or the nearest
  * enclosing td or th.
  */
-export function IXNode(wrapperNode, docIndex) {
+export function IXNode(id, wrapperNode, docIndex) {
     this.wrapperNode = wrapperNode;
     this.escaped = false;
     this.continuations = [];
     this.docIndex = docIndex;
     this.footnote = false;
+    this.id = id;
 }
 
+IXNode.prototype.continuationIds = function () {
+    return this.continuations.map(n => n.id);
+}
+
+IXNode.prototype.textContent = function () {
+    return [this].concat(this.continuations)
+        .map(n => n.wrapperNode.text())
+        .join(" ");
+}

--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -36,7 +36,14 @@ iXBRLReport.prototype.setIXNodeMap = function(ixData) {
 }
 
 iXBRLReport.prototype._initialize = function () {
-    var fncount = 1;
+
+    // Build an array of footnotes IDs in document order so that we can assign
+    // numbers to foonotes
+    var fnorder = Object.keys(this._ixNodeMap).filter((id) => this._ixNodeMap[id].footnote);
+    fnorder.sort((a,b) => this._ixNodeMap[a].docOrderindex - this._ixNodeMap[b].docOrderindex);
+
+    // Create footnote objects for all footnotes, and associate facts with
+    // those footnotes to allow 2 way fact <-> footnote navigation.
     for (var id in this.data.facts) {
         var f = new Fact(this, id);
         this._items[id] = f;
@@ -44,7 +51,7 @@ iXBRLReport.prototype._initialize = function () {
         fns.forEach((fnid) => {
             var fn = this._items[fnid];
             if (fn === undefined) {
-                fn = new Footnote(this, fnid, "Footnote " + (fncount++).toString());
+                fn = new Footnote(this, fnid, "Footnote " + (fnorder.indexOf(fnid) + 1));
                 this._items[fnid] = fn;
             }
             // Associate fact with footnote

--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import { Fact } from "./fact.js"
+import { Footnote } from "./footnote.js"
 import { QName } from "./qname.js"
 import { Concept } from "./concept.js";
 import { ViewerOptions } from "./viewerOptions.js";
@@ -23,6 +24,23 @@ export function iXBRLReport (data) {
     this._facts = {};
     this._ixNodeMap = {};
     this._viewerOptions = new ViewerOptions();
+    this._initialize();
+}
+
+iXBRLReport.prototype._initialize = function () {
+    for (var id in this.data.facts) {
+        var f = new Fact(this, id);
+        this._facts[id] = f;
+        var fns = this.data.facts[id].fn || [];
+        fns.forEach((fnid) => {
+            var fn = this._facts[fnid];
+            if (fn === undefined) {
+                fn = new Footnote(fnid);
+                this._facts[fnid] = fn;
+            }
+            fn.addFact(f);
+        });
+    }
 }
 
 iXBRLReport.prototype.getLabel = function(c, rolePrefix, showPrefix, viewerOptions) {
@@ -73,14 +91,6 @@ iXBRLReport.prototype.languageNames = function() {
 }
 
 iXBRLReport.prototype.getFactById = function(id) {
-    if (!this._facts.hasOwnProperty(id)) {
-        if (this.data.facts.hasOwnProperty(id)) {
-            this._facts[id] = new Fact(this, id);
-        }
-        else {
-            this._facts[id] = null;
-        }
-    }
     return this._facts[id];
 }
 

--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -21,23 +21,32 @@ import $ from 'jquery'
 
 export function iXBRLReport (data) {
     this.data = data;
-    this._facts = {};
+    // A map of IDs to Fact and Footnote objects
+    this._items = {};
     this._ixNodeMap = {};
     this._viewerOptions = new ViewerOptions();
+}
+
+/*
+ * Set additional information about facts obtained from parsing the iXBRL.
+ */
+iXBRLReport.prototype.setIXNodeMap = function(ixData) {
+    this._ixNodeMap = ixData;
     this._initialize();
 }
 
 iXBRLReport.prototype._initialize = function () {
     for (var id in this.data.facts) {
         var f = new Fact(this, id);
-        this._facts[id] = f;
+        this._items[id] = f;
         var fns = this.data.facts[id].fn || [];
         fns.forEach((fnid) => {
-            var fn = this._facts[fnid];
+            var fn = this._items[fnid];
             if (fn === undefined) {
-                fn = new Footnote(fnid);
-                this._facts[fnid] = fn;
+                fn = new Footnote(this, fnid);
+                this._items[fnid] = fn;
             }
+            // Associate fact with footnote
             fn.addFact(f);
         });
     }
@@ -90,28 +99,22 @@ iXBRLReport.prototype.languageNames = function() {
     return this.data.languages;
 }
 
-iXBRLReport.prototype.getFactById = function(id) {
-    return this._facts[id];
+iXBRLReport.prototype.getItemById = function(id) {
+    return this._items[id];
 }
 
-/*
- * Set additional information about facts obtained from parsing the iXBRL.
- */
-iXBRLReport.prototype.setIXNodeMap = function(ixData) {
-    this._ixNodeMap = ixData;
-}
 
-iXBRLReport.prototype.getIXNodeForFactId = function(factId) {
-    return this._ixNodeMap[factId] || {};
+iXBRLReport.prototype.getIXNodeForItemId = function(id) {
+    return this._ixNodeMap[id] || {};
 }
 
 iXBRLReport.prototype.facts = function() {
-    var allFacts = [];
+    var allItems = [];
     var report = this;
     $.each(this.data.facts, function (id, f) {
-        allFacts.push(report.getFactById(id));
+        allItems.push(report.getItemById(id));
     });
-    return allFacts;
+    return allItems;
 }
 
 iXBRLReport.prototype.prefixMap = function() {

--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -36,6 +36,7 @@ iXBRLReport.prototype.setIXNodeMap = function(ixData) {
 }
 
 iXBRLReport.prototype._initialize = function () {
+    var fncount = 1;
     for (var id in this.data.facts) {
         var f = new Fact(this, id);
         this._items[id] = f;
@@ -43,7 +44,7 @@ iXBRLReport.prototype._initialize = function () {
         fns.forEach((fnid) => {
             var fn = this._items[fnid];
             if (fn === undefined) {
-                fn = new Footnote(this, fnid);
+                fn = new Footnote(this, fnid, "Footnote " + (fncount++).toString());
                 this._items[fnid] = fn;
             }
             // Associate fact with footnote

--- a/iXBRLViewerPlugin/viewer/src/js/report.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.test.js
@@ -58,6 +58,7 @@ var testReportData = {
 
 describe("Language options", () => {
     var testReport = new iXBRLReport(testReportData);
+    testReport._initialize();
     test("Available languages", () => {
         var al = testReport.availableLanguages();
         expect(al).toHaveLength(3);
@@ -74,15 +75,17 @@ describe("Language options", () => {
 
 describe("Fetching facts", () => {
     var testReport = new iXBRLReport(testReportData);
+    testReport._initialize();
 
     test("Successful", () => {
-        var f = testReport.getFactById("f1");
+        var f = testReport.getItemById("f1");
+        testReport._initialize();
         expect(f).not.toBeNull();
         expect(f.decimals()).toEqual(-3);
     });
 
     test("Non-existent fact", () => {
-        var f = testReport.getFactById("fact-does-not-exist");
-        expect(f).toBeNull();
+        var f = testReport.getItemById("fact-does-not-exist");
+        expect(f).toBeUndefined();
     });
 });

--- a/iXBRLViewerPlugin/viewer/src/js/search.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.js
@@ -62,11 +62,11 @@ ReportSearch.prototype.search = function(s) {
         return [];
     }
 
-    $.each(rr, function (i,r) {
+    rr.forEach((i,r) => 
         results.push({
             "fact": searchIndex._report.getItemById(r.ref),
             "score": r.score
-        });
-    })
+        })
+    );
     return results;
 }

--- a/iXBRLViewerPlugin/viewer/src/js/search.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.js
@@ -64,7 +64,7 @@ ReportSearch.prototype.search = function(s) {
 
     $.each(rr, function (i,r) {
         results.push({
-            "fact": searchIndex._report.getFactById(r.ref),
+            "fact": searchIndex._report.getItemById(r.ref),
             "score": r.score
         });
     })

--- a/iXBRLViewerPlugin/viewer/src/js/util.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.js
@@ -91,6 +91,19 @@ export function wrapLabel(str, maxwidth){
     return sections;
 }
 
+/*
+ * Truncate the label to the specified length, breaking on a word boundary, and
+ * adding an ellipsis if the label is actually shortened.
+ */
+export function truncateLabel(label, length) {
+    var vv = wrapLabel(label, length);
+    var t = vv[0];
+    if (vv.length > 1) {
+        t += ' \u2026';
+    }
+    return t;
+}
+
 /* 
  * The JSON format supports datetimes being abbreviated to just xsd:dates.
  * moment.js doesn't support timezoned dates, so fix them to midnight before

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -137,7 +137,7 @@ Viewer.prototype._preProcessiXBRL = function(n, docIndex, inHidden) {
         node = $(n).parent();
     }
     var id = n.getAttribute("id");
-    node.addClass("ixbrl-element").data('ivid',id);
+    node.addClass("ixbrl-element").data('ivid', id);
     var ixn = new IXNode(node, docIndex);
     this._ixNodeMap[id] = ixn;
     if (n.getAttribute("continuedAt")) {
@@ -206,7 +206,7 @@ Viewer.prototype._selectAdjacentTag = function (offset) {
         next = elements.last();
     }
     
-    this.showDocumentForFactId(next.data('ivid'));
+    this.showDocumentForItemId(next.data('ivid'));
     this.showElement(next);
     this.selectElement(next);
 }
@@ -313,14 +313,14 @@ Viewer.prototype.clearRelatedHighlighting = function (f) {
 }
 
 Viewer.prototype.elementForFact = function (fact) {
-    return this.elementForFactId(fact.id);
+    return this.elementForItemId(fact.id);
 }
 
-Viewer.prototype.elementForFactId = function (factId) {
+Viewer.prototype.elementForItemId = function (factId) {
     return this._ixNodeMap[factId].wrapperNode;
 }
 
-Viewer.prototype.elementsForFactIds = function (ids) {
+Viewer.prototype.elementsForItemIds = function (ids) {
     var viewer = this;
     return $($.map(ids, function (id, n) {
         return viewer._ixNodeMap[id].wrapperNode.get();
@@ -328,17 +328,17 @@ Viewer.prototype.elementsForFactIds = function (ids) {
 }
 
 Viewer.prototype.elementsForFacts = function (facts) {
-    return this.elementsForFactIds($.map(facts, function (f) { return f.id }));
+    return this.elementsForItemIds($.map(facts, function (f) { return f.id }));
 }
 
 Viewer.prototype.highlightFact = function(factId) {
     var continuations = this._ixNodeMap[factId].continuations;
-    this.highlightElements(this.elementsForFactIds([factId].concat(continuations)));
+    this.highlightElements(this.elementsForItemIds([factId].concat(continuations)));
 }
 
-Viewer.prototype.showFactById = function (factId) {
-    let elt = this.elementForFactId(factId);
-    this.showDocumentForFactId(factId);
+Viewer.prototype.showItemById = function (id) {
+    let elt = this.elementForItemId(id);
+    this.showDocumentForItemId(id);
     if (elt) {
         this.showElement(elt);
     }
@@ -355,7 +355,7 @@ Viewer.prototype.highlightAllTags = function (on, namespaceGroups) {
         $(".ixbrl-element:not(.ixbrl-continuation):not(.ixbrl-element-footnote)", this._contents).each(function () {
             var factId = $(this).data('ivid');
             var continuations = viewer._ixNodeMap[factId].continuations;
-            var elements = viewer.elementsForFactIds([factId].concat(continuations));
+            var elements = viewer.elementsForItemIds([factId].concat(continuations));
             elements.addClass("ixbrl-highlight");
             var i = groups[report.getFactById(factId).conceptQName().prefix];
             if (i !== undefined) {
@@ -413,7 +413,7 @@ Viewer.prototype._setTitle = function (docIndex) {
     $('#top-bar .document-title').text($('head title', this._iframes.eq(docIndex).contents()).text());
 }
 
-Viewer.prototype.showDocumentForFactId = function(factId) {
+Viewer.prototype.showDocumentForItemId = function(factId) {
     this.selectDocument(this._ixNodeMap[factId].docIndex);
 }
 

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -331,7 +331,7 @@ Viewer.prototype.elementsForFacts = function (facts) {
     return this.elementsForItemIds($.map(facts, function (f) { return f.id }));
 }
 
-Viewer.prototype.highlightFact = function(factId) {
+Viewer.prototype.highlightItem = function(factId) {
     var continuations = this._ixNodeMap[factId].continuationIds();
     this.highlightElements(this.elementsForItemIds([factId].concat(continuations)));
 }

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -352,7 +352,7 @@ Viewer.prototype.highlightAllTags = function (on, namespaceGroups) {
     var report = this._report;
     var viewer = this;
     if (on) {
-        $(".ixbrl-element:not(.ixbrl-continuation)", this._contents).each(function () {
+        $(".ixbrl-element:not(.ixbrl-continuation):not(.ixbrl-element-footnote)", this._contents).each(function () {
             var factId = $(this).data('ivid');
             var continuations = viewer._ixNodeMap[factId].continuations;
             var elements = viewer.elementsForFactIds([factId].concat(continuations));
@@ -362,6 +362,7 @@ Viewer.prototype.highlightAllTags = function (on, namespaceGroups) {
                 elements.addClass("ixbrl-highlight-" + i);
             }
         });
+        $(".ixbrl-element-footnote", this._contents).addClass("ixbrl-highlight");
     }
     else {
         $(".ixbrl-element", this._contents).removeClass (function (i, className) {

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -261,7 +261,7 @@ Viewer.prototype.highlightElements = function (ee) {
     ee.addClass("ixbrl-selected");
 }
 
-Viewer.prototype._factIdForElement = function (e) {
+Viewer.prototype._ixIdForElement = function (e) {
     var id = e.data('ivid');
     if (e.hasClass("ixbrl-continuation")) {
         id = this._continuedAtMap[id].continuationOf;
@@ -276,7 +276,7 @@ Viewer.prototype._factIdForElement = function (e) {
  * falls within.  If omitted, it's treated as a click on a non-nested fact.
  */
 Viewer.prototype.selectElement = function (e, factIdList) {
-    var factId = this._factIdForElement(e);
+    var factId = this._ixIdForElement(e);
     this.onSelect.fire(factId, factIdList);
 }
 
@@ -284,7 +284,7 @@ Viewer.prototype.selectElementByClick = function (e) {
     var eltSet = [];
     var viewer = this;
     e.parents(".ixbrl-element").addBack().each(function () { 
-        eltSet.unshift(viewer._factIdForElement($(this))); 
+        eltSet.unshift(viewer._ixIdForElement($(this))); 
     });
     this.selectElement(e, eltSet);
 }

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -112,7 +112,10 @@ Viewer.prototype._addDocumentSetTabs = function() {
 Viewer.prototype._preProcessiXBRL = function(n, docIndex, inHidden) {
   var elt;
   var name = localName(n.nodeName).toUpperCase();
-  if(n.nodeType == 1 && (name == 'NONNUMERIC' || name == 'NONFRACTION' || name == 'CONTINUATION')) {
+  var isFootnote = (name == 'FOOTNOTE');
+  if(n.nodeType == 1 && (name == 'NONNUMERIC' || name == 'NONFRACTION' || name == 'CONTINUATION' || isFootnote)) {
+    /* Is the element the only significant content within a <td> or <th> ? If
+     * so, use that as the wrapper element. */
     var node = $(n).closest("td,th").eq(0);
     if (node.length == 1) {
         var regex = "^[^0-9A-Za-z]*" + escapeRegex($(n).text()) + "[^0-9A-Za-z]*$";
@@ -120,6 +123,7 @@ Viewer.prototype._preProcessiXBRL = function(n, docIndex, inHidden) {
             node = null;
         } 
     }
+    /* Otherwise, insert a <span> as wrapper */
     if (node == null || node.length == 0) {
         var wrapper = "<span>";
         var nn = n.getElementsByTagName("*");
@@ -153,6 +157,10 @@ Viewer.prototype._preProcessiXBRL = function(n, docIndex, inHidden) {
       if (n.hasAttribute('escape') && n.getAttribute('escape').match(/^(true|1)$/)) {
           ixn.escaped = true;
       }
+    }
+    if (isFootnote) {
+      $(node).addClass("ixbrl-element-footnote");
+      ixn.footnote = true;
     }
     if (elt) {
       var concept = n.getAttribute("name");

--- a/iXBRLViewerPlugin/viewer/src/less/block-list.less
+++ b/iXBRLViewerPlugin/viewer/src/less/block-list.less
@@ -12,16 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export function Footnote(report, footnoteId) {
-    this.id = footnoteId;
-    this.facts = [];
-    this._ixNode = report.getIXNodeForItemId(footnoteId);
-}
+.block-list-item {
+  margin: 0.9rem 0;
+  padding: 0.3rem 0.9rem;
+  background-color: @button-background;
+  cursor: pointer;
+  position: relative;
 
-Footnote.prototype.addFact = function (f) {
-    this.facts.push(f); 
-}
+  & > * {
+    margin: 0.6rem 0;
+  }
 
-Footnote.prototype.textContent = function () {
-    return this._ixNode.wrapperNode.text();
+  &:hover {
+    background-color: @background-selected;
+  }
+
+  &.selected {
+    background-color: @background-selected;
+  }
+
+  &.linked-highlight {
+    .linked-highlight-cell();
+  }
 }

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -520,7 +520,7 @@
         }
       }
 
-      .fact-details {
+      .inspector-body {
         .no-fact-overlay {
           display: none;
         }
@@ -530,7 +530,7 @@
         display: none;
       }
 
-      .fact-details.no-fact-selected {
+      .inspector-body.no-fact-selected {
         position: absolute;
         top: 13.8rem;
         bottom: 0;

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -435,6 +435,11 @@
       }
     }
 
+    .inspector-section {
+      padding-left: 0.9rem;
+      padding-right: 0.9rem;
+    }
+
     .collapsible-section {
       .collapsible-body {
         padding-left: 0.9rem;

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -25,6 +25,7 @@
 @import "loader.less";
 @import "tabs.less";
 @import (reference) "text-mixins.less";
+@import "block-list.less";
 
 @top-bar-height: 35px;
 @powered-by-footer-height: 30px;
@@ -486,46 +487,6 @@
           overflow-y: scroll;
         }
 
-        .result {
-          margin: 0.9rem 0;
-          padding: 0.3rem 0.9rem;
-          background-color: @button-background;
-          cursor: pointer;
-          position: relative;
-
-          & > * {
-            margin: 0.6rem 0;
-          }
-
-          .title {
-            color: @text-title;
-          }
-
-          .dimension {
-            color: @text-light;
-            margin: 0.6rem 0;
-          }
-
-          &:hover {
-            background-color: @background-selected;
-          }
-
-          &.selected {
-            background-color: @background-selected;
-
-            .title {
-              font-weight: bold;
-            }
-
-            .dimension {
-              color: @text;
-            }
-          }
-
-          &.linked-highlight {
-            .linked-highlight-cell();
-          }
-        }
 
         .search-overlay {
           transform: translate(-50%, -50%);
@@ -559,6 +520,10 @@
         .no-fact-overlay {
           display: none;
         }
+      }
+
+      .footnote-details {
+        display: none;
       }
 
       .fact-details.no-fact-selected {
@@ -643,6 +608,32 @@
           outline-offset: 1px;
         }
       }
+
+      .fact-list {
+        .fact-list-item {
+          .block-list-item();
+
+          .title {
+            color: @text-title;
+          }
+
+          .dimension {
+            color: @text-light;
+            margin: 0.6rem 0;
+          }
+
+
+          &.selected {
+            .title {
+              font-weight: bold;
+            }
+
+            .dimension {
+              color: @text;
+            }
+          }
+        }
+      }
     }
 
     &.search-mode .inspector-content {
@@ -664,7 +655,8 @@
         }
       }
 
-      .fact-details {
+      .fact-details,
+      .footnote-details {
         display: none;
       }
 
@@ -681,6 +673,9 @@
         h1.footnote-properties {
             display: block;
         }
+      }
+      .footnote-details {
+        display: block;
       }
       .fact-details,
       .next-prev {

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -197,6 +197,10 @@
           padding: 0;
           font-size: 1.8rem;
           line-height: 3.2rem;
+
+          &.footnote-properties {
+            display: none;
+          }
         }
 
         .back {
@@ -666,6 +670,21 @@
 
       .search-results {
         display: block;
+      }
+    }
+
+    &.footnote-mode:not(.search-mode) .inspector-content {
+      #ixbrl-controls-top .title {
+        h1.fact-properties {
+            display: none;
+        }
+        h1.footnote-properties {
+            display: block;
+        }
+      }
+      .fact-details,
+      .next-prev {
+        display: none;
       }
     }
 

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -492,7 +492,6 @@
           overflow-y: scroll;
         }
 
-
         .search-overlay {
           transform: translate(-50%, -50%);
           position: absolute;
@@ -627,7 +626,6 @@
             margin: 0.6rem 0;
           }
 
-
           &.selected {
             .title {
               font-weight: bold;
@@ -673,15 +671,18 @@
     &.footnote-mode:not(.search-mode) .inspector-content {
       #ixbrl-controls-top .title {
         h1.fact-properties {
-            display: none;
+          display: none;
         }
+
         h1.footnote-properties {
-            display: block;
+          display: block;
         }
       }
+
       .footnote-details {
         display: block;
       }
+
       .fact-details,
       .next-prev {
         display: none;

--- a/samples/src/continuation/continuation.html
+++ b/samples/src/continuation/continuation.html
@@ -31,7 +31,8 @@
               <xbrli:endDate>2017-12-31</xbrli:endDate>
             </xbrli:period>
           </xbrli:context>
-          <ix:relationship fromRefs="f1" toRefs="fn1" />
+          <ix:relationship fromRefs="f1" toRefs="fn1 fn2" />
+          <ix:relationship fromRefs="f4" toRefs="fn2" />
         </ix:resources>
       </ix:header>
     </div>
@@ -68,5 +69,16 @@
     <p><ix:footnote id="fn1">
         This is the content of footnote 1.
     </ix:footnote></p>
+    <ix:footnote id="fn2">
+        <p>
+            This is the content of footnote 2.  It's much longer that footnote 1 and has multiple paragraphs.
+        </p>
+        <p>
+            It also has <b>bold</b> and <i>italic</i> text.
+        </p>
+        <p>
+            It's also associated with multiple facts.
+        </p>
+    </ix:footnote>
   </body>
 </html>

--- a/samples/src/continuation/continuation.html
+++ b/samples/src/continuation/continuation.html
@@ -32,7 +32,7 @@
             </xbrli:period>
           </xbrli:context>
           <ix:relationship fromRefs="f1" toRefs="fn1 fn2" />
-          <ix:relationship fromRefs="f4" toRefs="fn2" />
+          <ix:relationship fromRefs="f4" toRefs="fn2 fn4" />
           <ix:relationship fromRefs="f11" toRefs="fn3" />
         </ix:resources>
       </ix:header>
@@ -75,7 +75,10 @@
             This is the content of footnote 2.  It's much longer that footnote 1 and has multiple paragraphs.
         </p>
         <p>
-            It also has <b>bold</b> and <i>italic</i> text.
+            <ix:footnote id="fn4">
+            It also has <b>bold</b> and <i>italic</i> text, and contains a nested footnote.
+              <ix:nonNumeric id="f14" name="ifrs:ConcentrationsOfRisk" contextRef="c1" >And a nested fact.</ix:nonNumeric>
+            </ix:footnote>
         </p>
         <p>
             It's also associated with multiple facts.

--- a/samples/src/continuation/continuation.html
+++ b/samples/src/continuation/continuation.html
@@ -31,6 +31,7 @@
               <xbrli:endDate>2017-12-31</xbrli:endDate>
             </xbrli:period>
           </xbrli:context>
+          <ix:relationship fromRefs="f1" toRefs="fn1" />
         </ix:resources>
       </ix:header>
     </div>
@@ -64,5 +65,8 @@
       </ix:nonNumeric>
       <ix:continuation id="f12"> ix:continuation </ix:continuation>
     </p>
+    <p><ix:footnote id="fn1">
+        This is the content of footnote 1.
+    </ix:footnote></p>
   </body>
 </html>

--- a/samples/src/continuation/continuation.html
+++ b/samples/src/continuation/continuation.html
@@ -33,6 +33,7 @@
           </xbrli:context>
           <ix:relationship fromRefs="f1" toRefs="fn1 fn2" />
           <ix:relationship fromRefs="f4" toRefs="fn2" />
+          <ix:relationship fromRefs="f11" toRefs="fn3" />
         </ix:resources>
       </ix:header>
     </div>
@@ -80,5 +81,16 @@
             It's also associated with multiple facts.
         </p>
     </ix:footnote>
+        <p>
+            <ix:footnote id="fn3" continuedAt="fn3-cont1">
+            This is 
+            </ix:footnote>
+            <ix:continuation id="fn3-cont1" continuedAt="fn3-cont2">
+            footnote 3
+            </ix:continuation>
+            <ix:continuation id="fn3-cont2">
+            which is split with continuations
+            </ix:continuation>
+        </p>
   </body>
 </html>

--- a/tests/unit_tests/iXBRLViewerPlugin/mock_arelle.py
+++ b/tests/unit_tests/iXBRLViewerPlugin/mock_arelle.py
@@ -8,6 +8,11 @@ def qname_effect(prefix, namespaceURI, localName):
         localName=localName
     )
 
+def mrs_effect(dts, reltype):
+    return Mock(
+        fromModelObject = lambda source: []  
+    )
+
 def inferredDecimals_effect(fact):
     return float("INF")
 
@@ -19,6 +24,7 @@ def mock_arelle():
         sys.modules['arelle'] = Mock()
         sys.modules['arelle.XbrlConst'] = Mock()
         sys.modules['arelle.ModelDocument'] = Mock()
+        sys.modules['arelle.ModelRelationshipSet'] = Mock(ModelRelationshipSet = mrs_effect)
         sys.modules['arelle.ModelValue'] = Mock(
             QName=qname_effect
         )


### PR DESCRIPTION
Add support for viewing footnotes in an iXBRL document.

When selecting a fact which has one or more footnotes, the footnotes will be listed in the "footnotes" section of the inspector.  Clicking on a footnote focus on the footnote, and the inspector will show a list of facts with which that footnote is associated.

Footnotes can also be selected directly by clicking in iXBRL view, and will be highlighted by "highlight all tags".