### PR TITLE
XT-1255 Format fact with commas and decimals when accuracy is inf

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -16,7 +16,7 @@ import { isodateToHuman } from "./util.js"
 import { QName } from "./qname.js"
 import { Aspect } from "./aspect.js";
 import { Period } from './period.js';
-import { formatNumber } from "./util.js";
+import { formatNumber, numberWithCommas } from "./util.js";
 import { Footnote } from "./footnote.js";
 import $ from 'jquery'
 
@@ -77,7 +77,7 @@ Fact.prototype.readableValue = function() {
             formattedNumber = "nil";
         }
         else if (d === undefined) {
-            formattedNumber = formatNumber(v,0);
+            formattedNumber = numberWithCommas(v);
         }
         else {
             if (d < 0) {

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -77,7 +77,7 @@ Fact.prototype.readableValue = function() {
             formattedNumber = "nil";
         }
         else if (d === undefined) {
-            formattedNumber = v;
+            formattedNumber = formatNumber(v,0);
         }
         else {
             if (d < 0) {

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -16,7 +16,7 @@ import { isodateToHuman } from "./util.js"
 import { QName } from "./qname.js"
 import { Aspect } from "./aspect.js";
 import { Period } from './period.js';
-import { formatNumber, numberWithCommas } from "./util.js";
+import { formatNumber } from "./util.js";
 import { Footnote } from "./footnote.js";
 import $ from 'jquery'
 
@@ -76,13 +76,7 @@ Fact.prototype.readableValue = function() {
         if (this.isNil()) {
             formattedNumber = "nil";
         }
-        else if (d === undefined) {
-            formattedNumber = numberWithCommas(v);
-        }
         else {
-            if (d < 0) {
-                d = 0;
-            }
             formattedNumber = formatNumber(v,d);
         }
         if (this.isMonetaryValue()) {

--- a/iXBRLViewerPlugin/viewer/src/js/fact.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.test.js
@@ -121,17 +121,17 @@ describe("Simple fact properties", () => {
 
     test("Numeric (infinite precision)", () => {
         var f = testFact({
-                "v": 0.0125,
+                "v": 1000000.0125,
                 "a": {
                     "c": "eg:Concept1",
                     "u": "eg:USD", 
                     "p": "2018-01-01/2019-01-01",
                 }});
-        expect(f.value()).toEqual(0.0125);
+        expect(f.value()).toEqual(1000000.0125);
         expect(f.decimals()).toBeUndefined();
         expect(f.isNumeric()).toBeTruthy();
         expect(f.isMonetaryValue()).toBeFalsy();
-        expect(f.readableValue()).toEqual("0.0125 eg:USD");
+        expect(f.readableValue()).toEqual("1,000,000.0125 eg:USD");
         expect(f.unit().value()).toEqual("eg:USD");
         expect(f.conceptQName().prefix).toEqual("eg");
         expect(f.conceptQName().localname).toEqual("Concept1");

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.test.js
@@ -96,13 +96,13 @@ describe("Describe changes", () => {
     });
 
     test("Sign changes", () => {
-        expect(insp.describeChange(fromFact(1000), toFact(-1000))).toBe("From US $ 1000 in ");
-        expect(insp.describeChange(fromFact(-1000000), toFact(1000))).toBe("From US $ -1000000 in ");
+        expect(insp.describeChange(fromFact(1000), toFact(-1000))).toBe("From US $ 1,000 in ");
+        expect(insp.describeChange(fromFact(-1000000), toFact(1000))).toBe("From US $ -1,000,000 in ");
     });
 
     test("From/to zero", () => {
         expect(insp.describeChange(fromFact(0), toFact(1000))).toBe("From US $ 0 in ");
         expect(insp.describeChange(fromFact(0), toFact(0))).toBe("From US $ 0 in ");
-        expect(insp.describeChange(fromFact(1000), toFact(0))).toBe("From US $ 1000 in ");
+        expect(insp.describeChange(fromFact(1000), toFact(0))).toBe("From US $ 1,000 in ");
     });
 });

--- a/iXBRLViewerPlugin/viewer/src/js/util.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.js
@@ -36,6 +36,13 @@ export function momentToHuman(d, adjust) {
 }
 
 /*
+ * Format a number with a thousands separator, infinite decimal places
+ */
+export function numberWithCommas(v) {
+    return Number(v).toString().replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ",");
+}
+
+/*
  * Format a number with a thousands separator, and the specified number of
  * decimal places.
  */

--- a/iXBRLViewerPlugin/viewer/src/js/util.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.js
@@ -36,18 +36,13 @@ export function momentToHuman(d, adjust) {
 }
 
 /*
- * Format a number with a thousands separator, infinite decimal places
- */
-export function numberWithCommas(v) {
-    return Number(v).toString().replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ",");
-}
-
-/*
  * Format a number with a thousands separator, and the specified number of
  * decimal places.
  */
 export function formatNumber(v, d) {
-    return Number(v).toFixed(d).replace(/(\d)(?=(\d{3})+(?:\.\d+)?$)/g, '$1,');
+    var n = Number(v);
+    var s = d === undefined ? n.toString() : n.toFixed(Math.max(0, d));
+    return s.replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ",");
 }
 
 /* 


### PR DESCRIPTION
### Description
No commas were being added when a fact value was set to infinite precision. This adjusts the code to format inf accuracy facts

| Current | Previous |
|---------|----------|
| <img width="419" alt="Screen Shot 2021-03-11 at 2 29 03 PM" src="https://user-images.githubusercontent.com/17255946/110857954-b804b480-8276-11eb-9d34-b2fd8b3b0c53.png"> |<img width="419" alt="Screen Shot 2021-03-11 at 2 29 16 PM" src="https://user-images.githubusercontent.com/17255946/110857942-b3400080-8276-11eb-8008-557eed762f84.png">  |

### Testing Steps
1. Create a doc with a fact that has a value large enough to have commas inserted
2. Set the fact accuracy to INF
3. Generate
4. Open the preview and verify that there are no commas in the fact value
5. Deploy this build
6. Regenerate
7. Open the preview and verify that there are now commas in the fact value

### Review
@Workiva/xt  



