### PR TITLE
Add support for wider narrower (anchoring) relationships

### DIFF
--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -25,6 +25,8 @@ from arelle.ModelRelationshipSet import ModelRelationshipSet
 from .xhtmlserialize import XHTMLSerializer
 import os
 
+WIDER_NARROWER_ARCROLE = 'http://www.esma.europa.eu/xbrl/esef/arcrole/wider-narrower'
+
 class NamespaceMap:
     """
     Class for building a 1:1 map of prefixes to namespace URIs
@@ -161,7 +163,7 @@ class IXBRLViewerBuilder:
 
         for baseSetKey, baseSetModelLinks  in self.dts.baseSets.items():
             arcrole, ELR, linkqname, arcqname = baseSetKey
-            if arcrole == XbrlConst.summationItem and ELR is not None:
+            if arcrole in (XbrlConst.summationItem, WIDER_NARROWER_ARCROLE) and ELR is not None:
                 self.addELR(ELR)
                 rr = dict()
                 relSet = self.dts.relationshipSet(arcrole, ELR)

--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -188,10 +188,11 @@ class IXBRLViewerBuilder:
         dts = self.dts
         iv = iXBRLViewer(dts)
         idGen = 0
-        self.roleMap.getPrefix(XbrlConst.standardLabel,"std")
-        self.roleMap.getPrefix(XbrlConst.documentationLabel,"doc")
-        self.roleMap.getPrefix(XbrlConst.summationItem,"calc")
-        self.roleMap.getPrefix(XbrlConst.parentChild,"pres")
+        self.roleMap.getPrefix(XbrlConst.standardLabel, "std")
+        self.roleMap.getPrefix(XbrlConst.documentationLabel, "doc")
+        self.roleMap.getPrefix(XbrlConst.summationItem, "calc")
+        self.roleMap.getPrefix(XbrlConst.parentChild, "pres")
+        self.roleMap.getPrefix(WIDER_NARROWER_ARCROLE, "w-n")
 
         for f in dts.facts:
             if f.id is None:

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -29,132 +29,132 @@ limitations under the License.
         <div class="content"></div>
       </div>
     </div>
-    <div id="inspector">
-      <div id="inspector-head">
-        <div class="title">
-          <h1 class="footnote-mode-off">Fact Properties</h1>
-          <h1 class="footnote-mode-only">Footnote Properties</h1>
-          <div class="back search-mode-only">
-          </div>
+  </div>
+  <div id="inspector">
+    <div id="inspector-head">
+      <div class="title">
+        <h1 class="footnote-mode-off">Fact Properties</h1>
+        <h1 class="footnote-mode-only">Footnote Properties</h1>
+        <div class="back search-mode-only">
         </div>
-        <div class="controls">
-          <div class="search-button">
-            <span class="icon-search"></span>
-          </div>
-          <div class="next-prev">
-              <span class="ixbrl-prev-tag"></span><span class="ixbrl-next-tag"></span>
-          </div>
+      </div>
+      <div class="controls">
+        <div class="search-button">
+          <span class="icon-search"></span>
         </div>
+        <div class="next-prev">
+            <span class="ixbrl-prev-tag"></span><span class="ixbrl-next-tag"></span>
+        </div>
+      </div>
 
-        <div class="search-controls search-mode-only">
-          <div class="search-input">
-            <input id="ixbrl-search" type="text" />
-            <div class="filter-toggle"></div>
-          </div>
-          <div class="search-filters">
-            <div class="reset">Reset</div>
-            <h3>Filter</h3>
-            <div class="control-label">
-                Concept Type
-            </div>
-            <select id="search-filter-concept-type">
-                <option value="*">ALL</option>
-                <option value="numeric">Numeric</option>
-                <option value="text">Text</option>
-            </select>
-            <div class="control-label">
-                Period
-            </div>
-            <select id="search-filter-period">
-            </select>
-            
-            <div class="checkboxes">
-              <div>
-                <label class="checkbox">
-                  <input id="search-hidden-fact-filter" type="checkbox" checked="checked"/> Hidden Facts
-                  <span class="checkmark"></span>
-                </label>
-              </div>
-              <div>
-                <label class="checkbox">
-                  <input id="search-visible-fact-filter" type="checkbox" checked="checked"/> Visible Facts
-                  <span class="checkmark"></span>
-                </label>
-              </div>
-            </div>
-          </div>
+      <div class="search-controls search-mode-only">
+        <div class="search-input">
+          <input id="ixbrl-search" type="text" />
+          <div class="filter-toggle"></div>
         </div>
-      </div> <!-- inspector-head -->
-
-      <div class="inspector-body">
-        <div class="fact-mode-only inspector-body-fact">
-          <div class="no-fact-overlay">
-            <div class="no-fact-overlay-icon"></div>
-            <p class="title">No Fact Selected</p>
+        <div class="search-filters">
+          <div class="reset">Reset</div>
+          <h3>Filter</h3>
+          <div class="control-label">
+              Concept Type
           </div>
-          <div class="fact-selected-only">
-            <div class="hidden-fact-tag">Hidden Fact</div>
-            <div class="collapsible-section">
-              <div class="fact-inspector collapsible-body">
-              </div>
-            </div>
-            <div class="footnote-mode-off">
-              <div class="collapsible-section anchoring">
-                 <h3 class="collapsible-header">Anchoring</h3>
-                 <div class="collapsible-body">
-                     <h4>Wider anchor</h4>
-                     <div class="anchors-wider">
-                     </div>
-                     <h4>Narrower anchors</h4>
-                     <div class="anchors-narrower">
-                     </div>
-                 </div>
-              </div>
-              <div class="collapsible-section anchoring">
-                 <h3 class="collapsible-header">Anchoring</h3>
-                 <div class="collapsible-body">
-                 </div>
-              </div>
-              <div class="collapsible-section">
-                 <h3 class="collapsible-header">References</h3>
-                 <div class="collapsible-body references">
-                 </div>
-              </div>
-              <div class="collapsible-section">
-                <h3 class="collapsible-header">Calculations</h3>
-                <div class="collapsible-body calculations">
-                  <div class="tree"></div>
-                </div>
-              </div>
-              <div class="collapsible-section">
-                 <h3 class="collapsible-header">Footnotes</h3>
-                 <div class="collapsible-body footnotes">
-                 </div>
-              </div>
-            </div>
-            <div class="footnote-details footnote-mode-only">
-              <div class="collapsible-section">
-                <h3 class="collapsible-header">Associated facts</h3>
-                 <div class="collapsible-body footnote-facts fact-list">
-                 </div>
-              </div>
-            </div>
+          <select id="search-filter-concept-type">
+              <option value="*">ALL</option>
+              <option value="numeric">Numeric</option>
+              <option value="text">Text</option>
+          </select>
+          <div class="control-label">
+              Period
           </div>
-        </div>
-
-        <div class="search-results search-mode-only">
-          <div class="results fact-list">
-          </div>
-          <div class="search-overlay">
-            <div class="search-overlay-icon"></div>
-            <div class="search-overlay-text"><p class="title">Fact Search</p><p class="text">Please enter some search terms</p></div>
+          <select id="search-filter-period">
+          </select>
+          
+          <div class="checkboxes">
+            <div>
+              <label class="checkbox">
+                <input id="search-hidden-fact-filter" type="checkbox" checked="checked"/> Hidden Facts
+                <span class="checkmark"></span>
+              </label>
+            </div>
+            <div>
+              <label class="checkbox">
+                <input id="search-visible-fact-filter" type="checkbox" checked="checked"/> Visible Facts
+                <span class="checkmark"></span>
+              </label>
+            </div>
           </div>
         </div>
       </div>
+    </div> <!-- inspector-head -->
+
+    <div class="inspector-body">
+      <div class="fact-mode-only inspector-body-fact">
+        <div class="no-fact-overlay">
+          <div class="no-fact-overlay-icon"></div>
+          <p class="title">No Fact Selected</p>
+        </div>
+        <div class="fact-selected-only">
+          <div class="hidden-fact-tag">Hidden Fact</div>
+          <div class="collapsible-section">
+            <div class="fact-inspector collapsible-body">
+            </div>
+          </div>
+          <div class="footnote-mode-off">
+            <div class="collapsible-section anchoring">
+               <h3 class="collapsible-header">Anchoring</h3>
+               <div class="collapsible-body">
+                   <h4>Wider anchor</h4>
+                   <div class="anchors-wider">
+                   </div>
+                   <h4>Narrower anchors</h4>
+                   <div class="anchors-narrower">
+                   </div>
+               </div>
+            </div>
+            <div class="collapsible-section anchoring">
+               <h3 class="collapsible-header">Anchoring</h3>
+               <div class="collapsible-body">
+               </div>
+            </div>
+            <div class="collapsible-section">
+               <h3 class="collapsible-header">References</h3>
+               <div class="collapsible-body references">
+               </div>
+            </div>
+            <div class="collapsible-section">
+              <h3 class="collapsible-header">Calculations</h3>
+              <div class="collapsible-body calculations">
+                <div class="tree"></div>
+              </div>
+            </div>
+            <div class="collapsible-section">
+               <h3 class="collapsible-header">Footnotes</h3>
+               <div class="collapsible-body footnotes">
+               </div>
+            </div>
+          </div>
+          <div class="footnote-details footnote-mode-only">
+            <div class="collapsible-section">
+              <h3 class="collapsible-header">Associated facts</h3>
+               <div class="collapsible-body footnote-facts fact-list">
+               </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="search-results search-mode-only">
+        <div class="results fact-list">
+        </div>
+        <div class="search-overlay">
+          <div class="search-overlay-icon"></div>
+          <div class="search-overlay-text"><p class="title">Fact Search</p><p class="text">Please enter some search terms</p></div>
+        </div>
+      </div>
     </div>
-    <div class="powered-by">
-      Powered by
-      <a href="https://www.workiva.co.uk/solutions/xbrl-and-ixbrl" target="_blank"><img src="../img/workiva.svg" /></a>
+    <div class="inspector-foot powered-by">
+        Powered by
+        <a href="https://www.workiva.co.uk/solutions/xbrl-and-ixbrl" target="_blank"><img src="../img/workiva.svg" /></a>
     </div>
   </div>
   <div class="dialog-mask">

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -103,6 +103,17 @@ limitations under the License.
               <div class="collapsible-section anchoring">
                  <h3 class="collapsible-header">Anchoring</h3>
                  <div class="collapsible-body">
+                     <h4>Wider anchor</h4>
+                     <div class="anchors-wider">
+                     </div>
+                     <h4>Narrower anchors</h4>
+                     <div class="anchors-narrower">
+                     </div>
+                 </div>
+              </div>
+              <div class="collapsible-section anchoring">
+                 <h3 class="collapsible-header">Anchoring</h3>
+                 <div class="collapsible-body">
                  </div>
               </div>
               <div class="collapsible-section">

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -100,6 +100,11 @@ limitations under the License.
               </div>
             </div>
             <div class="footnote-mode-off">
+              <div class="collapsible-section anchoring">
+                 <h3 class="collapsible-header">Anchoring</h3>
+                 <div class="collapsible-body">
+                 </div>
+              </div>
               <div class="collapsible-section">
                  <h3 class="collapsible-header">References</h3>
                  <div class="collapsible-body references">

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -15,19 +15,18 @@ limitations under the License.
 -->
 
 <div id="ixv" xmlns="http://www.w3.org/1999/xhtml">
-    <div class="loader loading">
-       <span class="text">Loading iXBRL Viewer</span>
+  <div class="loader loading">
+     <span class="text">Loading iXBRL Viewer</span>
+  </div>
+  <div id="top-bar">
+    <div class="header">
+       <img src="../img/inline-viewer.svg" />
     </div>
-    <div id="top-bar">
-      <div class="header">
-         <img src="../img/inline-viewer.svg" />
-      </div>
-      <div class="document-title"></div>
-      <div class="menu" id='display-options-menu'>
-        <div class="title">Display Options</div>
-        <div class="content-container">
-          <div class="content"></div>
-        </div>
+    <div class="document-title"></div>
+    <div class="menu" id='display-options-menu'>
+      <div class="title">Display Options</div>
+      <div class="content-container">
+        <div class="content"></div>
       </div>
     </div>
     <div id="inspector">
@@ -152,27 +151,28 @@ limitations under the License.
           </div>
         </div>
       </div>
-      <div class="inspector-foot powered-by">
-        Powered by
-        <a href="https://www.workiva.co.uk/solutions/xbrl-and-ixbrl" target="_blank"><img src="../img/workiva.svg" /></a>
-      </div>
     </div>
-    <div class="dialog-mask">
+    <div class="powered-by">
+      Powered by
+      <a href="https://www.workiva.co.uk/solutions/xbrl-and-ixbrl" target="_blank"><img src="../img/workiva.svg" /></a>
     </div>
-    <div id="chart" class="dialog">
-        <div class="close"></div>
-        <div class="contents">
-            <div class="chart-container" ><canvas id='chart-canvas'></canvas></div>
-            <div class="other-aspects"></div>
-        </div>
+  </div>
+  <div class="dialog-mask">
+  </div>
+  <div id="chart" class="dialog">
+    <div class="close"></div>
+    <div class="contents">
+      <div class="chart-container" ><canvas id='chart-canvas'></canvas></div>
+      <div class="other-aspects"></div>
     </div>
-    <div id="viewer-pane" >
-        <div class="ixds-tabs"><div class="tab-area"></div></div>
-        <div id="iframe-container">
-            <div class="zoom-in">+</div>
-            <div class="zoom-out">-</div>
-        </div>
-        <div class="resize"></div>
-        <div class="resize-spacer"></div>
+  </div>
+  <div id="viewer-pane" >
+    <div class="ixds-tabs"><div class="tab-area"></div></div>
+    <div id="iframe-container">
+      <div class="zoom-in">+</div>
+      <div class="zoom-out">-</div>
     </div>
+    <div class="resize"></div>
+    <div class="resize-spacer"></div>
+  </div>
 </div>

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -111,11 +111,6 @@ limitations under the License.
                    </div>
                </div>
             </div>
-            <div class="collapsible-section anchoring">
-               <h3 class="collapsible-header">Anchoring</h3>
-               <div class="collapsible-body">
-               </div>
-            </div>
             <div class="collapsible-section">
                <h3 class="collapsible-header">References</h3>
                <div class="collapsible-body references">

--- a/iXBRLViewerPlugin/viewer/src/js/calculations.js
+++ b/iXBRLViewerPlugin/viewer/src/js/calculations.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import $ from 'jquery';
+import { setDefault } from './util.js';
 
 export function Calculation(fact) {
     this._fact = fact;
@@ -25,16 +26,13 @@ Calculation.prototype.calculationFacts = function () {
     var fact = this._fact;
     var report = fact.report();
     if (!this._conceptToFact) {
-        var rels = report.getChildConcepts(fact.conceptName(), "calc")
+        var rels = report.getChildRelationships(fact.conceptName(), "calc")
         var ctf = {};
         $.each(rels, function (elr, rr) {
             ctf[elr] = {};
             if (rr.length > 0) {
-                var otherFacts = report.getAlignedFacts(fact, {"c": $.map(rr, function (r,i) { return r.t }) });
-                $.each(otherFacts, function (i,ff) {
-                    ctf[elr][ff.conceptName()] = ctf[elr][ff.conceptName()] || {};
-                    ctf[elr][ff.conceptName()][ff.id] = ff;
-                });
+                var otherFacts = report.getAlignedFacts(fact, {"c": $.map(rr, (r,i) => r.t ) });
+                $.each(otherFacts, (i,ff) => setDefault(ctf[elr], ff.conceptName(), {})[ff.id] = ff);
             }
         });
         this._conceptToFact = ctf;
@@ -93,7 +91,7 @@ Calculation.prototype.bestELRForFactSet = function(facts) {
 Calculation.prototype.resolvedCalculation = function(elr) {
     var calc = [];
     var calcFacts = this.calculationFacts()[elr];
-    var rels = this._fact.report().getChildConcepts(this._fact.conceptName(), "calc")[elr];
+    var rels = this._fact.report().getChildRelationships(this._fact.conceptName(), "calc")[elr];
     $.each(rels, function (i, r) {
         var s;
         if (r.w == 1) {

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -253,36 +253,19 @@ Fact.prototype.isHidden = function () {
 }
 
 Fact.prototype.widerConcepts = function () {
-    if (!this._report.usesAnchoring()) {
-        return [];
-    }
     var concepts = [];
-    const wn = this._report.data.rels["w-n"];
-    for (const elr in wn) {
-        for (const src in wn[elr]) {
-            if ($.map(wn[elr][src], (target) => target.t).includes(this.conceptName())) {
-                concepts.push(src);
-            }
-        }
+    const parentsByELR = this._report.getParentRelationships(this.conceptName(), "w-n");
+    for (const elr in parentsByELR) {
+        concepts.push(...$.map(parentsByELR[elr], (rel) => rel.src));
     }
     return concepts;
 }
 
 Fact.prototype.narrowerConcepts = function () {
-    if (!this._report.usesAnchoring()) {
-        return [];
-    }
     var concepts = [];
-    const wn = this._report.data.rels["w-n"];
-    for (const elr in wn) {
-        for (const src in wn[elr]) {
-            if (src == this.conceptName()) {
-                for (const target of wn[elr][src]) {
-                    concepts.push(target.t)
-                }
-            }
-        }
+    const childrenByELR = this._report.getChildRelationships(this.conceptName(), "w-n");
+    for (const elr in childrenByELR) {
+        concepts.push(...$.map(childrenByELR[elr], (rel) => rel.t));
     }
     return concepts;
 }
-

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -267,3 +267,22 @@ Fact.prototype.widerConcepts = function () {
     }
     return concepts;
 }
+
+Fact.prototype.narrowerConcepts = function () {
+    if (!this._report.usesAnchoring()) {
+        return [];
+    }
+    var concepts = [];
+    const wn = this._report.data.rels["w-n"];
+    for (const elr in wn) {
+        for (const src in wn[elr]) {
+            if (src == this.conceptName()) {
+                for (const target of wn[elr][src]) {
+                    concepts.push(target.t)
+                }
+            }
+        }
+    }
+    return concepts;
+}
+

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -251,3 +251,19 @@ Fact.prototype.footnotes = function () {
 Fact.prototype.isHidden = function () {
     return this._ixNode.wrapperNode.length == 0;
 }
+
+Fact.prototype.widerConcepts = function () {
+    if (!this._report.usesAnchoring()) {
+        return [];
+    }
+    var concepts = [];
+    const wn = this._report.data.rels["w-n"];
+    for (const elr in wn) {
+        for (const src in wn[elr]) {
+            if ($.map(wn[elr][src], (target) => target.t).includes(this.conceptName())) {
+                concepts.push(src);
+            }
+        }
+    }
+    return concepts;
+}

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -261,6 +261,21 @@ Inspector.prototype.updateFootnotes = function (fact) {
     $('.footnotes').empty().append(this._footnotesHTML(fact));
 }
 
+Inspector.prototype.updateAnchoring = function (fact) {
+    if (!this._report.usesAnchoring()) {
+        $('.anchoring').hide();
+    }
+    else {
+        $('.anchoring').show();
+        $('.anchoring .collapsible-body').empty();
+        const wider = fact.widerConcepts();
+        for (const c of wider) {
+            $("<p></p>").text(c).appendTo($('.anchoring .collapsible-body'));
+        }
+    }
+
+}
+
 Inspector.prototype._referencesHTML = function (fact) {
     var c = fact.concept();
     var a = new Accordian();
@@ -541,6 +556,7 @@ Inspector.prototype.update = function () {
 
             this.updateCalculation(cf);
             this.updateFootnotes(cf);
+            this.updateAnchoring(cf);
             $('div.references').empty().append(this._referencesHTML(cf));
             $('#inspector .search-results .fact-list-item').removeClass('selected');
             $('#inspector .search-results .fact-list-item').filter(function () { return $(this).data('ivid') == cf.id }).addClass('selected');

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -270,7 +270,7 @@ Inspector.prototype.updateAnchoring = function (fact) {
         $('.anchoring .collapsible-body').empty();
         const wider = fact.widerConcepts();
         for (const c of wider) {
-            $("<p></p>").text(c).appendTo($('.anchoring .collapsible-body'));
+            $("<p></p>").text(this._report.getLabel(c, "std", true)).appendTo($('.anchoring .collapsible-body'));
         }
     }
 

--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -17,6 +17,7 @@ import { Footnote } from "./footnote.js"
 import { QName } from "./qname.js"
 import { Concept } from "./concept.js";
 import { ViewerOptions } from "./viewerOptions.js";
+import { setDefault } from "./util.js";
 import $ from 'jquery'
 
 export function iXBRLReport (data) {
@@ -25,6 +26,7 @@ export function iXBRLReport (data) {
     this._items = {};
     this._ixNodeMap = {};
     this._viewerOptions = new ViewerOptions();
+    this._reverseRelationshipCache = {};
 }
 
 /*
@@ -133,18 +135,43 @@ iXBRLReport.prototype.qname = function(v) {
     return new QName(this.prefixMap(), v);
 }
 
-iXBRLReport.prototype.getChildConcepts = function(c,arcrole) {
+iXBRLReport.prototype.getChildRelationships = function(c, arcrole) {
     var rels = {}
-    if (this.data.rels.hasOwnProperty(arcrole)) {
-        $.each(this.data.rels[arcrole], function (elr, rr) {
-            if (rr.hasOwnProperty(c)) {
-                rels[elr] = rr[c]
-            }
-        })
+    const elrs = this.data.rels[arcrole] || {};
+    for (const elr in elrs) {
+        if (c in elrs[elr]) {
+            rels[elr] = elrs[elr][c];
+        }
     }
     return rels;
 }
 
+iXBRLReport.prototype._reverseRelationships = function(arcrole) {
+    if (!(arcrole in this._reverseRelationshipCache)) {
+        const rrc = {};
+        const elrs = this.data.rels[arcrole] || {};
+        for (const [elr, relSet] of Object.entries(elrs)) {
+            for (const [src, rels] of Object.entries(relSet)) {
+                for (const r of rels) {
+                    r.src = src;
+                    setDefault(setDefault(rrc, elr, {}), r.t, []).push(r);
+                }
+            }
+        }
+        this._reverseRelationshipCache[arcrole] = rrc;
+    }
+    return this._reverseRelationshipCache[arcrole];
+}
+
+iXBRLReport.prototype.getParentRelationships = function(c, arcrole) {
+    var rels = {}
+    for (const [elr, relSet] of Object.entries(this._reverseRelationships(arcrole))) {
+        if (c in relSet) {
+            rels[elr] = relSet[c];
+        }
+    }
+    return rels;
+}
 
 iXBRLReport.prototype.getAlignedFacts = function(f, coveredAspects) {
     var all = this.facts();

--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -146,6 +146,14 @@ iXBRLReport.prototype.getChildRelationships = function(c, arcrole) {
     return rels;
 }
 
+/* 
+ * Build and cache an inverse map of relationships for a given arcrole for
+ * efficient lookup of parents concept from a child.
+ *
+ * Map is arcrole => elr => target => [ rel, ... ]
+ *
+ * "rel" is modified to have a "src" property with the source concept.
+ */
 iXBRLReport.prototype._reverseRelationships = function(arcrole) {
     if (!(arcrole in this._reverseRelationshipCache)) {
         const rrc = {};

--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -210,3 +210,7 @@ iXBRLReport.prototype.documentSetFiles = function() {
 iXBRLReport.prototype.isDocumentSet = function() {
     return this.data.docSetFiles !== undefined;
 }
+
+iXBRLReport.prototype.usesAnchoring = function() {
+    return this.data.rels["w-n"] !== undefined;
+}

--- a/iXBRLViewerPlugin/viewer/src/js/search.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.js
@@ -29,6 +29,7 @@ ReportSearch.prototype.buildSearchIndex = function () {
         var f = facts[i];
         var doc = { "id": f.id };
         var l = f.getLabel("std");
+        doc.concept = f.conceptQName().localname;
         doc.doc = f.getLabel("doc");
         doc.date = f.periodTo();
         doc.startDate = f.periodFrom();
@@ -38,6 +39,12 @@ ReportSearch.prototype.buildSearchIndex = function () {
         }
         doc.label = l;
         doc.ref = f.concept().referenceValuesAsString();
+        const wider = f.widerConcepts();
+        if (wider.length > 0) {
+            doc.widerConcept = this._report.qname(wider[0]).localname;
+            doc.widerLabel = this._report.getLabel(wider[0],"std");
+            doc.widerDoc = this._report.getLabel(wider[0],"doc");
+        }
         docs.push(doc);
 
         var p = f.period();
@@ -49,10 +56,14 @@ ReportSearch.prototype.buildSearchIndex = function () {
     this._searchIndex = lunr(function () {
       this.ref('id');
       this.field('label');
+      this.field('concept');
       this.field('startDate');
       this.field('date');
       this.field('doc');
       this.field('ref');
+      this.field('widerLabel');
+      this.field('widerDoc');
+      this.field('widerConcept');
 
       docs.forEach(function (doc) {
         this.add(doc);

--- a/iXBRLViewerPlugin/viewer/src/js/util.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.js
@@ -129,3 +129,10 @@ export function xbrlDateToMoment(dateString) {
 export function escapeRegex(text) {
     return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
 }
+
+export function setDefault(obj, key, def) {
+    if (!obj.hasOwnProperty(key)) {
+        obj[key] = def;
+    }
+    return obj[key];
+}

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -640,7 +640,7 @@
           position: relative;
           line-height: 1.8rem;
 
-          &:not(.fact-link, .total) .concept-name {
+          &:not(.calc-fact-link, .total) .concept-name {
             color: #777;
           }
 
@@ -649,7 +649,7 @@
             margin-left: 15px;
           }
 
-          &.fact-link {
+          &.calc-fact-link {
             cursor: pointer;
 
             .concept-name {
@@ -663,7 +663,7 @@
           }
 
           &.linked-highlight,
-          &.fact-link:hover {
+          &.calc-fact-link:hover {
             .linked-highlight-text();
           }
 
@@ -671,16 +671,6 @@
             border-top: solid 1px @border-grey;
             padding-bottom: 1.2rem;
           }
-        }
-      }
-
-      .year-on-year-fact-link {
-        cursor: pointer;
-        color: @primary;
-
-        &:hover {
-          outline: solid 2px @linked-fact;
-          outline-offset: 1px;
         }
       }
     }
@@ -748,12 +738,14 @@
     }
   }
 
-  #period {
-    margin-top: 10px;
-  }
+  .fact-link {
+    cursor: pointer;
+    color: @primary;
 
-  #value {
-    margin-top: 10px;
+    &:hover {
+      outline: solid 2px @linked-fact;
+      outline-offset: 1px;
+    }
   }
 
   .fact-list {

--- a/samples/build-viewer.py
+++ b/samples/build-viewer.py
@@ -36,6 +36,7 @@ class CntlrCreateViewer(Cntlr.Cntlr):
                 self.addToLog("Package added", messageCode="info", file=pi.get("URL"))
             else:
                 self.addToLog("Failed to load package", messageCode="error", file=p)
+        PackageManager.rebuildRemappings(self)
     
     def createViewer(self, f, scriptUrl=None, outPath=None):
         if os.path.isdir(f):


### PR DESCRIPTION
Add support for anchoring relationships:

* Wider and narrower concepts are shown in a new "Anchoring" section of the fact inspector.
* Labels and documentation from wider concepts are added to the search index for the facts to which they relate, so a search for the name or description of a wider concept will find related narrower facts.
* Search now allows search for element names, as well as labels.

The anchoring section of the fact inspector is only shown if there is at least one anchoring relationship in the document.