### PR TITLE
Handle nil text facts

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -92,6 +92,9 @@ Fact.prototype.readableValue = function() {
             v = formattedNumber + " " + this.unit().valueLabel();
         }
     }
+    else if (this.isNil()) {
+        v = "nil";
+    }
     else if (this.escaped()) {
         var html = $("<div>").append($($.parseHTML(v, null, false)));
         /* Insert an extra space at the beginning and end of block elements to

--- a/iXBRLViewerPlugin/viewer/src/js/footnote.js
+++ b/iXBRLViewerPlugin/viewer/src/js/footnote.js
@@ -26,3 +26,7 @@ Footnote.prototype.addFact = function (f) {
 Footnote.prototype.textContent = function () {
     return this._ixNode.textContent();
 }
+
+Footnote.prototype.readableValue = function () {
+    return this.textContent();
+}

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -474,9 +474,9 @@ Inspector.prototype._updateValue = function (item, showAll, context) {
         $('tr.value', context).removeClass('truncated');
     }
 
-    $('tr.value td .value', context).empty().text(v);
+    var valueSpan = $('tr.value td .value', context).empty().text(v);
     if (item instanceof Fact && item.isNil()) {
-        $('tr.value td .value', context).wrapInner("<i></i>");
+        valueSpan.wrapInner("<i></i>");
     }
 
 }
@@ -538,9 +538,9 @@ Inspector.prototype._selectionSummaryAccordian = function() {
             this._updateEntityIdentifier(fact, factHTML);
             this._updateValue(fact, false, factHTML);
 
-            $('tr.accuracy td', factHTML).empty().append(fact.readableAccuracy());
+            var accuracyTD = $('tr.accuracy td', factHTML).empty().append(fact.readableAccuracy());
             if (!fact.isNumeric() || fact.isNil()) {
-                $('tr.accuracy td', factHTML).wrapInner("<i></i>");
+                accuracyTD.wrapInner("<i></i>");
             }
 
             $('#dimensions', factHTML).empty();

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -455,7 +455,8 @@ Inspector.prototype.getPeriodIncrease = function (fact) {
 
 }
 
-Inspector.prototype._updateValue = function (text, showAll, context) {
+Inspector.prototype._updateValue = function (item, showAll, context) {
+    const text = item.readableValue();
     var v = text;
     if (!showAll) {
         var fullLabel = text;
@@ -473,7 +474,11 @@ Inspector.prototype._updateValue = function (text, showAll, context) {
         $('tr.value', context).removeClass('truncated');
     }
 
-    $('tr.value td .value', context).text(v);
+    $('tr.value td .value', context).empty().text(v);
+    if (item instanceof Fact && item.isNil()) {
+        $('tr.value td .value', context).wrapInner("<i></i>");
+    }
+
 }
 
 Inspector.prototype._updateEntityIdentifier = function (fact, context) {
@@ -531,8 +536,13 @@ Inspector.prototype._selectionSummaryAccordian = function() {
                 );
             }
             this._updateEntityIdentifier(fact, factHTML);
-            this._updateValue(fact.readableValue(), false, factHTML);
-            $('tr.accuracy td', factHTML).text(fact.readableAccuracy());
+            this._updateValue(fact, false, factHTML);
+
+            $('tr.accuracy td', factHTML).empty().append(fact.readableAccuracy());
+            if (!fact.isNumeric() || fact.isNil()) {
+                $('tr.accuracy td', factHTML).wrapInner("<i></i>");
+            }
+
             $('#dimensions', factHTML).empty();
             var dims = fact.dimensions();
             for (var d in dims) {
@@ -554,7 +564,7 @@ Inspector.prototype._selectionSummaryAccordian = function() {
         }
         else if (fact instanceof Footnote) {
             factHTML = $(require('../html/footnote-details.html')); 
-            this._updateValue(fact.textContent(), false, factHTML);
+            this._updateValue(fact, false, factHTML);
         }
         a.addCard(
             title,


### PR DESCRIPTION
Previously, nil-valued text facts would cause a JavaScript error when clicking on them.  This PR fixes this, and the value should be displayed as "nil" in the fact inspector.

Additionally, this PR applies italics consistently to "nil" (value) and "n/a" (units and accuracy) when they appear in the fact inspector, making a nil value distinct from a string value of `nil`.

Fixes XT 790