### PR TITLE
Deselect fact on click away

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -113,6 +113,9 @@ Inspector.prototype.updateURLFragment = function () {
     if (this._currentItem) {
         location.hash = "#f-" + this._currentItem.id;
     }
+    else {
+        location.hash = "";
+    }
 }
 
 Inspector.prototype.buildDisplayOptionsMenu = function () {

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -544,9 +544,16 @@ Inspector.prototype.selectItem = function (id, itemIdList) {
  * For footnotes, we currently only support a single footnote being selected.
  */
 Inspector.prototype.switchItem = function (id) {
-    this._currentItem = this._report.getItemById(id);
-    this._viewer.showItemById(id);
-    this._viewer.highlightItem(id);
+    if (id !== null) {
+        this._currentItem = this._report.getItemById(id);
+        this._viewer.showItemById(id);
+        this._viewer.highlightItem(id);
+    }
+    else {
+        this._currentItem = null;
+        this._viewer.clearHighlighting();
+    }
+    this.update();
     this.update();
 }
 

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -472,10 +472,10 @@ Inspector.prototype.update = function () {
     var cf = inspector._currentItem;
     if (!cf) {
         $('#inspector').removeClass('footnote-mode');
-        $('#inspector .fact-details').addClass('no-fact-selected');
+        $('#inspector .inspector-body').addClass('no-fact-selected');
     } 
     else { 
-        $('#inspector .fact-details').removeClass('no-fact-selected');
+        $('#inspector .inspector-body').removeClass('no-fact-selected');
 
         $('#inspector .fact-inspector')
             .empty()

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -220,6 +220,10 @@ Viewer.prototype._bindHandlers = function () {
         })
         .mouseenter(function (e) { viewer._mouseEnter($(this)) })
         .mouseleave(function (e) { viewer._mouseLeave($(this)) });
+    $("body", this._contents)
+        .click(function (e) {
+            viewer.selectElement(null);
+        });
     
     $('#iframe-container .zoom-in').click(function () { viewer.zoomIn() });
     $('#iframe-container .zoom-out').click(function () { viewer.zoomOut() });
@@ -250,6 +254,10 @@ Viewer.prototype.showAndSelectElement = function(e) {
     this.scrollIfNotVisible(e);
 }
 
+Viewer.prototype.clearHighlighting = function () {
+    $("body", this._iframes.contents()).find(".ixbrl-element").removeClass("ixbrl-selected").removeClass("ixbrl-related").removeClass("ixbrl-linked-highlight");
+}
+
 /*
  * Update the currently highlighted fact, but do not trigger a change in the
  * inspector.
@@ -257,7 +265,7 @@ Viewer.prototype.showAndSelectElement = function(e) {
  * Used to switch facts when the selection corresponds to multiple facts.
  */
 Viewer.prototype.highlightElements = function (ee) {
-    $("body", this._iframes.contents()).find(".ixbrl-element").removeClass("ixbrl-selected").removeClass("ixbrl-related").removeClass("ixbrl-linked-highlight");
+    this.clearHighlighting();
     ee.addClass("ixbrl-selected");
 }
 
@@ -276,8 +284,13 @@ Viewer.prototype._ixIdForElement = function (e) {
  * falls within.  If omitted, it's treated as a click on a non-nested fact.
  */
 Viewer.prototype.selectElement = function (e, factIdList) {
-    var factId = this._ixIdForElement(e);
-    this.onSelect.fire(factId, factIdList);
+    if (e !== null) {
+        var factId = this._ixIdForElement(e);
+        this.onSelect.fire(factId, factIdList);
+    }
+    else {
+        this.onSelect.fire(null);
+    }
 }
 
 Viewer.prototype.selectElementByClick = function (e) {
@@ -337,10 +350,12 @@ Viewer.prototype.highlightItem = function(factId) {
 }
 
 Viewer.prototype.showItemById = function (id) {
-    let elt = this.elementForItemId(id);
-    this.showDocumentForItemId(id);
-    if (elt) {
-        this.showElement(elt);
+    if (id !== null) {
+        let elt = this.elementForItemId(id);
+        this.showDocumentForItemId(id);
+        if (elt) {
+            this.showElement(elt);
+        }
     }
 }
 


### PR DESCRIPTION
When you first load the viewer, there is no fact selected.  Once you have clicked on a fact, there is no way to get back to the initial state of having no fact selected.

This PR makes it so that clicking on any untagged area in the viewer window will remove your current fact selection.