### PR TITLE
Improve support for invalid iXBRL values

### DIFF
--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -14,7 +14,7 @@
 
 from arelle import XbrlConst
 from arelle.ModelDocument import Type
-from arelle.ModelValue import QName
+from arelle.ModelValue import QName, INVALIDixVALUE
 from lxml import etree
 import json
 import math
@@ -236,6 +236,8 @@ class IXBRLViewerBuilder:
                     self.addConcept(dts.qnameConcepts.get(qn))
             else:
                 factData["v"] = f.value 
+                if f.value == INVALIDixVALUE:
+                    factData["err"] = 'INVALID_IX_VALUE'
 
             if f.format is not None:
                 factData["f"] = str(f.format)

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -75,7 +75,10 @@ Fact.prototype.value = function() {
 
 Fact.prototype.readableValue = function() {
     var v = this.f.v;
-    if (this.isNumeric()) {
+    if (this.isInvalidIXValue()) {
+        v = "Invalid value";
+    }
+    else if (this.isNumeric()) {
         var d = this.decimals();
         var formattedNumber;
         if (this.isNil()) {
@@ -199,6 +202,10 @@ Fact.prototype.duplicates = function () {
 
 Fact.prototype.isNil = function() {
     return this.f.v === null
+}
+
+Fact.prototype.isInvalidIXValue = function() {
+    return this.f.err == 'INVALID_IX_VALUE';
 }
 
 Fact.prototype.readableAccuracy = function () {

--- a/iXBRLViewerPlugin/viewer/src/js/fact.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.test.js
@@ -123,6 +123,7 @@ describe("Simple fact properties", () => {
         expect(f.conceptQName().prefix).toEqual("eg");
         expect(f.conceptQName().localname).toEqual("Concept1");
         expect(f.conceptQName().namespace).toEqual("http://www.example.com");
+        expect(f.isInvalidIXValue()).toBeFalsy();
     });
 
     test("Numeric (non-monetary)", () => {
@@ -143,6 +144,7 @@ describe("Simple fact properties", () => {
         expect(f.conceptQName().prefix).toEqual("eg");
         expect(f.conceptQName().localname).toEqual("Concept1");
         expect(f.conceptQName().namespace).toEqual("http://www.example.com");
+        expect(f.isInvalidIXValue()).toBeFalsy();
     });
 
     test("Numeric (infinite precision)", () => {
@@ -162,6 +164,7 @@ describe("Simple fact properties", () => {
         expect(f.conceptQName().prefix).toEqual("eg");
         expect(f.conceptQName().localname).toEqual("Concept1");
         expect(f.conceptQName().namespace).toEqual("http://www.example.com");
+        expect(f.isInvalidIXValue()).toBeFalsy();
     });
 
     test("String", () => {
@@ -179,6 +182,7 @@ describe("Simple fact properties", () => {
         expect(f.conceptQName().prefix).toEqual("eg");
         expect(f.conceptQName().localname).toEqual("Concept1");
         expect(f.conceptQName().namespace).toEqual("http://www.example.com");
+        expect(f.isInvalidIXValue()).toBeFalsy();
     });
 
     test("Enumeration", () => {
@@ -193,6 +197,7 @@ describe("Simple fact properties", () => {
         expect(f.decimals()).toBeUndefined();
         expect(f.isMonetaryValue()).toBeFalsy();
         expect(f.readableValue()).toEqual("Member One");
+        expect(f.isInvalidIXValue()).toBeFalsy();
 
         f.f.v = "eg:Member1 eg:Member2";
         expect(f.value()).toEqual("eg:Member1 eg:Member2");
@@ -200,6 +205,7 @@ describe("Simple fact properties", () => {
         expect(f.decimals()).toBeUndefined();
         expect(f.isMonetaryValue()).toBeFalsy();
         expect(f.readableValue()).toEqual("Member One, Member Two");
+        expect(f.isInvalidIXValue()).toBeFalsy();
 
         f.f.v = "eg:Member1 eg:NotDefined";
         expect(f.value()).toEqual("eg:Member1 eg:NotDefined");
@@ -207,6 +213,7 @@ describe("Simple fact properties", () => {
         expect(f.decimals()).toBeUndefined();
         expect(f.isMonetaryValue()).toBeFalsy();
         expect(f.readableValue()).toEqual("Member One, <no label>");
+        expect(f.isInvalidIXValue()).toBeFalsy();
 
         f.f.v = "eg:Member1 eg:UnlabelledMember";
         expect(f.value()).toEqual("eg:Member1 eg:UnlabelledMember");
@@ -214,6 +221,7 @@ describe("Simple fact properties", () => {
         expect(f.decimals()).toBeUndefined();
         expect(f.isMonetaryValue()).toBeFalsy();
         expect(f.readableValue()).toEqual("Member One, eg:UnlabelledMember");
+        expect(f.isInvalidIXValue()).toBeFalsy();
 
         // Switch to a non-enumeration concept.
         // Values should be treated as strings
@@ -224,6 +232,7 @@ describe("Simple fact properties", () => {
         expect(f.decimals()).toBeUndefined();
         expect(f.isMonetaryValue()).toBeFalsy();
         expect(f.readableValue()).toEqual("eg:Member1 eg:NotDefined");
+        expect(f.isInvalidIXValue()).toBeFalsy();
     });
 
 });
@@ -589,5 +598,29 @@ describe("Aspect methods", () => {
         expect(f.aspects().filter(a => a.isTaxonomyDefined())[0].label()).toEqual("Dimension One");
         expect(f.aspects().filter(a => a.isTaxonomyDefined())[0].valueLabel()).toEqual("Member One");
         expect(f.aspect("eg:Dimension1").value()).toEqual("eg:Member1");
+    });
+});
+
+describe("Fact errors", () => {
+    test("iXBRL Invalid", () => {
+        var f = testFact({
+                "d": -3,
+                "v": "abcd",
+                "err": "INVALID_IX_VALUE",
+                "a": {
+                    "c": "eg:Concept1",
+                    "u": "iso4217:USD", 
+                    "p": "2018-01-01/2019-01-01",
+                }});
+        expect(f.value()).toEqual("abcd");
+        expect(f.decimals()).toEqual(-3);
+        expect(f.isNumeric()).toBeTruthy();
+        expect(f.isMonetaryValue()).toBeTruthy();
+        expect(f.readableValue()).toEqual("Invalid value");
+        expect(f.unit().value()).toEqual("iso4217:USD");
+        expect(f.conceptQName().prefix).toEqual("eg");
+        expect(f.conceptQName().localname).toEqual("Concept1");
+        expect(f.conceptQName().namespace).toEqual("http://www.example.com");
+        expect(f.isInvalidIXValue()).toBeTruthy();
     });
 });

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -529,7 +529,7 @@ Inspector.prototype._updateValue = function (item, showAll, context) {
     }
 
     var valueSpan = $('tr.value td .value', context).empty().text(v);
-    if (item instanceof Fact && item.isNil()) {
+    if (item instanceof Fact && (item.isNil() || item.isInvalidIXValue())) {
         valueSpan.wrapInner("<i></i>");
     }
 

--- a/samples/src/xbrl-invalid-tests/xbrl-invalid-test.html
+++ b/samples/src/xbrl-invalid-tests/xbrl-invalid-test.html
@@ -90,6 +90,23 @@
           <ix:nonFraction decimals="0" name="ifrs:DeferredTaxAssets" format="ixt:numdotdecimal" unitRef="u1" sign="-" id="f4" contextRef="i2">461,123</ix:nonFraction>)
         </td>
       </tr>
+      <tr>
+        <td style="padding: 15px">Calc error</td>
+        <td style="padding: 15px">
+          <ix:nonFraction decimals="0" name="ifrs:NoncurrentProvisions" unitRef="u1" format="ixt:numdotdecimal" contextRef="i1" id="f5">1234</ix:nonFraction>
+        </td>
+        <td style="padding: 15px">(
+          <ix:nonFraction decimals="0" name="ifrs:NoncurrentLiabilities" unitRef="u1" format="ixt:numdotdecimal" contextRef="i1" id="f6">4321</ix:nonFraction>
+        </td>
+      </tr>
+      <tr>
+        <td style="padding: 15px">Invalid format</td>
+        <td style="padding: 15px">
+          <ix:nonFraction decimals="0" name="ifrs:Assets" unitRef="u1" contextRef="i1" id="f7">abcd</ix:nonFraction>
+        </td>
+        <td style="padding: 15px">(
+        </td>
+      </tr>
     </table>
   </body>
 </html>

--- a/samples/src/xbrl-invalid-tests/xbrl-invalid-test.html
+++ b/samples/src/xbrl-invalid-tests/xbrl-invalid-test.html
@@ -26,7 +26,6 @@
     <div style="display: none">
       <ix:header>
         <ix:references>
-          <link:schemaRef xlink:href="http://xbrl.ifrs.org/taxonomy/2017-03-09/full_ifrs_entry_point_2017-03-09-es.xsd" xlink:type="simple" />
           <link:schemaRef xlink:href="http://xbrl.ifrs.org/taxonomy/2017-03-09/full_ifrs_doc_entry_point_2017-03-09.xsd" xlink:type="simple" />
         </ix:references>
         <ix:resources>

--- a/samples/src/xbrl-invalid-tests/xbrl-invalid-test.html
+++ b/samples/src/xbrl-invalid-tests/xbrl-invalid-test.html
@@ -102,9 +102,10 @@
       <tr>
         <td style="padding: 15px">Invalid format</td>
         <td style="padding: 15px">
-          <ix:nonFraction decimals="0" name="ifrs:Assets" unitRef="u1" contextRef="i1" id="f7">abcd</ix:nonFraction>
+          <ix:nonFraction decimals="0" name="ifrs:Assets" format="ixt:numdotdecimal" unitRef="u1" contextRef="i1" id="f7">abcd</ix:nonFraction>
         </td>
-        <td style="padding: 15px">(
+        <td style="padding: 15px">
+          <ix:nonFraction decimals="0" name="ifrs:Assets" unitRef="u1" contextRef="i1" id="f8">12,000.00</ix:nonFraction>
         </td>
       </tr>
     </table>


### PR DESCRIPTION
This PR improves display of invalid iXBRL values.  For example, a formatted number such as `38,000.00` which does not have a transform specified, or a value which does not match the specified transform.

Such values now show "Invalid value" rather than "NaN"

![image](https://user-images.githubusercontent.com/45077928/127392680-dd305ff3-0274-48f0-bef8-33da7ed86d28.png)
