### PR TITLE
Support nil-valued facts

### DIFF
--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -204,7 +204,7 @@ class IXBRLViewerBuilder:
             }
 
             factData = {
-                "v": f.value,
+                "v": f.value if not f.isNil else None,
                 "a": aspects,
             }
             if f.format is not None:

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -73,8 +73,11 @@ Fact.prototype.readableValue = function() {
     if (this.isNumeric()) {
         var d = this.decimals();
         var formattedNumber;
-        if (d === undefined) {
-            formattedNumber= v;
+        if (this.isNil()) {
+            formattedNumber = "nil";
+        }
+        else if (d === undefined) {
+            formattedNumber = v;
         }
         else {
             if (d < 0) {
@@ -187,8 +190,12 @@ Fact.prototype.duplicates = function () {
     return this._report.getAlignedFacts(this);
 }
 
+Fact.prototype.isNil = function() {
+    return this.f.v === null
+}
+
 Fact.prototype.readableAccuracy = function () {
-    if (!this.isNumeric()) {
+    if (!this.isNumeric() || this.isNil()) {
         return "n/a";
     }
     var d = this.decimals();


### PR DESCRIPTION
This PR improves the display of nil-valued facts in the fact inspector.
The value is now shown as "nil", and the accuracy as "n/a", rather than a blank value and "infinite" accuracy.

Fixes #77 