### PR TITLE
XT-1032 - Remove unused variable

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -558,7 +558,7 @@ Inspector.prototype._selectionSummaryAccordian = function() {
                     continue;
                 }
                 var h = $('<div class="dimension"></div>')
-                    .text(aspect.label() || d)
+                    .text(aspect.label())
                     .appendTo($('#dimensions', factHTML));
                 if (fact.isNumeric()) {
                     h.append(


### PR DESCRIPTION
#### Description:
- A bug was introduced that prohibits the inspector from properly showing facts because an unused variable was not assigned at runtime. This PR removes that variable.

#### Testing:
- Work with Derek to show that it actually works

**review**:
@Workiva/xt
