### PR TITLE
Fix javascript error when clicking on graph icon

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -429,7 +429,7 @@ Inspector.prototype._selectionSummaryAccordian = function() {
                     $("<span></span>") 
                         .addClass("analyse")
                         .text("")
-                        .click(() => inspector._chart.analyseDimension(fact,["p"]))
+                        .click(() => this._chart.analyseDimension(fact,["p"]))
                 );
             }
             this._updateEntityIdentifier(fact, factHTML);


### PR DESCRIPTION
This fixes the issue reported by @derekgengenbacher-wf whereby clicking on the graph icon causes a JavaScript error.