### PR TITLE
XT-1029 - Add better conditionals so that empty members fall through

### DIFF
--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -241,13 +241,13 @@ class IXBRLViewerBuilder:
                     factData["d"] = d
 
             for d, v in f.context.qnameDims.items():
-                if v.memberQname is None and v.typedMember is not None:
-                    aspects[self.nsmap.qname(v.dimensionQname)] = v.typedMember.text
-                    self.addConcept(v.dimension, dimensionType = "t")
-                elif v.memberQname is not None:
+                if v.memberQname is not None:
                     aspects[self.nsmap.qname(v.dimensionQname)] = self.nsmap.qname(v.memberQname)
                     self.addConcept(v.member)
                     self.addConcept(v.dimension, dimensionType = "e")
+                elif v.typedMember is not None:
+                    aspects[self.nsmap.qname(v.dimensionQname)] = v.typedMember.text
+                    self.addConcept(v.dimension, dimensionType = "t")
 
             if f.context.isForeverPeriod:
                 aspects["p"] = "f"

--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -241,10 +241,10 @@ class IXBRLViewerBuilder:
                     factData["d"] = d
 
             for d, v in f.context.qnameDims.items():
-                if v.memberQname is None:
+                if v.memberQname is None and v.typedMember is not None:
                     aspects[self.nsmap.qname(v.dimensionQname)] = v.typedMember.text
                     self.addConcept(v.dimension, dimensionType = "t")
-                else:
+                elif v.memberQname is not None:
                     aspects[self.nsmap.qname(v.dimensionQname)] = self.nsmap.qname(v.memberQname)
                     self.addConcept(v.member)
                     self.addConcept(v.dimension, dimensionType = "e")

--- a/tests/unit_tests/iXBRLViewerPlugin/test_iXBRLViewer.py
+++ b/tests/unit_tests/iXBRLViewerPlugin/test_iXBRLViewer.py
@@ -143,6 +143,19 @@ class TestIXBRLViewer(unittest.TestCase):
             member=member_concept
         )
 
+        typed_dimension = Mock(
+            dimensionQname=dimension_concept.qname,
+            memberQname=None,
+            dimension=dimension_concept,
+            typedMember=Mock(text='typedDimension')
+        )
+
+        dimension_missing_member = Mock(
+            dimensionQname=dimension_concept.qname,
+            memberQname=None,
+            dimension=dimension_concept
+        )
+
         def isoformat_effect():
             return '01-01-19T00:00:00'
 
@@ -160,6 +173,24 @@ class TestIXBRLViewer(unittest.TestCase):
             qnameDims={},
             isInstantPeriod=None,
             isStartEndPeriod=None
+        )
+
+        context_with_typed_dimension = Mock(
+            entityIdentifier=('scheme', 'ident'),
+            qnameDims={'d': typed_dimension},
+            isInstantPeriod=False,
+            isStartEndPeriod=True,
+            startDatetime=Mock(isoformat=isoformat_effect),
+            endDatetime=Mock(isoformat=isoformat_effect)
+        )
+
+        context_with_missing_member_on_dimension = Mock(
+            entityIdentifier=('scheme', 'ident'),
+            qnameDims={'d': dimension_missing_member},
+            isInstantPeriod=False,
+            isStartEndPeriod=True,
+            startDatetime=Mock(isoformat=isoformat_effect),
+            endDatetime=Mock(isoformat=isoformat_effect)
         )
 
         fact_1 = Mock(
@@ -183,6 +214,26 @@ class TestIXBRLViewer(unittest.TestCase):
             decimals=None,
             precision=None,
             format=None
+        )
+
+        fact_with_typed_dimension = Mock(
+            id='fact_typed_dimension',
+            qname=self.cash_concept.qname,
+            value=10,
+            isNumeric=False,
+            context=context_with_typed_dimension,
+            concept=self.cash_concept,
+            format='format'
+        )
+
+        fact_with_missing_member_on_dimension = Mock(
+            id='fact_dimension_missing_member',
+            qname=self.cash_concept.qname,
+            value=1000,
+            isNumeric=False,
+            context=context_with_missing_member_on_dimension,
+            concept=self.cash_concept,
+            format='format'
         )
 
         def fromModelObjects_effect(concept):
@@ -217,7 +268,7 @@ class TestIXBRLViewer(unittest.TestCase):
             relationshipSets={},
             baseSets=baseSets,
             roleTypes=roleTypes,
-            facts=[fact_1],
+            facts=[fact_1, fact_with_typed_dimension, fact_with_missing_member_on_dimension],
             info=info_effect,
             modelDocument=self.modelDocument
         )

--- a/tests/unit_tests/iXBRLViewerPlugin/test_iXBRLViewer.py
+++ b/tests/unit_tests/iXBRLViewerPlugin/test_iXBRLViewer.py
@@ -153,7 +153,8 @@ class TestIXBRLViewer(unittest.TestCase):
         dimension_missing_member = Mock(
             dimensionQname=dimension_concept.qname,
             memberQname=None,
-            dimension=dimension_concept
+            dimension=dimension_concept,
+            typedMember=None
         )
 
         def isoformat_effect():


### PR DESCRIPTION
#### Description: 
There is a scenario in which the ixbrl viewer fails with the new typed dimension code. If a member of a dimension/member pair is left empty the code currently assumes it must be a typed dimension. This was a wrong assumption and has been updated.

#### Testing:
CI

**review**:
@Workiva/xt