### PR TITLE
Typed dimensions support

### DIFF
--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -129,7 +129,7 @@ class IXBRLViewerBuilder:
                 label = rt[0].definition
             self.taxonomyData["roleDefs"].setdefault(prefix,{})["en"] = label
 
-    def addConcept(self, concept):
+    def addConcept(self, concept, dimensionType = None):
         if concept is None:
             return
         labelsRelationshipSet = self.dts.relationshipSet(XbrlConst.conceptLabel)
@@ -153,6 +153,9 @@ class IXBRLViewerBuilder:
 
             if len(refData) > 0:
                 conceptData['r'] = refData
+
+            if dimensionType is not None:
+                conceptData["d"] = dimensionType
 
             self.taxonomyData["concepts"][conceptName] = conceptData
 
@@ -233,11 +236,12 @@ class IXBRLViewerBuilder:
 
             for d, v in f.context.qnameDims.items():
                 if v.memberQname is None:
-                    # Typed dimension, not yet supported.
-                    continue
-                aspects[self.nsmap.qname(v.dimensionQname)] = self.nsmap.qname(v.memberQname)
-                self.addConcept(v.dimension)
-                self.addConcept(v.member)
+                    aspects[self.nsmap.qname(v.dimensionQname)] = v.typedMember.text
+                    self.addConcept(v.dimension, dimensionType = "t")
+                else:
+                    aspects[self.nsmap.qname(v.dimensionQname)] = self.nsmap.qname(v.memberQname)
+                    self.addConcept(v.member)
+                    self.addConcept(v.dimension, dimensionType = "e")
 
             if f.context.isForeverPeriod:
                 aspects["p"] = "f"

--- a/iXBRLViewerPlugin/viewer/src/js/aspect.js
+++ b/iXBRLViewerPlugin/viewer/src/js/aspect.js
@@ -58,13 +58,17 @@ Aspect.prototype.isTaxonomyDefined = function() {
     return (this._aspect.indexOf(":") > -1);
 }
 
+Aspect.prototype.isNil = function() {
+    return this._value === null;
+}
+
 Aspect.prototype.valueLabel = function(rolePrefix) {
     if (this._aspect == 'c') {
         return this._report.getLabel(this._value, rolePrefix) || this._value;
     }
     if (this.isTaxonomyDefined()) {
         if (this._report.getConcept(this._aspect).isTypedDimension()) {
-            return this._value === null ? "<nil>" : this._value;
+            return this._value === null ? "nil" : this._value;
         }
         return this._report.getLabel(this._value, rolePrefix) || this._value;
     }

--- a/iXBRLViewerPlugin/viewer/src/js/aspect.js
+++ b/iXBRLViewerPlugin/viewer/src/js/aspect.js
@@ -64,7 +64,7 @@ Aspect.prototype.valueLabel = function(rolePrefix) {
     }
     if (this.isTaxonomyDefined()) {
         if (this._report.getConcept(this._aspect).isTypedDimension()) {
-            return this._value === null ? "<null>" : this._value;
+            return this._value === null ? "<nil>" : this._value;
         }
         else {
             return this._report.getLabel(this._value, rolePrefix) || this._value;

--- a/iXBRLViewerPlugin/viewer/src/js/aspect.js
+++ b/iXBRLViewerPlugin/viewer/src/js/aspect.js
@@ -53,10 +53,22 @@ Aspect.prototype.equalTo = function(a) {
     return a !== undefined && this._aspect == a._aspect && this._value == a._value;
 }
 
+
+Aspect.prototype.isTaxonomyDefined = function() {
+    return (this._aspect.indexOf(":") > -1);
+}
+
 Aspect.prototype.valueLabel = function(rolePrefix) {
-    /* Taxonomy-defined dimension, treat as explicit - or concept */
-    if (this._aspect.indexOf(":") > -1 || this._aspect == 'c') {
+    if (this._aspect == 'c') {
         return this._report.getLabel(this._value, rolePrefix) || this._value;
+    }
+    if (this.isTaxonomyDefined()) {
+        if (this._report.getConcept(this._aspect).isTypedDimension()) {
+            return this._value === null ? "<null>" : this._value;
+        }
+        else {
+            return this._report.getLabel(this._value, rolePrefix) || this._value;
+        }
     }
     else if (this._aspect == 'u') {
         if (this._value === null) {

--- a/iXBRLViewerPlugin/viewer/src/js/aspect.js
+++ b/iXBRLViewerPlugin/viewer/src/js/aspect.js
@@ -66,9 +66,7 @@ Aspect.prototype.valueLabel = function(rolePrefix) {
         if (this._report.getConcept(this._aspect).isTypedDimension()) {
             return this._value === null ? "<nil>" : this._value;
         }
-        else {
-            return this._report.getLabel(this._value, rolePrefix) || this._value;
-        }
+        return this._report.getLabel(this._value, rolePrefix) || this._value;
     }
     else if (this._aspect == 'u') {
         if (this._value === null) {

--- a/iXBRLViewerPlugin/viewer/src/js/aspect.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/aspect.test.js
@@ -34,6 +34,22 @@ var testReportData = {
                     "en": "English label for concept two"
                 }
             }
+        },
+        "eg:ExplicitDimension": {
+            "labels": {
+                "std": {
+                    "en": "Explicit dimension"
+                }
+            },
+            "d": "e"
+        },
+        "eg:TypedDimension": {
+            "labels": {
+                "std": {
+                    "en": "Typed dimension"
+                }
+            },
+            "d": "t"
         }
     }
 };
@@ -77,9 +93,22 @@ test("Entity aspect labels - unknown scheme", () => {
 });
 
 test("Taxonomy defined dimension labels", () => {
-    var tda = new Aspect("eg:Concept1", "eg:Concept2", testReport);
-    expect(tda.label()).toBe("English label");  
+    var tda = new Aspect("eg:ExplicitDimension", "eg:Concept2", testReport);
+    expect(tda.label()).toBe("Explicit dimension");  
     expect(tda.valueLabel()).toBe("English label for concept two");  
+
+    tda = new Aspect("eg:TypedDimension", "eg:Concept2", testReport);
+    expect(tda.label()).toBe("Typed dimension");  
+    // "eg:Concept2" should be treated as a string, not a member name
+    expect(tda.valueLabel()).toBe("eg:Concept2");  
+
+    tda = new Aspect("eg:TypedDimension", "1 2 3 4", testReport);
+    expect(tda.label()).toBe("Typed dimension");  
+    expect(tda.valueLabel()).toBe("1 2 3 4");  
+
+    tda = new Aspect("eg:TypedDimension", null, testReport);
+    expect(tda.label()).toBe("Typed dimension");  
+    expect(tda.valueLabel()).toBe("<nil>");  
 });
 
 describe("AspectSet", () => {

--- a/iXBRLViewerPlugin/viewer/src/js/aspect.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/aspect.test.js
@@ -94,21 +94,21 @@ test("Entity aspect labels - unknown scheme", () => {
 
 test("Taxonomy defined dimension labels", () => {
     var tda = new Aspect("eg:ExplicitDimension", "eg:Concept2", testReport);
-    expect(tda.label()).toBe("Explicit dimension");  
-    expect(tda.valueLabel()).toBe("English label for concept two");  
+    expect(tda.label()).toBe("Explicit dimension");
+    expect(tda.valueLabel()).toBe("English label for concept two");
 
     tda = new Aspect("eg:TypedDimension", "eg:Concept2", testReport);
-    expect(tda.label()).toBe("Typed dimension");  
+    expect(tda.label()).toBe("Typed dimension");
     // "eg:Concept2" should be treated as a string, not a member name
-    expect(tda.valueLabel()).toBe("eg:Concept2");  
+    expect(tda.valueLabel()).toBe("eg:Concept2");
 
     tda = new Aspect("eg:TypedDimension", "1 2 3 4", testReport);
-    expect(tda.label()).toBe("Typed dimension");  
-    expect(tda.valueLabel()).toBe("1 2 3 4");  
+    expect(tda.label()).toBe("Typed dimension");
+    expect(tda.valueLabel()).toBe("1 2 3 4");
 
     tda = new Aspect("eg:TypedDimension", null, testReport);
-    expect(tda.label()).toBe("Typed dimension");  
-    expect(tda.valueLabel()).toBe("<nil>");  
+    expect(tda.label()).toBe("Typed dimension");
+    expect(tda.valueLabel()).toBe("nil");
 });
 
 describe("AspectSet", () => {
@@ -121,7 +121,6 @@ describe("AspectSet", () => {
         expect(uv).toHaveLength(2);
         expect(uv.map(x => x.value())).toEqual(expect.arrayContaining(["eg:Concept1", "eg:Concept2"]));
     });
-    
 });
 
 

--- a/iXBRLViewerPlugin/viewer/src/js/chart.js
+++ b/iXBRLViewerPlugin/viewer/src/js/chart.js
@@ -120,10 +120,10 @@ IXBRLChart.prototype._showAnalyseDimensionChart = function() {
     var set2av = new AspectSet();
     $.each(facts, function (i,f) {
         if (dims[0]) {
-            set1av.add(f.aspects()[dims[0]]);
+            set1av.add(f.aspect(dims[0]));
         }
         if (dims[1]) {
-            set2av.add(f.aspects()[dims[1]]);
+            set2av.add(f.aspect(dims[1]));
         }
     });
     var uv1 = set1av.uniqueValues();
@@ -169,7 +169,7 @@ IXBRLChart.prototype._showAnalyseDimensionChart = function() {
     /* Create controls for adding or removing aspects for analysis */
     $(".other-aspects", c).empty();
     var unselectedAspects = [];
-    $.each(fact.aspects(), function (a,av) {
+    for (const av of fact.aspects()) {
         /* Don't show concept in list of additional aspects */
         if (av.name() != 'c') {
             var a = $("<div>")
@@ -191,7 +191,7 @@ IXBRLChart.prototype._showAnalyseDimensionChart = function() {
                 }
             }
         }
-    });
+    }
 
     if (!dims[1]) {
         if (!dims[0]) {

--- a/iXBRLViewerPlugin/viewer/src/js/concept.js
+++ b/iXBRLViewerPlugin/viewer/src/js/concept.js
@@ -45,3 +45,8 @@ Concept.prototype.references = function () {
         });
     }
 }
+
+Concept.prototype.isTypedDimension = function () {
+    return this._c.d == "t";
+}
+

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -139,16 +139,16 @@ Fact.prototype.isMonetaryValue = function () {
 }
 
 Fact.prototype.aspects = function () {
-    var aspects = {};
-    var fact = this;
-    $.each(this.f.a, function (k,v) {
-        aspects[k] = fact.aspect(k);
-    });
+    var aspects = [];
+    $.each(this.f.a, (k,v) => { aspects.push(this.aspect(k) ) } );
     return aspects;
 }
 
 Fact.prototype.aspect = function (a) {
-    return new Aspect(a, this.f.a[a], this._report);
+    if (this.f.a[a] !== undefined) {
+        return new Aspect(a, this.f.a[a], this._report);
+    }
+    return undefined;
 }
 
 Fact.prototype.isAligned = function (of, coveredAspects) {

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -139,9 +139,7 @@ Fact.prototype.isMonetaryValue = function () {
 }
 
 Fact.prototype.aspects = function () {
-    var aspects = [];
-    $.each(this.f.a, (k,v) => { aspects.push(this.aspect(k) ) } );
-    return aspects;
+    return Object.keys(this.f.a).map(k => this.aspect(k));
 }
 
 Fact.prototype.aspect = function (a) {

--- a/iXBRLViewerPlugin/viewer/src/js/fact.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.test.js
@@ -42,6 +42,21 @@ var testReportData = {
                     "en": "English label for concept three"
                 }
             }
+        },
+        "eg:Dimension1": {
+            "labels": {
+                "std": {
+                    "en": "Dimension One"
+                }
+            },
+            "d": "e"
+        },
+        "eg:Member1": {
+            "labels": {
+                "std": {
+                    "en": "Member One"
+                }
+            }
         }
     },
     "facts": {
@@ -485,4 +500,23 @@ describe("Get Label", () => {
         expect(f.getLabel("doc")).toBeUndefined();
     });
 
+});
+
+describe("Aspect methods", () => {
+    var f = testFact({
+            "d": -3,
+            "v": 1000,
+            "a": {
+                "c": "eg:Concept1",
+                "u": "iso4217:USD", 
+                "p": "2018-01-01/2019-01-01",
+                "eg:Dimension1": "eg:Member1"
+            }});
+    test("Get aspects", () => {
+        expect(f.aspects().length).toEqual(4);
+        expect(f.aspects().filter(a => a.isTaxonomyDefined()).length).toEqual(1);
+        expect(f.aspects().filter(a => a.isTaxonomyDefined())[0].label()).toEqual("Dimension One");
+        expect(f.aspects().filter(a => a.isTaxonomyDefined())[0].valueLabel()).toEqual("Member One");
+        expect(f.aspect("eg:Dimension1").value()).toEqual("eg:Member1");
+    });
 });

--- a/iXBRLViewerPlugin/viewer/src/js/factset.js
+++ b/iXBRLViewerPlugin/viewer/src/js/factset.js
@@ -50,7 +50,7 @@ FactSet.prototype.minimallyUniqueLabel = function(fact) {
             var f = facts[i];
             allLabels[f.id] = [];
             for (var j = 0; j < allAspects.length; j++) {
-                var dd = f.aspects()[allAspects[j]];
+                var dd = f.aspect(allAspects[j]);
                 allLabels[f.id].push(dd ? dd.valueLabel() : null);
             }
         }

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -168,7 +168,7 @@ Inspector.prototype.factListRow = function(f) {
         .text(f.period().toString())
         .appendTo(row);
 
-    for (const [key, aspect] of Object.entries(f.aspects())) {
+    for (const aspect of f.aspects()) {
         if (aspect.isTaxonomyDefined()) {
             $('<div class="dimension"></div>')
                 .text(aspect.valueLabel())
@@ -535,7 +535,7 @@ Inspector.prototype._selectionSummaryAccordian = function() {
             this._updateValue(fact.readableValue(), false, factHTML);
             $('tr.accuracy td', factHTML).text(fact.readableAccuracy());
             $('#dimensions', factHTML).empty();
-            for (const [key, aspect] of Object.entries(fact.aspects())) {
+            for (const aspect of fact.aspects()) {
                 if (!aspect.isTaxonomyDefined()) {
                     continue;
                 }

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -169,7 +169,7 @@ Inspector.prototype.factListRow = function(f) {
         .appendTo(row);
 
     for (const aspect of f.aspects()) {
-        if (aspect.isTaxonomyDefined()) {
+        if (aspect.isTaxonomyDefined() && !aspect.isNil()) {
             $('<div class="dimension"></div>')
                 .text(aspect.valueLabel())
                 .appendTo(row);
@@ -550,9 +550,12 @@ Inspector.prototype._selectionSummaryAccordian = function() {
                             .click(() => this._chart.analyseDimension(fact,[a]))
                     )
                 }
-                $('<div class="dimension-value"></div>')
+                var s = $('<div class="dimension-value"></div>')
                     .text(aspect.valueLabel())
                     .appendTo(h);
+                if (aspect.isNil()) {
+                    s.wrapInner("<i></i>");
+                }
             }
         }
         else if (fact instanceof Footnote) {

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -168,11 +168,12 @@ Inspector.prototype.factListRow = function(f) {
         .text(f.period().toString())
         .appendTo(row);
 
-    var dims = f.dimensions();
-    for (var d in dims) {
-        $('<div class="dimension"></div>')
-            .text(f.report().getLabel(dims[d], "std", true) || dims[d])
-            .appendTo(row);
+    for (const [key, aspect] of Object.entries(f.aspects())) {
+        if (aspect.isTaxonomyDefined()) {
+            $('<div class="dimension"></div>')
+                .text(aspect.valueLabel())
+                .appendTo(row);
+        }
     }
     if (f.isHidden()) {
         $('<div class="hidden">Hidden fact</div>')
@@ -534,21 +535,23 @@ Inspector.prototype._selectionSummaryAccordian = function() {
             this._updateValue(fact.readableValue(), false, factHTML);
             $('tr.accuracy td', factHTML).text(fact.readableAccuracy());
             $('#dimensions', factHTML).empty();
-            var dims = fact.dimensions();
-            for (var d in dims) {
+            for (const [key, aspect] of Object.entries(fact.aspects())) {
+                if (!aspect.isTaxonomyDefined()) {
+                    continue;
+                }
                 var h = $('<div class="dimension"></div>')
-                    .text(fact.report().getLabel(d, "std", true) || d)
+                    .text(aspect.label() || d)
                     .appendTo($('#dimensions', factHTML));
                 if (fact.isNumeric()) {
                     h.append(
                         $("<span></span>") 
                             .addClass("analyse")
                             .text("")
-                            .click(() => this._chart.analyseDimension(fact,[d]))
+                            .click(() => this._chart.analyseDimension(fact,[a]))
                     )
                 }
                 $('<div class="dimension-value"></div>')
-                    .text(fact.report().getLabel(dims[d], "std", true) || dims[d])
+                    .text(aspect.valueLabel())
                     .appendTo(h);
             }
         }

--- a/iXBRLViewerPlugin/viewer/src/js/search.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.js
@@ -35,7 +35,14 @@ ReportSearch.prototype.buildSearchIndex = function () {
         doc.startDate = f.periodFrom();
         var dims = f.dimensions();
         for (var d in dims) {
-            l += " " + this._report.getLabel(dims[d],"std");
+            if (this._report.getConcept(d).isTypedDimension) {
+                if (d !== null) {
+                    l += " " + d;
+                }
+            }
+            else {
+                l += " " + this._report.getLabel(dims[d],"std");
+            }
         }
         doc.label = l;
         doc.ref = f.concept().referenceValuesAsString();

--- a/iXBRLViewerPlugin/viewer/src/js/search.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.js
@@ -41,7 +41,7 @@ ReportSearch.prototype.buildSearchIndex = function () {
                 }
             }
             else {
-                l += " " + this._report.getLabel(dims[d],"std");
+                l += " " + this._report.getLabel(dims[d], "std");
             }
         }
         doc.label = l;
@@ -49,8 +49,8 @@ ReportSearch.prototype.buildSearchIndex = function () {
         const wider = f.widerConcepts();
         if (wider.length > 0) {
             doc.widerConcept = this._report.qname(wider[0]).localname;
-            doc.widerLabel = this._report.getLabel(wider[0],"std");
-            doc.widerDoc = this._report.getLabel(wider[0],"doc");
+            doc.widerLabel = this._report.getLabel(wider[0], "std");
+            doc.widerDoc = this._report.getLabel(wider[0], "doc");
         }
         docs.push(doc);
 

--- a/iXBRLViewerPlugin/viewer/src/js/search.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.js
@@ -36,7 +36,7 @@ ReportSearch.prototype.buildSearchIndex = function () {
         var dims = f.dimensions();
         for (var d in dims) {
             if (this._report.getConcept(d).isTypedDimension) {
-                if (d !== null) {
+                if (dims[d] !== null) {
                     l += " " + d;
                 }
             }

--- a/iXBRLViewerPlugin/viewer/src/js/search.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.js
@@ -37,7 +37,7 @@ ReportSearch.prototype.buildSearchIndex = function () {
         for (var d in dims) {
             if (this._report.getConcept(d).isTypedDimension) {
                 if (dims[d] !== null) {
-                    l += " " + d;
+                    l += " " + dims[d];
                 }
             }
             else {

--- a/iXBRLViewerPlugin/viewer/src/js/tableExport.js
+++ b/iXBRLViewerPlugin/viewer/src/js/tableExport.js
@@ -127,7 +127,7 @@ TableExport.prototype._getConstantAspectsForSlice = function (slice, aspects) {
         return null;
     }
     var allAspectsMap = {};
-    for (var i = 0; i < facts.length; i++) {
+    for (const fact of facts) {
         for (const a of fact.aspects()) {
             allAspectsMap[a.name()] = 1;
         }
@@ -139,7 +139,7 @@ TableExport.prototype._getConstantAspectsForSlice = function (slice, aspects) {
         var a = allAspects[i];
         constantAspects[a] = facts[0].aspect(a);
         for (var j = 1; j < facts.length; j++) {
-            if (constantAspects[a] === undefined || !constantAspects[a].equalTo(facts[j].aspects(a))) {
+            if (constantAspects[a] === undefined || !constantAspects[a].equalTo(facts[j].aspect(a))) {
                 delete constantAspects[a];
             }
         }

--- a/iXBRLViewerPlugin/viewer/src/js/tableExport.js
+++ b/iXBRLViewerPlugin/viewer/src/js/tableExport.js
@@ -128,9 +128,8 @@ TableExport.prototype._getConstantAspectsForSlice = function (slice, aspects) {
     }
     var allAspectsMap = {};
     for (var i = 0; i < facts.length; i++) {
-        var aa = Object.keys(facts[i].aspects());
-        for (var k = 0; k < aa.length; k++) {
-            allAspectsMap[aa[k]] = 1;
+        for (const a of fact.aspects()) {
+            allAspectsMap[a.name()] = 1;
         }
     }
     var allAspects = Object.keys(allAspectsMap);
@@ -138,9 +137,9 @@ TableExport.prototype._getConstantAspectsForSlice = function (slice, aspects) {
     var constantAspects = {};
     for (var i = 0; i < allAspects.length; i++) {
         var a = allAspects[i];
-        constantAspects[a] = facts[0].aspects()[a];
+        constantAspects[a] = facts[0].aspect(a);
         for (var j = 1; j < facts.length; j++) {
-            if (constantAspects[a] === undefined || !constantAspects[a].equalTo(facts[j].aspects()[a])) {
+            if (constantAspects[a] === undefined || !constantAspects[a].equalTo(facts[j].aspects(a))) {
                 delete constantAspects[a];
             }
         }


### PR DESCRIPTION
This adds support for typed dimensions in the viewer.

Typed dimensions were previously dropped silently and would not be shown in the inspector.  It would also result in facts that differed only in typed dimension values would be treated as duplicate facts.

Typed dimension values are now shown in the inspector.  nil-valued typed dimensions are shown with a value of  `<nil>`