### PR TITLE
Tolerate missing concepts when fetching references

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/concept.js
+++ b/iXBRLViewerPlugin/viewer/src/js/concept.js
@@ -23,7 +23,7 @@ export function Concept(report, name) {
  * the concept has none.
  */
 Concept.prototype.referenceValuesAsString = function() {
-    if (!this._c.r) {
+    if (!this._c || !this._c.r) {
         return "";
     }
     else {
@@ -36,7 +36,7 @@ Concept.prototype.referenceValuesAsString = function() {
 }
 
 Concept.prototype.references = function () {
-    if (!this._c.r) {
+    if (!this._c || !this._c.r) {
         return  [];
     }
     else {

--- a/iXBRLViewerPlugin/viewer/src/js/concept.js
+++ b/iXBRLViewerPlugin/viewer/src/js/concept.js
@@ -49,6 +49,6 @@ Concept.prototype.references = function () {
 }
 
 Concept.prototype.isTypedDimension = function () {
-    return this._c.d == "t";
+    return this._c && this._c.d == "t";
 }
 

--- a/iXBRLViewerPlugin/viewer/src/js/search.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.js
@@ -35,7 +35,7 @@ ReportSearch.prototype.buildSearchIndex = function () {
         doc.startDate = f.periodFrom();
         var dims = f.dimensions();
         for (var d in dims) {
-            if (this._report.getConcept(d).isTypedDimension) {
+            if (this._report.getConcept(d).isTypedDimension()) {
                 if (dims[d] !== null) {
                     l += " " + dims[d];
                 }


### PR DESCRIPTION
This PR makes the viewer more tolerant of invalid iXBRL documents with missing concept definitions.

Currently, if an iXBRL report references a concept which does not exist in the taxonomy, an exception is thrown when building the search index. This fixes this.
