### PR TITLE
XT-829: fix fact highlighting

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -124,7 +124,7 @@ Inspector.prototype.updateURLFragment = function () {
 
 Inspector.prototype.buildDisplayOptionsMenu = function () {
     this._optionsMenu.reset();
-    this._optionsMenu.addCheckboxItem("Highlight", function (checked) { inspector.highlightAllTags(checked)}, "highlight-tags");
+    this._optionsMenu.addCheckboxItem("Highlight", (checked) => this.highlightAllTags(checked), "highlight-tags");
     if (this._report) {
         var dl = this.selectDefaultLanguage();
         this._optionsMenu.addCheckboxGroup(this._report.availableLanguages(), this._report.languageNames(), dl, (lang) => { this.setLanguage(lang); this.update() }, "select-language");


### PR DESCRIPTION
```
    ixbrlviewer.js:116 Uncaught TypeError: inspector.highlightAllTags is not a function
        at ixbrlviewer.js:116
        at HTMLDivElement.<anonymous> (ixbrlviewer.js:116)
        at HTMLDivElement.dispatch (ixbrlviewer.js:25)
        at HTMLDivElement.y.handle (ixbrlviewer.js:25)
```

**review**:
@Workiva/xt