### PR TITLE
Missing concept definitions from relationship sources

### DIFF
--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -178,6 +178,7 @@ class IXBRLViewerBuilder:
                         rel['w'] = r.weight
                     rr.setdefault(fromKey, []).append(rel)
                     self.addConcept(r.toModelObject)
+                    self.addConcept(r.fromModelObject)
 
                 rels.setdefault(self.roleMap.getPrefix(arcrole),{})[self.roleMap.getPrefix(ELR)] = rr
         return rels

--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -65,7 +65,12 @@ iXBRLReport.prototype._initialize = function () {
 iXBRLReport.prototype.getLabel = function(c, rolePrefix, showPrefix, viewerOptions) {
     rolePrefix = rolePrefix || 'std';
     var lang = this._viewerOptions.language;
-    var labels = this.data.concepts[c].labels[rolePrefix]
+    const concept = this.data.concepts[c];
+    if (concept === undefined) {
+        console.log("Attempt to get label for undefined concept: " + c);
+        return "<no label>";
+    }
+    const labels = concept.labels[rolePrefix]
     if (labels === undefined) {
         return undefined;
     }


### PR DESCRIPTION
This PR fixes #116 where concepts that not used in the report, but which are the source of a relationship do not get added to the concept information in the report.

In the case of wider-narrower relationships where the source (wider) concept is not used in the report, this causes an exception when building the search index.

For other relationships (calculations) where the source concept is not used in the report, the viewer will load as they are not added to the search index, but an exception would occur if and when the viewer attempts to get a label for them.

As well as fixing the failure to include the source information, this PR also makes the viewer cope more gracefully with an attempt to get a label for a non-existent concept, by returning a placeholder and logging a message on the console.