### PR TITLE
Fix scrolling to show selected elements on documents with scrollable divs

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
@@ -113,8 +113,10 @@ iXBRLViewer.prototype._reparentDocument = function () {
     const iframeBody = $(iframe).contents().find('body');
     $('body').children().not("script").not('#ixv').not(iframeContainer).appendTo(iframeBody);
 
-    for (const bodyAttr of $('body').prop("attributes")) {
+    /* Move all attributes on the body tag to the new body */
+    for (const bodyAttr of [...$('body').prop("attributes")]) {
         iframeBody.attr(bodyAttr.name, bodyAttr.value); 
+        $('body').removeAttr(bodyAttr.name);
     }
 
     /* Avoid any inline styles on the old body interfering with the inspector */

--- a/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
@@ -110,7 +110,12 @@ iXBRLViewer.prototype._reparentDocument = function () {
     /* Due to self-closing tags, our script tags may not be a direct child of
      * the body tag in an HTML DOM, so move them so that they are */
     $('body script').appendTo($('body'));
-    $('body').children().not("script").not('#ixv').not(iframeContainer).appendTo($(iframe).contents().find('body'));
+    const iframeBody = $(iframe).contents().find('body');
+    $('body').children().not("script").not('#ixv').not(iframeContainer).appendTo(iframeBody);
+
+    for (const bodyAttr of $('body').prop("attributes")) {
+        iframeBody.attr(bodyAttr.name, bodyAttr.value); 
+    }
 
     /* Avoid any inline styles on the old body interfering with the inspector */
     $('body').removeAttr('style');

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -286,10 +286,13 @@ Viewer.prototype.showElement = function(e) {
     /* offsetTop gives the position relative to the nearest positioned element.
      * Scrollable elements are not necessarily positioned. */
     var ee = e.get(0);
+    while (ee.offsetParent === null && ee.parentElement !== null) {
+        ee = ee.parentElement;
+    }
     var lastPositionedElement = ee;
     var currentChild = ee;
     var childOffset = ee.offsetTop;
-    /* Iterate through ancestors looking for scrollable or position element */
+    /* Iterate through ancestors looking for scrollable or positioned element */
     while (ee.parentElement !== null) {
         ee = ee.parentElement;
         if (ee == lastPositionedElement.offsetParent) {

--- a/samples/src/scrollable-div/scrollable-div.html
+++ b/samples/src/scrollable-div/scrollable-div.html
@@ -1,0 +1,392 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html 
+    xmlns="http://www.w3.org/1999/xhtml" 
+    xmlns:iso4217="http://www.xbrl.org/2003/iso4217" xmlns:xbrli="http://www.xbrl.org/2003/instance" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:link="http://www.xbrl.org/2003/linkbase" xmlns:ix="http://www.xbrl.org/2013/inlineXBRL" xmlns:ixt="http://www.xbrl.org/inlineXBRL/transformation/2011-07-31" xmlns:xbrldi="http://xbrl.org/2006/xbrldi" xmlns:ifrs="http://xbrl.ifrs.org/taxonomy/2017-03-09/ifrs-full"
+>
+    <head>
+        <title>iXBRL Viewer Test Document</title>
+        <style type="text/css">
+            .time-series td { 
+                padding: 5px;
+            }
+            table.accounts td,
+            table.accounts th {
+                padding: 5px;
+            }
+            td.figure {
+                text-align: right;
+            }
+            .top-border td.figure {
+                border-top: solid 1px #000;
+            }
+            .bottom-border td.figure {
+                border-bottom: solid 1px #000;
+            }
+        </style>
+    </head>
+    <body xmlns="http://www.w3.org/1999/xhtml" style="margin: 0">
+        <div style="display: none">
+            <ix:header>
+    <ix:references>
+        
+        <link:schemaRef xlink:type="simple" xlink:href="http://xbrl.ifrs.org/taxonomy/2017-03-09/full_ifrs_entry_point_2017-03-09-es.xsd" />
+        
+        <link:schemaRef xlink:type="simple" xlink:href="http://xbrl.ifrs.org/taxonomy/2017-03-09/full_ifrs_doc_entry_point_2017-03-09.xsd" />
+        
+    </ix:references>
+    <ix:resources>
+      
+        <xbrli:unit id="u1"><xbrli:measure>iso4217:GBP</xbrli:measure></xbrli:unit>
+      
+      
+        <xbrli:context id="c1">
+          <xbrli:entity>
+              <xbrli:identifier scheme="http://www.example.com/1234">1234</xbrli:identifier>
+              
+          </xbrli:entity>
+          <xbrli:period> 
+            
+                <xbrli:startDate>2018-01-01</xbrli:startDate>
+                <xbrli:endDate>2018-12-31</xbrli:endDate>
+            
+          </xbrli:period>
+          
+
+        </xbrli:context>
+      
+        <xbrli:context id="c2">
+          <xbrli:entity>
+              <xbrli:identifier scheme="http://www.example.com/1234">1234</xbrli:identifier>
+              
+          </xbrli:entity>
+          <xbrli:period> 
+            
+                <xbrli:startDate>2017-01-01</xbrli:startDate>
+                <xbrli:endDate>2017-12-31</xbrli:endDate>
+            
+          </xbrli:period>
+          
+
+        </xbrli:context>
+      
+        <xbrli:context id="c3">
+          <xbrli:entity>
+              <xbrli:identifier scheme="http://www.example.com/1234">1234</xbrli:identifier>
+              
+          </xbrli:entity>
+          <xbrli:period> 
+            
+                
+                <xbrli:instant>2018-12-31</xbrli:instant>
+                
+            
+          </xbrli:period>
+          
+
+        </xbrli:context>
+      
+        <xbrli:context id="c4">
+          <xbrli:entity>
+              <xbrli:identifier scheme="http://www.example.com/1234">1234</xbrli:identifier>
+              
+          </xbrli:entity>
+          <xbrli:period> 
+            
+                
+                <xbrli:instant>2017-12-31</xbrli:instant>
+                
+            
+          </xbrli:period>
+          
+
+        </xbrli:context>
+      
+        <xbrli:context id="c5">
+          <xbrli:entity>
+              <xbrli:identifier scheme="http://www.example.com/1234">1234</xbrli:identifier>
+              
+          </xbrli:entity>
+          <xbrli:period> 
+            
+                <xbrli:startDate>2018-01-01</xbrli:startDate>
+                <xbrli:endDate>2018-12-31</xbrli:endDate>
+            
+          </xbrli:period>
+          
+
+        </xbrli:context>
+      
+        <xbrli:context id="c6">
+          <xbrli:entity>
+              <xbrli:identifier scheme="http://www.example.com/1234">1234</xbrli:identifier>
+              
+          </xbrli:entity>
+          <xbrli:period> 
+            
+                <xbrli:startDate>2017-01-01</xbrli:startDate>
+                <xbrli:endDate>2017-12-31</xbrli:endDate>
+            
+          </xbrli:period>
+          
+
+        </xbrli:context>
+      
+        <xbrli:context id="c7">
+          <xbrli:entity>
+              <xbrli:identifier scheme="http://www.example.com/1234">1234</xbrli:identifier>
+              
+          </xbrli:entity>
+          <xbrli:period> 
+            
+                <xbrli:startDate>2016-01-01</xbrli:startDate>
+                <xbrli:endDate>2016-12-31</xbrli:endDate>
+            
+          </xbrli:period>
+          
+
+        </xbrli:context>
+      
+        <xbrli:context id="c8">
+          <xbrli:entity>
+              <xbrli:identifier scheme="http://www.example.com/1234">1234</xbrli:identifier>
+              
+          </xbrli:entity>
+          <xbrli:period> 
+            
+                <xbrli:startDate>2015-01-01</xbrli:startDate>
+                <xbrli:endDate>2015-12-31</xbrli:endDate>
+            
+          </xbrli:period>
+          
+
+        </xbrli:context>
+      
+        <xbrli:context id="c9">
+          <xbrli:entity>
+              <xbrli:identifier scheme="http://www.example.com/1234">1234</xbrli:identifier>
+              
+          </xbrli:entity>
+          <xbrli:period> 
+            
+                <xbrli:startDate>2014-01-01</xbrli:startDate>
+                <xbrli:endDate>2014-12-31</xbrli:endDate>
+            
+          </xbrli:period>
+          
+
+        </xbrli:context>
+      
+        <xbrli:context id="c10">
+          <xbrli:entity>
+              <xbrli:identifier scheme="http://www.example.com/1234">1234</xbrli:identifier>
+              
+          </xbrli:entity>
+          <xbrli:period> 
+            
+                <xbrli:startDate>2013-01-01</xbrli:startDate>
+                <xbrli:endDate>2013-12-31</xbrli:endDate>
+            
+          </xbrli:period>
+          
+
+        </xbrli:context>
+      
+        <xbrli:context id="c11">
+          <xbrli:entity>
+              <xbrli:identifier scheme="http://www.example.com/1234">1234</xbrli:identifier>
+              
+          </xbrli:entity>
+          <xbrli:period> 
+            
+                <xbrli:startDate>2018-09-01</xbrli:startDate>
+                <xbrli:endDate>2018-12-31</xbrli:endDate>
+            
+          </xbrli:period>
+          
+
+        </xbrli:context>
+      
+        <xbrli:context id="c12">
+          <xbrli:entity>
+              <xbrli:identifier scheme="http://www.example.com/1234">1234</xbrli:identifier>
+              
+          </xbrli:entity>
+          <xbrli:period> 
+            
+                <xbrli:startDate>2017-09-01</xbrli:startDate>
+                <xbrli:endDate>2017-12-31</xbrli:endDate>
+            
+          </xbrli:period>
+          
+
+        </xbrli:context>
+      
+    </ix:resources>
+</ix:header>
+        </div>
+
+
+        <div style="height: 100vh; overflow-y: auto; padding: 10px; box-sizing: border-box">
+
+        <p>
+<ix:nonNumeric name="ifrs:ConcentrationsOfRisk" contextRef="c1"  id="f1" >This is a text tag </ix:nonNumeric>
+        </p>
+        <p>
+<ix:nonNumeric name="ifrs:ChangesInExposureToRisk" contextRef="c1"  id="f2" >Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Phasellus egestas tellus rutrum tellus pellentesque eu tincidunt. Mauris rhoncus aenean vel elit. Turpis cursus in hac habitasse platea dictumst. Nulla porttitor massa id neque aliquam vestibulum morbi. At erat pellentesque adipiscing commodo elit at imperdiet dui  In egestas erat imperdiet sed euismod nisi porta lorem mollis. Ac ut consequat semper viverra nam. Sed ullamcorper morbi tincidunt ornare massa eget egestas purus. Risus ultricies tristique nulla aliquet. Pellentesque habitant morbi tristique senectus et. Ultrices neque ornare aenean euismod elementum nisi quis eleifend. </ix:nonNumeric>
+        </p>
+        <p>
+Profit Loss: <ix:nonFraction name="ifrs:ProfitLoss" contextRef="c1" unitRef="u1"  id="f3"  format="ixt:numdotdecimal" decimals="0">1234</ix:nonFraction>
+        </p>
+        <p>
+Profit Loss double tagged: <ix:nonFraction name="ifrs:ProfitLoss" contextRef="c1" unitRef="u1"  id="f4"  format="ixt:numdotdecimal" decimals="0"><ix:nonFraction name="ifrs:ProfitLoss" contextRef="c2" unitRef="u1"  id="f5"  format="ixt:numdotdecimal" decimals="0">1234</ix:nonFraction></ix:nonFraction>
+        </p>
+        <p>
+<ix:nonNumeric name="ifrs:DescriptionOfExposureToRisk" contextRef="c1"  id="f6" >Mattis rhoncus urna neque viverra justo nec ultrices. Amet tellus cras adipiscing enim. Sed arcu non odio euismod lacinia at. Odio euismod lacinia at quis risus sed vulputate odio. Ac odio tempor orci dapibus. In hac habitasse platea dictumst vestibulum rhoncus est pellentesque. Quis risus sed vulputate odio ut enim. Adipiscing commodo elit at imperdiet dui accumsan sit. Quis vel eros donec ac odio tempor orci dapibus. Turpis nunc eget lorem dolor. Dui nunc mattis enim ut tellus elementum sagittis vitae et. Facilisis sed odio morbi quis commodo. Vitae auctor eu augue ut lectus arcu. <b>Embedded fact:</b> <ix:nonFraction name="ifrs:Goodwill" contextRef="c3" unitRef="u1"  id="f7"  format="ixt:numdotdecimal" decimals="0">1,234,576</ix:nonFraction> Iaculis nunc sed augue lacus viverra vitae congue eu consequat. Neque sodales ut etiam sit amet nisl. Dictum sit amet justo donec enim diam vulputate ut. A diam maecenas sed enim ut sem. Nisl nisi scelerisque eu ultrices vitae auctor. Purus semper eget duis at tellus at. Vehicula ipsum a arcu cursus vitae congue mauris rhoncus. </ix:nonNumeric>
+        </p>
+        <h3>Table formatting</h3>
+        
+        <table>
+            <tr>
+                <td style="padding: 15px">Element in span with no other content</td>
+                <td style="padding: 15px"><span><ix:nonFraction name="ifrs:DeferredTaxAssets" contextRef="c3" unitRef="u1"  id="f8"  format="ixt:numdotdecimal" decimals="0">761,123</ix:nonFraction></span></td>
+                <td style="padding: 15px">(<ix:nonFraction name="ifrs:DeferredTaxAssets" contextRef="c4" unitRef="u1"  id="f9"  format="ixt:numdotdecimal" decimals="0" sign="-">461,123</ix:nonFraction>)</td>
+            </tr>
+            <tr>
+                <td style="padding: 15px">Other HTML present - cell highlighting OK</td>
+                <td style="padding: 15px">$(<span><ix:nonFraction name="ifrs:DeferredTaxAssets" contextRef="c3" unitRef="u1"  id="f10"  format="ixt:numdotdecimal" decimals="0">761,123</ix:nonFraction></span>)</td>
+                <td style="padding: 15px"><span style="font-weight: bold">&#163;</span><i>(<ix:nonFraction name="ifrs:DeferredTaxAssets" contextRef="c4" unitRef="u1"  id="f11"  format="ixt:numdotdecimal" decimals="0" sign="-">461,123</ix:nonFraction>)</i></td>
+            </tr>
+            <tr>
+                <td style="padding: 15px">Other alpha numeric content present - cell highlighting not OK</td>
+                <td style="padding: 15px"><span><ix:nonFraction name="ifrs:DeferredTaxAssets" contextRef="c3" unitRef="u1"  id="f12"  format="ixt:numdotdecimal" decimals="0">761,123</ix:nonFraction></span> <span><ix:nonFraction name="ifrs:DeferredTaxAssets" contextRef="c3" unitRef="u1"  id="f13"  format="ixt:numdotdecimal" decimals="0">761,123</ix:nonFraction></span></td>
+                <td style="padding: 15px"><span style="font-weight: bold">GBP</span><i>(<ix:nonFraction name="ifrs:DeferredTaxAssets" contextRef="c4" unitRef="u1"  id="f14"  format="ixt:numdotdecimal" decimals="0" sign="-">461,123</ix:nonFraction>)</i></td>
+            </tr>
+            <tr>
+                <td style="padding: 5px">Border via style attribute</td>
+                <td style="border-bottom: solid 1px #000; padding: 15px"><ix:nonFraction name="ifrs:PropertyPlantAndEquipment" contextRef="c3" unitRef="u1"  id="f15"  format="ixt:numdotdecimal" decimals="0">761,123</ix:nonFraction></td>
+                <td style="border-bottom: solid 1px #000; padding: 15px"><ix:nonFraction name="ifrs:PropertyPlantAndEquipment" contextRef="c4" unitRef="u1"  id="f16"  format="ixt:numdotdecimal" decimals="0">461,123</ix:nonFraction></td>
+            </tr>
+            <tr>
+                <td style="padding: 15px">Double border </td>
+                <td style="border-bottom: double 3px #000; padding: 15px"><ix:nonFraction name="ifrs:PropertyPlantAndEquipment" contextRef="c3" unitRef="u1"  id="f17"  format="ixt:numdotdecimal" decimals="0">761,123</ix:nonFraction></td>
+                <td style="border-bottom: double 3px #000; padding: 5px"><ix:nonFraction name="ifrs:PropertyPlantAndEquipment" contextRef="c4" unitRef="u1"  id="f18"  format="ixt:numdotdecimal" decimals="0">461,123</ix:nonFraction></td>
+            </tr>
+            <tr>
+                <td style="padding: 15px">Background colour</td>
+                <td style="border-bottom: solid 1px #000; padding: 15px; background-color: #f70;"><ix:nonFraction name="ifrs:PropertyPlantAndEquipment" contextRef="c3" unitRef="u1"  id="f19"  format="ixt:numdotdecimal" decimals="0">761,123</ix:nonFraction></td>
+                <td style="border-bottom: solid 1px #000 !important; padding: 5px; background-color: #f70;"><ix:nonFraction name="ifrs:PropertyPlantAndEquipment" contextRef="c4" unitRef="u1"  id="f20"  format="ixt:numdotdecimal" decimals="0">461,123</ix:nonFraction></td>
+            </tr>
+
+        </table>
+    
+        <h3>Styled via inline stylesheet</h3>
+
+        <table class="time-series">
+            
+            
+            
+            <tr ><td >2018</td><td ><ix:nonFraction name="ifrs:CostOfSales" contextRef="c5" unitRef="u1"  id="f22"  format="ixt:numdotdecimal" decimals="0">9,000</ix:nonFraction></td></tr>
+
+            <tr ><td >2017</td><td ><ix:nonFraction name="ifrs:CostOfSales" contextRef="c6" unitRef="u1"  id="f24"  format="ixt:numdotdecimal" decimals="0">8,750</ix:nonFraction></td></tr>
+
+            <tr ><td >2016</td><td ><ix:nonFraction name="ifrs:CostOfSales" contextRef="c7" unitRef="u1"  id="f26"  format="ixt:numdotdecimal" decimals="0">6,750</ix:nonFraction></td></tr>
+
+            <tr ><td >2015</td><td ><ix:nonFraction name="ifrs:CostOfSales" contextRef="c8" unitRef="u1"  id="f28"  format="ixt:numdotdecimal" decimals="0">6,500</ix:nonFraction></td></tr>
+
+            <tr ><td >2014</td><td ><ix:nonFraction name="ifrs:CostOfSales" contextRef="c9" unitRef="u1"  id="f30"  format="ixt:numdotdecimal" decimals="0">6,509</ix:nonFraction></td></tr>
+
+            <tr ><td >2013</td><td ><ix:nonFraction name="ifrs:CostOfSales" contextRef="c10" unitRef="u1"  id="f32"  format="ixt:numdotdecimal" decimals="0">5,336</ix:nonFraction></td></tr>
+
+        </table>
+
+
+        <h3>Table export test</h3>
+
+        <p>The table below cannot be represented using the intersection of row and column aspects.</p>
+
+        <table class="accounts">
+            
+            
+
+            <thead>
+                <tr>
+                    <th></th>
+                    <th>2018</th>
+                    <th>2017</th>
+                </tr>
+            </thead>
+            <tbody>
+<tr ><td >Surplus</td><td class="figure" ><ix:nonFraction name="ifrs:ProfitLoss" contextRef="c5" unitRef="u1"  id="f34"  format="ixt:numdotdecimal" decimals="0">252,867</ix:nonFraction></td><td class="figure" ><ix:nonFraction name="ifrs:ProfitLoss" contextRef="c6" unitRef="u1"  id="f35"  format="ixt:numdotdecimal" decimals="0">14,736</ix:nonFraction></td></tr>
+
+<tr ><td >Amortization and depreciation expense</td><td class="figure" ><ix:nonFraction name="ifrs:AdjustmentsForDepreciationAndAmortisationExpense" contextRef="c5" unitRef="u1"  id="f37"  format="ixt:numdotdecimal" decimals="0">214,955</ix:nonFraction></td><td class="figure" ><ix:nonFraction name="ifrs:AdjustmentsForDepreciationAndAmortisationExpense" contextRef="c6" unitRef="u1"  id="f38"  format="ixt:numdotdecimal" decimals="0">165,030</ix:nonFraction></td></tr>
+
+            <tr>
+                <td>Manual row (periods swapped)</td>
+                <td class="figure"><ix:nonFraction name="ifrs:ProfitLoss" contextRef="c6" unitRef="u1"  id="f39"  format="ixt:numdotdecimal" decimals="0">14,736</ix:nonFraction></td>
+                <td class="figure"><ix:nonFraction name="ifrs:ProfitLoss" contextRef="c5" unitRef="u1"  id="f40"  format="ixt:numdotdecimal" decimals="0">252,867</ix:nonFraction></td>
+            </tr>
+<tr ><td >Increase (decrease) of provisions</td><td class="figure" ><ix:nonFraction name="ifrs:AdjustmentsForProvisions" contextRef="c5" unitRef="u1"  id="f42"  format="ixt:numdotdecimal" decimals="0">27,174</ix:nonFraction></td><td class="figure" ><ix:nonFraction name="ifrs:AdjustmentsForProvisions" contextRef="c6" unitRef="u1"  id="f43"  format="ixt:numdotdecimal" decimals="0">19,596</ix:nonFraction></td></tr>
+
+<tr class="top-border" ><td >Financial income/expense</td><td class="figure" ><ix:nonFraction name="ifrs:AdjustmentsForFinanceIncomeCost" contextRef="c5" unitRef="u1"  id="f45"  format="ixt:numdotdecimal" decimals="0" sign="-">300</ix:nonFraction></td><td class="figure" >-<ix:nonFraction name="ifrs:AdjustmentsForFinanceIncomeCost" contextRef="c6" unitRef="u1"  id="f46"  format="ixt:numdotdecimal" decimals="0">479</ix:nonFraction></td></tr>
+
+<tr class="bottom-border" ><td >Cash flow from operating activities</td><td class="figure" >-<ix:nonFraction name="ifrs:CashFlowsFromUsedInOperatingActivities" contextRef="c5" unitRef="u1"  id="f48"  format="ixt:numdotdecimal" decimals="0" sign="-">1,765,126</ix:nonFraction></td><td class="figure" ><ix:nonFraction name="ifrs:CashFlowsFromUsedInOperatingActivities" contextRef="c6" unitRef="u1"  id="f49"  format="ixt:numdotdecimal" decimals="0">1,648,790</ix:nonFraction></td></tr>
+
+            </tbody>
+        
+
+        </table>
+
+        <h3>Decimals/precision tests</h3>
+
+        <table class="accounts">
+            
+            
+            <tbody>
+            <tr ><td >Decimals = -3</td><td class="figure" ><ix:nonFraction name="ifrs:ProfitLoss" contextRef="c5" unitRef="u1"  id="f51"  format="ixt:numdotdecimal" decimals="-3">137,000</ix:nonFraction></td></tr>
+
+            <tr ><td >Decimals = 2</td><td class="figure" ><ix:nonFraction name="ifrs:ProfitLoss" contextRef="c5" unitRef="u1"  id="f53"  format="ixt:numdotdecimal" decimals="2">137,456.00</ix:nonFraction></td></tr>
+
+            <tr ><td >Precision = 3</td><td class="figure" ><ix:nonFraction name="ifrs:ProfitLoss" contextRef="c5" unitRef="u1"  id="f55"  format="ixt:numdotdecimal" decimals="0">137,000</ix:nonFraction></td></tr>
+
+            <tr ><td >Precision = INF</td><td class="figure" ><ix:nonFraction name="ifrs:ProfitLoss" contextRef="c5" unitRef="u1"  id="f57"  format="ixt:numdotdecimal" decimals="0">137,000.00</ix:nonFraction></td></tr>
+
+            <tr ><td >Decimals = INF</td><td class="figure" ><ix:nonFraction name="ifrs:ProfitLoss" contextRef="c5" unitRef="u1"  id="f59"  format="ixt:numdotdecimal" decimals="INF">137,000.00</ix:nonFraction></td></tr>
+
+            <tr ><td >Precision = 0</td><td class="figure" ><ix:nonFraction name="ifrs:ProfitLoss" contextRef="c5" unitRef="u1"  id="f61"  format="ixt:numdotdecimal" decimals="0">137,000.00</ix:nonFraction></td></tr>
+
+            </tbody>
+        </table>
+
+        <h3>Prior period tests</h3>
+
+        
+        
+
+        <table class="accounts">
+            
+            
+            <thead>
+                <tr>
+                    <th></th>
+                    <th>2018</th>
+                    <th>2017</th>
+                    <th>3 months to <br></br>31 Dec 2018</th>
+                    <th>3 months to <br></br>31 Dec 2017</th>
+                </tr>
+
+            </thead>
+            <tbody>
+            <tr ><td >Licence fee income</td><td class="figure" ><ix:nonFraction name="ifrs:LicenceFeeIncome" contextRef="c5" unitRef="u1"  id="f63"  format="ixt:numdotdecimal" decimals="0">123,000</ix:nonFraction></td><td class="figure" ><ix:nonFraction name="ifrs:LicenceFeeIncome" contextRef="c6" unitRef="u1"  id="f64"  format="ixt:numdotdecimal" decimals="0">99,000</ix:nonFraction></td><td class="figure" ><ix:nonFraction name="ifrs:LicenceFeeIncome" contextRef="c11" unitRef="u1"  id="f65"  format="ixt:numdotdecimal" decimals="0">35,000</ix:nonFraction></td><td class="figure" ><ix:nonFraction name="ifrs:LicenceFeeIncome" contextRef="c12" unitRef="u1"  id="f66"  format="ixt:numdotdecimal" decimals="0">22,000</ix:nonFraction></td></tr>
+
+            <tr ><td >Finance Income (Cost)</td><td class="figure" ><ix:nonFraction name="ifrs:FinanceIncomeCost" contextRef="c5" unitRef="u1"  id="f68"  format="ixt:numdotdecimal" decimals="0">88,000</ix:nonFraction></td><td class="figure" >(<ix:nonFraction name="ifrs:FinanceIncomeCost" contextRef="c6" unitRef="u1"  id="f69"  format="ixt:numdotdecimal" decimals="0" sign="-">67,000</ix:nonFraction>)</td><td class="figure" >(<ix:nonFraction name="ifrs:FinanceIncomeCost" contextRef="c11" unitRef="u1"  id="f70"  format="ixt:numdotdecimal" decimals="0" sign="-">35,000</ix:nonFraction>)</td><td class="figure" >(<ix:nonFraction name="ifrs:FinanceIncomeCost" contextRef="c12" unitRef="u1"  id="f71"  format="ixt:numdotdecimal" decimals="0" sign="-">22,000</ix:nonFraction>)</td></tr>
+
+            </tbody>
+        </table>
+        </div>
+            
+        
+    </body>
+     
+
+
+</html>

--- a/samples/src/scrollable-div/scrollable-div.html
+++ b/samples/src/scrollable-div/scrollable-div.html
@@ -352,7 +352,7 @@ Profit Loss double tagged: <ix:nonFraction name="ifrs:ProfitLoss" contextRef="c1
 
             <tr ><td >Decimals = INF</td><td class="figure" ><ix:nonFraction name="ifrs:ProfitLoss" contextRef="c5" unitRef="u1"  id="f59"  format="ixt:numdotdecimal" decimals="INF">137,000.00</ix:nonFraction></td></tr>
 
-            <tr ><td >Precision = 0</td><td class="figure" ><ix:nonFraction name="ifrs:ProfitLoss" contextRef="c5" unitRef="u1"  id="f61"  format="ixt:numdotdecimal" decimals="0">137,000.00</ix:nonFraction></td></tr>
+            <tr ><td >Precision = 0</td><td class="figure" >137,000.00<span style="display: none"><ix:nonFraction name="ifrs:ProfitLoss" contextRef="c5" unitRef="u1"  id="f61"  format="ixt:numdotdecimal" decimals="0">137,000.00</ix:nonFraction></span></td></tr>
 
             </tbody>
         </table>


### PR DESCRIPTION
A number of ESEF filings don't have scroll bars on the `<body>` element but instead have a `<div>` element that takes up the whole viewport and has a scrollbar.  With such documents, the viewer would not scroll the viewport to show the selected fact.

This PR fixes this, by scrolling any scrollable ancestor elements as required to make an element visible.

The PR also fixes a small bug whereby inline styles and other attributes on the `<body>` tag were not copied into the inspector's iframe.

A sample document with both inline body styles and content in a scrollable div is included.  A real world example of a document with the scrollable div problem can be seen here:

https://filings.xbrl.org/5493007JXOLJ0QCY2D70/2020-12-31/ESEF/GB/

The PR also fixes scrolling to elements where the tag is not actually visible because it's hidden inside an element with `display: none` (which is the case for most of the tags in the above ESEF example!)
