### PR TITLE
XT-1678: Update dependabot ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
   reviewers:
   - Workiva/xt
   ignore:
+  - dependency-name: babel-jest
+    versions:
+    - ">=27"
   - dependency-name: chart.js
     versions:
     - ">=3"
@@ -21,6 +24,9 @@ updates:
   - dependency-name: html-loader
     versions:
     - ">=1"
+  - dependency-name: jest
+    versions:
+    - ">=27"
   - dependency-name: less
     versions:
     - ">=4"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,9 @@ updates:
   - dependency-name: html-loader
     versions:
     - ">=1"
+  - dependency-name: i18next
+    versions:
+    - ">=21"
   - dependency-name: jest
     versions:
     - ">=27"


### PR DESCRIPTION
The latest major i18next and jest versions fail the build. Make dependabot ignore those updates until the repo is updated to be compatible.
