### PR TITLE
XT-1517 - Host ixviewer.js on the CDN

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,11 @@ RUN npm run stylelint
 # Upload ixbrlviewer.js to github artifacts
 ARG BUILD_ARTIFACTS_GITHUB_RELEASE_ASSETS=/build/iXBRLViewerPlugin/viewer/dist/ixbrlviewer.js
 
+# Host ixviewer.js on CDN
+RUN mkdir /static_release
+RUN tar -czf /static_release/assets.tar.gz -C /build/iXBRLViewerPlugin/viewer/dist/ .
+ARG BUILD_ARTIFACTS_CDN=/static_release/assets.tar.gz
+
 # python tests
 ARG BUILD_ARTIFACTS_TEST=/test_reports/*.xml
 RUN mkdir /test_reports


### PR DESCRIPTION
#### Description:
- Host the ixviewer.js on the CDN for easy download

#### Testing:
Hit `https://cdn-dev.wdesk.org/ixbrl-viewer/<build_id>/ixbrlviewer.js` and verify that the ixviewer.js is hosted correctly on the CDN.

**review**:
@Workiva/xt