### PR TITLE
Update "no prior fact" wording

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -470,7 +470,7 @@ Inspector.prototype.getPeriodIncrease = function (fact) {
 
         }
         else {
-            s = $("<i>").text("No prior fact");
+            s = $("<i>").text("No prior fact in this report");
         }
     }
     else {


### PR DESCRIPTION
This PR changes the wording displayed when no comparative data is shown because no fact with an earlier period exists in the report.

"No prior fact" is changed to "No prior fact in this report" to clarify that the comparative data is drawn only from the current report.

![image](https://user-images.githubusercontent.com/45077928/108766122-a8822d80-754c-11eb-81ac-e07bbc0e9290.png)
