### PR TITLE
Loading performance improvements

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
@@ -210,7 +210,7 @@ iXBRLViewer.prototype.load = function() {
                         inspector.handleFactDeepLink();
                     });
             }
-        });
+        }, 250);
     }, 0);
 }
 

--- a/iXBRLViewerPlugin/viewer/src/less/loader.less
+++ b/iXBRLViewerPlugin/viewer/src/less/loader.less
@@ -54,8 +54,8 @@
   }
 
   .loader.loading .text::after {
-    -webkit-animation: loader 0.6s linear;
-    animation: loader 0.6s linear;
+    -webkit-animation: loader 4s steps(64);
+    animation: loader 4s steps(64);
     -webkit-animation-iteration-count: infinite;
     animation-iteration-count: infinite;
     border-color: #fff transparent transparent;


### PR DESCRIPTION
This PR provides some minor performance improvements to viewer loading:

* Polling interval to check if all iframes have finished rendering is increased from 10ms to 250ms
* The loading spinner animation is now much slower and uses fewer animation frames

At present these only have a modest benefit, as they only affect the time when the spinner is showing.  I have a separate set of changes in progress which make it possible for the spinner to be shown during the whole document load, and my tests show that these changes reduce load time by 15-30%.