### PR TITLE
fact-explanatoryFact support

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -133,7 +133,7 @@ limitations under the License.
             </div>
             <div class="collapsible-section">
                <h3 class="collapsible-header" data-i18n="inspector.footnotes">Footnotes</h3>
-               <div class="collapsible-body footnotes">
+               <div class="collapsible-body footnotes fact-list">
                </div>
             </div>
             <div class="collapsible-section">

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -136,6 +136,11 @@ limitations under the License.
                <div class="collapsible-body footnotes fact-list">
                </div>
             </div>
+            <div class="collapsible-section footnote-facts-section">
+               <h3 class="collapsible-header" data-i18n="inspector.associatedFacts">Associated Facts</h3>
+               <div class="collapsible-body footnote-facts fact-list">
+               </div>
+            </div>
             <div class="collapsible-section">
                <h3 class="collapsible-header" data-i18n="inspector.fact-groups">Sections</h3>
                <div class="collapsible-body fact-groups fact-list">

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -26,6 +26,7 @@ export function Fact(report, factId) {
     this.ixNode = report.getIXNodeForItemId(factId);
     this._report = report;
     this.id = factId;
+    this.linkedFacts = [];
 }
 
 Fact.prototype.report = function() {
@@ -277,9 +278,7 @@ Fact.prototype.narrowerConcepts = function () {
     return concepts;
 }
 
-// Called if the document contains fact-fact footnote relationships.  Viewer
-// support not yet implemented.
-Fact.prototype.addFact = function (f) {
-    return
+Fact.prototype.addLinkedFact = function (f) {
+    this.linkedFacts.push(f);
 }
 

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -276,3 +276,10 @@ Fact.prototype.narrowerConcepts = function () {
     }
     return concepts;
 }
+
+// Called if the document contains fact-fact footnote relationships.  Viewer
+// support not yet implemented.
+Fact.prototype.addFact = function (f) {
+    return
+}
+

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -278,6 +278,7 @@ Fact.prototype.narrowerConcepts = function () {
     return concepts;
 }
 
+// Facts that are the source of relationships to this fact.
 Fact.prototype.addLinkedFact = function (f) {
     this.linkedFacts.push(f);
 }

--- a/iXBRLViewerPlugin/viewer/src/js/footnote.js
+++ b/iXBRLViewerPlugin/viewer/src/js/footnote.js
@@ -14,13 +14,13 @@
 
 export function Footnote(report, footnoteId, title) {
     this.id = footnoteId;
-    this.facts = [];
+    this.linkedFacts = [];
     this.title = title;
     this.ixNode = report.getIXNodeForItemId(footnoteId);
 }
 
-Footnote.prototype.addFact = function (f) {
-    this.facts.push(f); 
+Footnote.prototype.addLinkedFact = function (f) {
+    this.linkedFacts.push(f); 
 }
 
 Footnote.prototype.textContent = function () {

--- a/iXBRLViewerPlugin/viewer/src/js/footnote.js
+++ b/iXBRLViewerPlugin/viewer/src/js/footnote.js
@@ -19,6 +19,7 @@ export function Footnote(report, footnoteId, title) {
     this.ixNode = report.getIXNodeForItemId(footnoteId);
 }
 
+// Facts that are the source of relationships to this fact.
 Footnote.prototype.addLinkedFact = function (f) {
     this.linkedFacts.push(f); 
 }

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -470,13 +470,15 @@ Inspector.prototype._calculationHTML = function (fact, elr) {
 Inspector.prototype._footnotesHTML = function (fact) {
     var html = $("<div></div>");
     $.each(fact.footnotes(), (n, fn) => {
-        $("<div></div>")
-            .addClass("block-list-item")
-            .appendTo(html)
-            .text(truncateLabel(fn.textContent(), 120))
-            .mouseenter(() => this._viewer.linkedHighlightFact(fn))
-            .mouseleave(() => this._viewer.clearLinkedHighlightFact(fn))
-            .click(() => this.selectItem(fn.id));
+        if (fn instanceof Footnote) {
+            $("<div></div>")
+                .addClass("block-list-item")
+                .appendTo(html)
+                .text(truncateLabel(fn.textContent(), 120))
+                .mouseenter(() => this._viewer.linkedHighlightFact(fn))
+                .mouseleave(() => this._viewer.clearLinkedHighlightFact(fn))
+                .click(() => this.selectItem(fn.id));
+        }
     });
     return html;
 }

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -357,7 +357,21 @@ Inspector.prototype.updateOutline = function (cf) {
 }
 
 Inspector.prototype.updateFootnotes = function (fact) {
+    // Outbound fact->footnote and fact->fact links
     $('.footnotes').empty().append(this._footnotesHTML(fact));
+
+    // Inbound fact->fact footnote links.  Not widely used, so only show the
+    // section if we have some. 
+    if (fact.linkedFacts.length > 0) {
+        $('#inspector .footnote-facts-section')
+            .show()
+            .find('.footnote-facts')
+            .empty()
+            .append(this._footnoteFactsHTML(fact));
+    }
+    else {
+        $('#inspector .footnote-facts-section').hide();
+    }
 }
 
 
@@ -602,10 +616,10 @@ Inspector.prototype._updateEntityIdentifier = function (fact, context) {
     }
 }
 
-Inspector.prototype._footnoteFactsHTML = function() {
+Inspector.prototype._footnoteFactsHTML = function(fact) {
     var html = $('<div></div>');
-    this._currentItem.facts.forEach((fact) =>  {
-        html.append(this.factListRow(fact));
+    fact.linkedFacts.forEach((linkedFact) =>  {
+        html.append(this.factListRow(linkedFact));
     });
     return html;
 }
@@ -739,10 +753,11 @@ Inspector.prototype.update = function () {
             else if (cf.isHTMLHidden()) {
                 $('#inspector').addClass('html-hidden-fact');
             }
+
         }
         else if (cf instanceof Footnote) {
             $('#inspector').addClass('footnote-mode');
-            $('#inspector .footnote-details .footnote-facts').empty().append(this._footnoteFactsHTML());
+            $('#inspector .footnote-details .footnote-facts').empty().append(this._footnoteFactsHTML(cf));
         }
         $('.fact-details').localize();
     }

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -468,16 +468,19 @@ Inspector.prototype._calculationHTML = function (fact, elr) {
 }
 
 Inspector.prototype._footnotesHTML = function (fact) {
-    var html = $("<div></div>");
+    var html = $("<div></div>").addClass("fact-list");
     $.each(fact.footnotes(), (n, fn) => {
         if (fn instanceof Footnote) {
             $("<div></div>")
                 .addClass("block-list-item")
-                .appendTo(html)
                 .text(truncateLabel(fn.textContent(), 120))
                 .mouseenter(() => this._viewer.linkedHighlightFact(fn))
                 .mouseleave(() => this._viewer.clearLinkedHighlightFact(fn))
-                .click(() => this.selectItem(fn.id));
+                .click(() => this.selectItem(fn.id))
+                .appendTo(html);
+        }
+        else if (fn instanceof Fact) {
+            html.append(this.factListRow(fn));
         }
     });
     return html;

--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -44,12 +44,19 @@ iXBRLReport.prototype._initialize = function () {
     var fnorder = Object.keys(this._ixNodeMap).filter((id) => this._ixNodeMap[id].footnote);
     fnorder.sort((a,b) => this._ixNodeMap[a].docOrderindex - this._ixNodeMap[b].docOrderindex);
 
-    // Create footnote objects for all footnotes, and associate facts with
-    // those footnotes to allow 2 way fact <-> footnote navigation.
-    for (var id in this.data.facts) {
-        var f = new Fact(this, id);
-        this._items[id] = f;
-        var fns = this.data.facts[id].fn || [];
+    // Create Fact objects for all facts.  
+    for (const id in this.data.facts) {
+        this._items[id] = new Fact(this, id);
+    }
+
+    // Now resolve footnote references, creating footnote objects for "normal"
+    // footnotes, and finding Fact objects for fact->fact footnotes.  
+    //
+    // Associate source facts with target footnote/facts to allow two way
+    // navigation.
+    for (const id in this.data.facts) {
+        const f = this._items[id];
+        const fns = this.data.facts[id].fn || [];
         fns.forEach((fnid) => {
             var fn = this._items[fnid];
             if (fn === undefined) {
@@ -57,7 +64,7 @@ iXBRLReport.prototype._initialize = function () {
                 this._items[fnid] = fn;
             }
             // Associate fact with footnote
-            fn.addFact(f);
+            fn.addLinkedFact(f);
         });
     }
 }

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -327,17 +327,6 @@ Viewer.prototype.clearHighlighting = function () {
     $("body", this._iframes.contents()).find(".ixbrl-element").removeClass("ixbrl-selected").removeClass("ixbrl-related").removeClass("ixbrl-linked-highlight");
 }
 
-/*
- * Update the currently highlighted fact, but do not trigger a change in the
- * inspector.
- * 
- * Used to switch facts when the selection corresponds to multiple facts.
- */
-Viewer.prototype.highlightElements = function (ee) {
-    this.clearHighlighting();
-    ee.addClass("ixbrl-selected");
-}
-
 Viewer.prototype._ixIdsForElement = function (e) {
     var ids = e.data('ivid');
     if (e.hasClass("ixbrl-continuation")) {
@@ -390,20 +379,17 @@ Viewer.prototype._mouseLeave = function (e) {
 }
 
 Viewer.prototype.highlightRelatedFact = function (f) {
-    var e = this.elementForFact(f);
-    e.addClass("ixbrl-related");
+    this.changeItemClass(f.id, "ixbrl-related");
 }
 
 Viewer.prototype.highlightRelatedFacts = function (facts) {
-    this.elementsForFacts(facts).addClass("ixbrl-related");
+    for (const f of facts) {
+        this.changeItemClass(f.id, "ixbrl-related");
+    }
 }
 
 Viewer.prototype.clearRelatedHighlighting = function (f) {
     $(".ixbrl-related", this._contents).removeClass("ixbrl-related");
-}
-
-Viewer.prototype.elementForFact = function (fact) {
-    return this.elementForItemId(fact.id);
 }
 
 Viewer.prototype.elementForItemId = function (factId) {
@@ -417,13 +403,26 @@ Viewer.prototype.elementsForItemIds = function (ids) {
     }));
 }
 
-Viewer.prototype.elementsForFacts = function (facts) {
-    return this.elementsForItemIds($.map(facts, function (f) { return f.id }));
+/*
+ * Add or remove a class to an item (fact or footnote) and any continuation elements
+ */
+Viewer.prototype.changeItemClass = function(itemId, highlightClass, removeClass) {
+    const continuations = this._ixNodeMap[itemId].continuationIds();
+    const elements = this.elementsForItemIds([itemId].concat(continuations));
+    if (removeClass) {
+        elements.removeClass(highlightClass);
+    }
+    else {
+        elements.addClass(highlightClass);
+    }
 }
 
+/*
+ * Change the currently highlighted item
+ */
 Viewer.prototype.highlightItem = function(factId) {
-    var continuations = this._ixNodeMap[factId].continuationIds();
-    this.highlightElements(this.elementsForItemIds([factId].concat(continuations)));
+    this.clearHighlighting();
+    this.changeItemClass(factId, "ixbrl-selected");
 }
 
 Viewer.prototype.showItemById = function (id) {
@@ -486,7 +485,7 @@ Viewer.prototype.zoomOut = function () {
 }
 
 Viewer.prototype.factsInSameTable = function (fact) {
-    var e = this.elementForFact(fact);
+    var e = this.elementForItemId(fact.id);
     var facts = [];
     e.closest("table").find(".ixbrl-element").each(function (i,e) {
         facts = facts.concat($(this).data('ivid'));
@@ -495,13 +494,11 @@ Viewer.prototype.factsInSameTable = function (fact) {
 }
 
 Viewer.prototype.linkedHighlightFact = function (f) {
-    var e = this.elementForFact(f);
-    e.addClass("ixbrl-linked-highlight");
+    this.changeItemClass(f.id, "ixbrl-linked-highlight");
 }
 
 Viewer.prototype.clearLinkedHighlightFact = function (f) {
-    var e = this.elementForFact(f);
-    e.removeClass("ixbrl-linked-highlight");
+    this.changeItemClass(f.id, "ixbrl-linked-highlight", true);
 }
 
 Viewer.prototype._setTitle = function (docIndex) {

--- a/iXBRLViewerPlugin/viewer/src/less/components.less
+++ b/iXBRLViewerPlugin/viewer/src/less/components.less
@@ -26,3 +26,8 @@
   cursor: pointer;
   color: @primary;
 }
+
+.panel-indent {
+  padding-left: 0.9rem;
+  padding-right: 0.9rem;
+}

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -491,6 +491,7 @@
       .search-results {
         overflow-y: auto;
         height: 100%;
+        .panel-indent();
 
         .search-overlay {
           transform: translate(-50%, -50%);
@@ -544,6 +545,10 @@
       .outline {
         overflow-y: auto;
         height: 100%;
+      }
+
+      .body {
+        .panel-indent();
       }
     } /* inspector body */
 
@@ -732,8 +737,7 @@
 
     .collapsible-section {
       .collapsible-body {
-        padding-left: 0.9rem;
-        padding-right: 0.9rem;
+        .panel-indent();
       }
 
       .collapsible-header {
@@ -903,9 +907,6 @@
   }
 
   .fact-list {
-    margin-left: 0.9rem;
-    margin-right: 0.9rem;
-
     .fact-list-item {
       .block-list-item();
 

--- a/samples/src/continuation/continuation.html
+++ b/samples/src/continuation/continuation.html
@@ -31,9 +31,11 @@
               <xbrli:endDate>2017-12-31</xbrli:endDate>
             </xbrli:period>
           </xbrli:context>
+          <link:arcroleRef xlink:type="simple" xlink:href="http://www.xbrl.org/lrr/arcrole/factExplanatory-2009-12-16.xsd#fact-explanatoryFact" arcroleURI="http://www.xbrl.org/2009/arcrole/fact-explanatoryFact" />
           <ix:relationship fromRefs="f1" toRefs="fn1 fn2" />
           <ix:relationship fromRefs="f4" toRefs="fn2 fn4" />
           <ix:relationship fromRefs="f11" toRefs="fn3" />
+          <ix:relationship fromRefs="f1" toRefs="f4" arcrole="http://www.xbrl.org/2009/arcrole/fact-explanatoryFact" />
         </ix:resources>
       </ix:header>
     </div>


### PR DESCRIPTION
This PR adds support for fact-explanatoryFact relationships.  These are footnote relationships between a pair of facts, rather than a fact and a footnote.  Prior to this PR, the viewer would crash when opening documents with these relationships.

Facts that are the target of footnote relationships are shown in the "Footnotes" section, alongside any text footnotes.

Facts that are the source of an inbound footnote relationship to another fact are shown in the "Associated facts" section, as they are currently in the footnote inspector.  The "associated facts" section is only shown for facts if there is at least one such inbound relationship.

This PR also fixes the highlighting of "related facts" (highlighting of other facts of in a calculation or search results) which previously only highlighted the main fact in an iXBRL document, and any continuation sections.