### PR TITLE
Fix for long text content appearing within table cells causing exception on document load

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -128,7 +128,7 @@ Viewer.prototype._preProcessiXBRL = function(n, docIndex, inHidden) {
                 const outerText = $(node).text();
                 const start = outerText.indexOf(innerText);
                 const wrapper = outerText.substring(0, start) + outerText.substring(start + innerText.length);
-                if (/[0-9A-Za-z]/.exec(wrapper) !== null) {
+                if (/[0-9A-Za-z]/.test(wrapper)) {
                     node = $();
                 } 
             }

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -128,7 +128,7 @@ Viewer.prototype._preProcessiXBRL = function(n, docIndex, inHidden) {
                 const outerText = $(node).text();
                 const start = outerText.indexOf(innerText);
                 const wrapper = outerText.substring(0, start) + outerText.substring(start + innerText.length);
-                if (wrapper.match('[0-9A-Za-z]') !== null) {
+                if (/[0-9A-Za-z]/.exec(wrapper) !== null) {
                     node = $();
                 } 
             }

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -121,9 +121,14 @@ Viewer.prototype._preProcessiXBRL = function(n, docIndex, inHidden) {
             /* Is the element the only significant content within a <td> or <th> ? If
              * so, use that as the wrapper element. */
             node = $(n).closest("td,th").eq(0);
-            if (node.length == 1) {
-                var regex = "^[^0-9A-Za-z]*" + escapeRegex($(n).text()) + "[^0-9A-Za-z]*$";
-                if (node.text().match(regex) == null) {
+            const innerText = $(n).text();
+            if (node.length == 1 && innerText.length > 0) {
+                // Use indexOf rather than a single regex because innerText may
+                // be too long for the regex engine 
+                const outerText = $(node).text();
+                const start = outerText.indexOf(innerText);
+                const wrapper = outerText.substring(0, start) + outerText.substring(start + innerText.length);
+                if (wrapper.match('[0-9A-Za-z]') !== null) {
                     node = $();
                 } 
             }


### PR DESCRIPTION
This PR fixes a bug whereby a very large tag appearing within a `<td>` or `<th>` element would cause the viewer to throw an exception and fail to load.

Previously we were embedding the content of the tag into a regex and checking that we had no significant characters either side of it.  This could lead to a regex that was too long for the regex engine.

This fix now manually extracts the text before and after the tag (using `indexOf` rather than a regex) and then checks that with a regex.

The document that triggered this bug is on issue #152 .

Fixes #152 
