### PR TITLE
Fix next/prev tag behaviour in documents with continuations

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -233,8 +233,8 @@ Viewer.prototype.contents = function() {
 
 
 Viewer.prototype._selectAdjacentTag = function (offset) {
-    var elements = $(".ixbrl-element", this._contents);
-    var current = $(".ixbrl-selected", this._contents);
+    var elements = $(".ixbrl-element:not(.ixbrl-continuation)", this._contents);
+    var current = $(".ixbrl-selected:not(.ixbrl-continuation)", this._contents);
     var next;
     if (current.length == 1) {
         next = elements.eq((elements.index(current.first()) + offset) % elements.length);


### PR DESCRIPTION
This PR fixes a bug whereby the next/prev buttons would not work correctly when the currently selected item had continuations, and the selection would wrap to the beginning or end of the document.

The bug can be seen on any document with a tag containing continuations: select the tag, and then press the "next tag" button in the top right.  Selection will move back to the first tag in the document, not the next tag.