### PR TITLE
Avoid missing elements in calculation inspector and improve label language fallback

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/concept.js
+++ b/iXBRLViewerPlugin/viewer/src/js/concept.js
@@ -28,7 +28,9 @@ Concept.prototype.referenceValuesAsString = function() {
     }
     else {
         return $.map(this._c.r, function (r,j) {
-                    return $.map(r, function (p,i) { return p[1] }).join(" ")
+            return $.map(r, function (p,i) { 
+                return p[1] 
+            }).join(" ")
         }).join(" ");
     }
 }

--- a/iXBRLViewerPlugin/viewer/src/js/concept.js
+++ b/iXBRLViewerPlugin/viewer/src/js/concept.js
@@ -15,7 +15,7 @@
 import $ from 'jquery'
 
 export function Concept(report, name) {
-    this._c = report.data.concepts[name]
+    this._c = report.data.concepts[name];
 }
 
 /*

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -35,6 +35,10 @@ Fact.prototype.getLabel = function(rolePrefix, withPrefix) {
     return this._report.getLabel(this.f.a.c, rolePrefix, withPrefix);
 }
 
+Fact.prototype.getLabelOrName = function(rolePrefix, withPrefix) {
+    return this._report.getLabelOrName(this.f.a.c, rolePrefix, withPrefix);
+}
+
 Fact.prototype.conceptName = function() {
     return this.f.a.c;
 }

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -186,7 +186,7 @@ Inspector.prototype.factListRow = function(f) {
         })
         .appendTo(row)
     $('<div class="title"></div>')
-        .text(f.getLabel("std") || f.conceptName())
+        .text(f.getLabelOrName("std"))
         .appendTo(row);
     $('<div class="dimension"></div>')
         .text(f.period().toString())
@@ -547,7 +547,7 @@ Inspector.prototype._selectionSummaryAccordian = function() {
         var title = fs.minimallyUniqueLabel(fact);
         if (fact instanceof Fact) {
             factHTML = $(require('../html/fact-details.html')); 
-            $('.std-label', factHTML).text(fact.getLabel("std", true) || fact.conceptName());
+            $('.std-label', factHTML).text(fact.getLabelOrName("std", true));
             $('.documentation', factHTML).text(fact.getLabel("doc") || "");
             $('tr.concept td', factHTML).text(fact.conceptName());
             $('tr.period td', factHTML)

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -367,7 +367,7 @@ Inspector.prototype._calculationHTML = function (fact, elr) {
             var itemHTML = $("<div></div>")
                 .addClass("item")
                 .append($("<span></span>").addClass("weight").text(r.weightSign + " "))
-                .append($("<span></span>").addClass("concept-name").text(report.getLabel(r.concept, "std")))
+                .append($("<span></span>").addClass("concept-name").text(report.getLabelOrName(r.concept, "std")))
                 .appendTo(calcBody);
 
             if (r.facts) {
@@ -381,7 +381,7 @@ Inspector.prototype._calculationHTML = function (fact, elr) {
         });
         $("<div></div>").addClass("item").addClass("total")
             .append($("<span></span>").addClass("weight"))
-            .append($("<span></span>").addClass("concept-name").text(fact.getLabel("std")))
+            .append($("<span></span>").addClass("concept-name").text(fact.getLabelOrName("std")))
             .appendTo(calcBody);
 
         a.addCard($("<span></span>").text(label), calcBody, e == elr);

--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -62,7 +62,7 @@ iXBRLReport.prototype._initialize = function () {
     }
 }
 
-iXBRLReport.prototype.getLabel = function(c, rolePrefix, showPrefix, viewerOptions) {
+iXBRLReport.prototype.getLabel = function(c, rolePrefix, showPrefix) {
     rolePrefix = rolePrefix || 'std';
     var lang = this._viewerOptions.language;
     const concept = this.data.concepts[c];

--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -95,6 +95,14 @@ iXBRLReport.prototype.getLabel = function(c, rolePrefix, showPrefix) {
     }
 }
 
+iXBRLReport.prototype.getLabelOrName = function(c, rolePrefix, showPrefix) {
+    const label = this.getLabel(c, rolePrefix, showPrefix);
+    if (label === undefined) {
+        return c;
+    }
+    return label;
+}
+
 iXBRLReport.prototype.availableLanguages = function() {
     if (!this._availableLanguages) {
         var map = {};

--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -71,7 +71,7 @@ iXBRLReport.prototype.getLabel = function(c, rolePrefix, showPrefix) {
         return "<no label>";
     }
     const labels = concept.labels[rolePrefix]
-    if (labels === undefined) {
+    if (labels === undefined || Object.keys(labels).length == 0) {
         return undefined;
     }
     else {
@@ -80,7 +80,8 @@ iXBRLReport.prototype.getLabel = function(c, rolePrefix, showPrefix) {
             label = labels[lang];
         }
         else {
-            label = labels["en"] || labels["en-us"];
+            // Fall back on English, then any label deterministically.
+            label = labels["en"] || labels["en-us"] || labels[Object.keys(labels).sort()[0]];
         }
         if (label === undefined) {
             return undefined;

--- a/iXBRLViewerPlugin/viewer/src/js/report.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.test.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import { iXBRLReport } from "./report.js";
+import { ViewerOptions } from "./viewerOptions.js";
 
 var testReportData = {
     "languages": {
@@ -39,6 +40,15 @@ var testReportData = {
                     "en-gb": "English (GB) label for concept two"
                 }
             }
+        },
+        "eg:Concept3": {
+            "labels": {
+                "std": {
+                    "fr": "Concept trois",
+                    "de": "Concept vier",
+                    "es": "Concept cuatro",
+                }
+            }
         }
     },
 
@@ -61,8 +71,8 @@ describe("Language options", () => {
     testReport._initialize();
     test("Available languages", () => {
         var al = testReport.availableLanguages();
-        expect(al).toHaveLength(3);
-        expect(al).toEqual(expect.arrayContaining(["en", "en-us", "en-gb"]));
+        expect(al).toHaveLength(6);
+        expect(al).toEqual(expect.arrayContaining(["en", "en-us", "en-gb", "fr", "de", "es"]));
     });
 
     test("Names for available languages", () => {
@@ -88,4 +98,29 @@ describe("Fetching facts", () => {
         var f = testReport.getItemById("fact-does-not-exist");
         expect(f).toBeUndefined();
     });
+});
+
+describe("Concept labels", () => {
+    var testReport = new iXBRLReport(testReportData);
+    var vo = new ViewerOptions();
+    testReport.setViewerOptions(vo);
+    test("Label fallback", () => {
+        vo.language = 'fr';
+        expect(testReport.getLabel('eg:Concept3', 'std')).toBe("Concept trois");
+        vo.language = 'es';
+        expect(testReport.getLabel('eg:Concept3', 'std')).toBe("Concept cuatro");
+        // No English label, so fall back on German (de is first alphabetically)
+        vo.language = 'en';
+        expect(testReport.getLabel('eg:Concept3', 'std')).toBe("Concept vier");
+
+        // Attempt to get an undefined label type 
+        expect(testReport.getLabel('eg:Concept3', 'doc')).toBeUndefined();
+    });
+
+    test("With prefix", () => {
+        vo.language = 'fr';
+        expect(testReport.getLabel('eg:Concept3', 'std', true)).toBe("(eg) Concept trois");
+        expect(testReport.getLabel('eg:Concept3', 'doc', true)).toBeUndefined();
+    });
+
 });

--- a/iXBRLViewerPlugin/viewer/src/js/report.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.test.js
@@ -124,7 +124,10 @@ describe("Concept labels", () => {
     test("With prefix", () => {
         vo.language = 'fr';
         expect(testReport.getLabel('eg:Concept3', 'std', true)).toBe("(eg) Concept trois");
+        expect(testReport.getLabelOrName('eg:Concept3', 'std', true)).toBe("(eg) Concept trois");
+
         expect(testReport.getLabel('eg:Concept3', 'doc', true)).toBeUndefined();
+        expect(testReport.getLabelOrName('eg:Concept3', 'doc', true)).toBe("eg:Concept3");
     });
 
 });

--- a/iXBRLViewerPlugin/viewer/src/js/report.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.test.js
@@ -107,14 +107,18 @@ describe("Concept labels", () => {
     test("Label fallback", () => {
         vo.language = 'fr';
         expect(testReport.getLabel('eg:Concept3', 'std')).toBe("Concept trois");
+        expect(testReport.getLabelOrName('eg:Concept3', 'std')).toBe("Concept trois");
         vo.language = 'es';
         expect(testReport.getLabel('eg:Concept3', 'std')).toBe("Concept cuatro");
+        expect(testReport.getLabelOrName('eg:Concept3', 'std')).toBe("Concept cuatro");
         // No English label, so fall back on German (de is first alphabetically)
         vo.language = 'en';
         expect(testReport.getLabel('eg:Concept3', 'std')).toBe("Concept vier");
+        expect(testReport.getLabelOrName('eg:Concept3', 'std')).toBe("Concept vier");
 
         // Attempt to get an undefined label type 
         expect(testReport.getLabel('eg:Concept3', 'doc')).toBeUndefined();
+        expect(testReport.getLabelOrName('eg:Concept3', 'doc')).toBe('eg:Concept3');
     });
 
     test("With prefix", () => {


### PR DESCRIPTION
Previously, if a concept that did not have an English label (or a label in the current viewer language, if different) was shown in the calculation section of the inspector, a blank line was shown.

This PR fixes this by changing the label language fallback to be:

1. Current viewer language
2. en
3. en-US
4. (new) Any defined label (chosen deterministically based on language code in alphabetical order)

If no label is found, the calculation view will now fall back on concept name, so a blank line is never displayed.

The above fallback hierarchy is now used in all places where a label is displayed.

Fixes XT-1354