### PR TITLE
Swap highlight colors

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/less/colours.less
+++ b/iXBRLViewerPlugin/viewer/src/less/colours.less
@@ -27,8 +27,8 @@
 @simple-border: solid 0.1rem @border-grey;
 
 @highlight-default: hsl(90 69% 85% / 1);
-@highlight-1: hsl(48 100% 85% / 1);
-@highlight-2: #eaa8ff;
+@highlight-1: #eaa8ff;
+@highlight-2: hsl(48 100% 85% / 1);
 
 @icon-grey: @text;
 


### PR DESCRIPTION
This PR swaps the colors used for highlighting facts in the 2nd and 3rd namespaces used in a document.

This is for consistency with the Workiva plugin which has also swapped these colors, and is needed in order to make the "key" that appears when hovering over the "?" icon show the correct colors.

The way this currently works is somewhat fragile, as the key allocates the colors in a fixed order, and the plugin needs to make sure that it allocates the same colors in the same order to the items in the key.  There's some discussion of making the color palettes configurable which would involve giving this code an overhaul, so I think it makes sense to just do this simple fix for now.