### PR TITLE
Fix popup namespace key

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -80,7 +80,7 @@ Inspector.prototype.initialize = function (report) {
             $("#inspector-head .back").on("click", function () {
                 $(this).closest("#inspector").removeClass("search-mode");
             });
-            $(".popup-trigger").on("hover", function () { $(this).find(".popup-content").show() }, function () { $(this).find(".popup-content").hide() });
+            $(".popup-trigger").hover(function () { $(this).find(".popup-content").show() }, function () { $(this).find(".popup-content").hide() });
             inspector._toolbarMenu = new Menu($("#toolbar-highlight-menu"));
             inspector.buildToolbarHighlightMenu();
 


### PR DESCRIPTION
This PR fixes a regression that prevents the namespace key that appears when you mouse over the question mark next to "Highlight" in the title bar from working.

With this PR, a box should appear when the mouse is over the question mark showing the colors allocated to each namespace in the document.

The regression was introduced by c837db1208d4ff460669016774e42ea8fe8c0d50
