### PR TITLE
Revert "Bump css-loader from 3.6.0 to 4.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "base64-inline-loader": "^1.1.1",
     "chart.js": "^2.9.3",
     "core-js": "^3.6.4",
-    "css-loader": "^4.0.0",
+    "css-loader": "^3.4.2",
     "dateformat": "^3.0.3",
     "exceljs": "^4.0.1",
     "file-saver": "^2.0.2",


### PR DESCRIPTION
Reverts Workiva/ixbrl-viewer#122

This breaks the viewer at this time.