### PR TITLE
Fix for handling units with no measures (XT-831)

### DIFF
--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -226,7 +226,7 @@ class IXBRLViewerBuilder:
                 factData["f"] = str(f.format)
 
             if f.isNumeric:
-                if f.unit is not None:
+                if f.unit is not None and len(f.unit.measures[0]):
                     # XXX does not support complex units
                     unit = self.nsmap.qname(f.unit.measures[0][0])
                     aspects["u"] = unit


### PR DESCRIPTION
This fixes a bug whereby a fact with units that has no measures associated with it would result in a Python exception when generating a viewer.

The viewer is now created with null units, which is rendered as `<NO UNIT>`

![image](https://user-images.githubusercontent.com/45077928/100028343-9de9b800-2de6-11eb-94ee-106d623cce44.png)
