### PR TITLE
Add option to highlight tags by default

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -57,8 +57,9 @@ Inspector.prototype.i18nInit = function () {
     });
 }
 
-Inspector.prototype.initialize = function (report) {
+Inspector.prototype.initialize = function (report, viewer) {
     var inspector = this;
+    this._viewer = viewer;
     return new Promise(function (resolve, reject) {
         inspector._chart = new IXBRLChart();
         inspector._report = report;
@@ -98,14 +99,15 @@ Inspector.prototype.initialize = function (report) {
                 inspector.buildDisplayOptionsMenu();
                 inspector.buildToolbarHighlightMenu();
                 inspector.buildHighlightKey();
+                inspector.initializeViewer();
                 resolve();
             });
         });
     });
 }
 
-Inspector.prototype.setViewer = function (viewer) {
-    this._viewer = viewer;
+Inspector.prototype.initializeViewer = function () {
+    var viewer = this._viewer;
     viewer.onSelect.add((id, eltSet) => this.selectItem(id, eltSet));
     viewer.onMouseEnter.add((id) => this.viewerMouseEnter(id));
     viewer.onMouseLeave.add(id => this.viewerMouseLeave(id));
@@ -158,7 +160,7 @@ Inspector.prototype.buildDisplayOptionsMenu = function () {
 
 Inspector.prototype.buildToolbarHighlightMenu = function () {
     this._toolbarMenu.reset();
-    this._toolbarMenu.addCheckboxItem(i18next.t("toolbar.xbrlElements"), (checked) => this.highlightAllTags(checked), "highlight-tags");
+    this._toolbarMenu.addCheckboxItem(i18next.t("toolbar.xbrlElements"), (checked) => this.highlightAllTags(checked), "highlight-tags", null, this._iv.options.highlightTagsOnStartup);
     this._iv.callPluginMethod("extendToolbarHighlightMenu", this._toolbarMenu);
 }
 

--- a/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
@@ -18,10 +18,11 @@ import { iXBRLReport } from "./report.js";
 import { Viewer } from "./viewer.js";
 import { Inspector } from "./inspector.js";
 
-export function iXBRLViewer() {
+export function iXBRLViewer(options) {
     this._plugins = [];
     this.inspector = new Inspector(this);
     this.viewer = null;
+    this.options = options || {};
 }
 
 /*
@@ -193,9 +194,8 @@ iXBRLViewer.prototype.load = function () {
                 var viewer = iv.viewer = new Viewer(iv, iframes, report);
 
                 viewer.initialize()
-                    .then(() => inspector.initialize(report))
+                    .then(() => inspector.initialize(report, viewer))
                     .then(() => {
-                        inspector.setViewer(viewer);
                         interact('#viewer-pane').resizable({
                             edges: { left: false, right: ".resize", bottom: false, top: false },
                             restrictEdges: {

--- a/iXBRLViewerPlugin/viewer/src/js/menu.js
+++ b/iXBRLViewerPlugin/viewer/src/js/menu.js
@@ -59,7 +59,7 @@ Menu.prototype._add = function(item, after) {
     }
 }
 
-Menu.prototype.addCheckboxItem = function(name, callback, itemName, after) {
+Menu.prototype.addCheckboxItem = function(name, callback, itemName, after, onByDefault) {
     var menu = this;
     var item = $("<label></label>")
         .addClass("menu-checkbox")
@@ -68,6 +68,7 @@ Menu.prototype.addCheckboxItem = function(name, callback, itemName, after) {
         .data("iv-menu-item-name", itemName)
         .prepend(
             $('<input type="checkbox"></input>')
+                .prop("checked", onByDefault)
                 .change(function () {
                     callback($(this).prop("checked"));
                     menu.close(); 
@@ -75,6 +76,9 @@ Menu.prototype.addCheckboxItem = function(name, callback, itemName, after) {
         )
         .append($("<span></span>").addClass("checkmark"));
     this._add(item, after);
+    if (onByDefault) {
+        callback(true);
+    }
 }
 
 Menu.prototype.addCheckboxGroup = function(values, names, def, callback, name, after) {


### PR DESCRIPTION
This PR adds a configuration option to highlight tags by default on viewer startup.  At the moment, this option is not set in the public viewer, but it is available for plugins to call when instantiating the viewer.