### PR TITLE
Support for -sec-ix-hidden

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -184,7 +184,7 @@ Viewer.prototype._preProcessiXBRL = function(n, docIndex, inHidden) {
   }
   else if(n.nodeType == 1) {
     if (n.hasAttribute('style')) {
-      const re = /(?:^|\s|;)-sec-ix-hidden:\s*([^\s;]+)/;
+      const re = /(?:^|\s|;)-(?:sec|esef)-ix-hidden:\s*([^\s;]+)/;
       var m = n.getAttribute('style').match(re);
       if (m) {
         var id = m[1];

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -174,6 +174,19 @@ Viewer.prototype._preProcessiXBRL = function(n, docIndex, inHidden) {
   else if(n.nodeType == 1 && localName(n.nodeName) == 'HIDDEN') {
     inHidden = true;
   }
+  else if(n.nodeType == 1) {
+    if (n.hasAttribute('style')) {
+      const re = /(?:^|\s|;)-sec-ix-hidden:\s*([^\s;]+)/;
+      var m = n.getAttribute('style').match(re);
+      if (m) {
+        console.log("IX Hidden: " + m[1]);
+        node = $(n);
+        node.addClass("ixbrl-element").data('ivid', m[1]);
+        var ixn = new IXNode(id, node, docIndex);
+        this._ixNodeMap[id] = ixn;
+      }
+    }
+  }
   for (var i=0; i < n.childNodes.length; i++) {
     this._preProcessiXBRL(n.childNodes[i], docIndex, inHidden);
   }


### PR DESCRIPTION
This PR adds support for the `-sec-ix-hidden` custom style property, allowing arbitrary HTML elements to be linked to hidden facts.

Clicking on such an element in the viewer will show the details of the hidden fact with the ID that is the value of the property.  The value shown in the fact inspector will be the value from the hidden element, which may be unrelated to the text in the HTML element.

The PR also adds support for the equivalent property for ESEF, `-esef-ix-hidden`.