### PR TITLE
Reintroduce fallback for taxonomy defined dimensions with missing labels

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -558,7 +558,7 @@ Inspector.prototype._selectionSummaryAccordian = function() {
                     continue;
                 }
                 var h = $('<div class="dimension"></div>')
-                    .text(aspect.label())
+                    .text(aspect.label() || aspect.name())
                     .appendTo($('#dimensions', factHTML));
                 if (fact.isNumeric()) {
                     h.append(


### PR DESCRIPTION
If a dimension doesn't have a label, the viewer should fallback on the element name.

This got broken by #153 which referenced an uninitialised variable.  The uninitialised variable was removed in #163, but this also removed the fallback behaviour.  This PR reintroduces the fallback with the correct value. 