### PR TITLE
Fix "no fact selected" mask

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -27,7 +27,7 @@ limitations under the License.
         <b>Highlight:</b><span class="content"></span>
     </div>
   </div>
-  <div id="inspector">
+  <div id="inspector" class="no-fact-selected">
     <div id="inspector-head">
       <div class="title">
         <h1 class="footnote-mode-off">Fact Properties</h1>

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -683,7 +683,6 @@ Inspector.prototype.switchItem = function (id) {
         this._viewer.clearHighlighting();
     }
     this.update();
-    this.update();
 }
 
 Inspector.prototype.selectDefaultLanguage = function () {


### PR DESCRIPTION
This PR re-instates the "no fact selected"  mask which should be shown when the viewer is first loaded (unless a fact ID is provided in the URL fragment).