### PR TITLE
Document set cross document links / other links in new tabs

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -281,6 +281,9 @@ iXBRLReport.prototype.getRoleLabel = function(rolePrefix, viewerOptions) {
 }
 
 iXBRLReport.prototype.documentSetFiles = function() {
+    if (this.data.docSetFiles === undefined) {
+        return []
+    }
     return this.data.docSetFiles;
 }
 

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -239,14 +239,6 @@ Viewer.prototype._preProcessiXBRL = function(n, docIndex, inHidden) {
             $(node).addClass("ixbrl-element-footnote");
             ixn.footnote = true;
         }
-        if (elt) {
-            var concept = n.getAttribute("name");
-            if (elt.children().first().text() == "") {
-                elt.children().first().html("<i>no content</i>");
-            }
-            var tr = $("<tr></tr>").append("<td><div title=\"" + concept + "\">" + concept + "</div></td>").append($(elt).wrap("<td></td>").parent());
-            $("#ixbrl-inspector-hidden-facts-table-body").append(tr);
-        }
     }
     else if(n.nodeType == 1 && name == 'HIDDEN') {
         inHidden = true;

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -110,6 +110,23 @@ Viewer.prototype._addDocumentSetTabs = function() {
     }
 }
 
+
+/*
+ * Select the document within the current document set identified docIndex, and
+ * if specified, the element identified by fragment (via id or a.name
+ * attribute)
+ */
+Viewer.prototype._showDocumentAndElement = function (docIndex, fragment) {
+    this.selectDocument(docIndex); 
+    if (fragment !== undefined && fragment != "") {
+        const f = $.escapeSelector(fragment);
+        const ee = this._iframes.eq(docIndex).contents().find('#' + f + ', a[name="' + f + '"]');
+        if (ee.length > 0) {
+            this.showElement(ee.eq(0));
+        }
+    }
+}
+
 /*
  * Rewrite hyperlinks in the iXBRL.
  *
@@ -123,22 +140,17 @@ Viewer.prototype._updateLink = function(n) {
     const url = $(n).attr("href");
     if (url !== undefined) {
         const [file, fragment] = url.split('#', 2);
-        const docSetFiles = this._report.documentSetFiles();
-        if (this._report.isDocumentSet() && !url.includes('/') && docSetFiles.includes(file)) {
+        const docIndex = this._report.documentSetFiles().indexOf(file);
+        if (!url.includes('/') && docIndex != -1) {
             $(n).click((e) => { 
-                const index = docSetFiles.indexOf(file);
-                this.selectDocument(index); 
-                if (fragment !== undefined && fragment != "") {
-                    const f = $.escapeSelector(fragment);
-                    const ee = this._iframes.eq(index).contents().find('#' + f + ', a[name="' + f + '"]');
-                    if (ee.length > 0) {
-                        this.showElement(ee.eq(0));
-                    }
-                }
+                this._showDocumentAndElement(docIndex, fragment);
                 e.preventDefault(); 
             });
         }
         else {
+            // Open target in a new browser tab.  Without this, links will
+            // replace the contents of the current iframe in the viewer, which
+            // leaves the viewer in a confusing state.
             $(n).attr("target", "_blank");
         }
     }

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -129,7 +129,8 @@ Viewer.prototype._updateLink = function(n) {
                 const index = docSetFiles.indexOf(file);
                 this.selectDocument(index); 
                 if (fragment !== undefined && fragment != "") {
-                    const ee = this._iframes.eq(index).contents().find('#' + fragment);
+                    const f = $.escapeSelector(fragment);
+                    const ee = this._iframes.eq(index).contents().find('#' + f + ', a[name="' + f + '"]');
                     if (ee.length > 0) {
                         this.showElement(ee.eq(0));
                     }

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -198,9 +198,8 @@ Viewer.prototype._findOrCreateWrapperNode = function(domNode) {
 }
 
 Viewer.prototype._preProcessiXBRL = function(n, docIndex, inHidden) {
-    var elt;
-    var name = localName(n.nodeName).toUpperCase();
-    var isFootnote = (name == 'FOOTNOTE');
+    const name = localName(n.nodeName).toUpperCase();
+    const isFootnote = (name == 'FOOTNOTE');
     if(n.nodeType == 1 && (name == 'NONNUMERIC' || name == 'NONFRACTION' || name == 'CONTINUATION' || isFootnote)) {
         var node = $();
         const id = n.getAttribute("id");

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -119,10 +119,15 @@ Viewer.prototype._addDocumentSetTabs = function() {
 Viewer.prototype._showDocumentAndElement = function (docIndex, fragment) {
     this.selectDocument(docIndex); 
     if (fragment !== undefined && fragment != "") {
-        const f = $.escapeSelector(fragment);
-        const ee = this._iframes.eq(docIndex).contents().find('#' + f + ', a[name="' + f + '"]');
-        if (ee.length > 0) {
-            this.showElement(ee.eq(0));
+        // As per HTML spec, try fragment, then try %-decoded fragment
+        // https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-indicated-part-of-the-document
+        for (const fragment_option of [fragment, decodeURIComponent(fragment)]) {
+            const f = $.escapeSelector(fragment_option);
+            const ee = this._iframes.eq(docIndex).contents().find('#' + f + ', a[name="' + f + '"]');
+            if (ee.length > 0) {
+                this.showElement(ee.eq(0));
+                return
+            }
         }
     }
 }

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -59,14 +59,17 @@
     top: @top-bar-height;
     bottom: 0;
     z-index: 0;
+    display: flex;
+    flex-flow: column;
 
     .ixds-tabs {
       display: none;
+      flex: 0 1 auto;
     }
 
     #iframe-container {
       position: relative;
-      height: 100%;
+      flex: 1 1 auto;
 
       & > iframe {
         width: 100%;

--- a/samples/src/ixds-test/document1.html
+++ b/samples/src/ixds-test/document1.html
@@ -511,6 +511,8 @@ Profit Loss double tagged:
     <br />
     <a href="valeo.html#name-link-target">With fragment to name</a>
     <br />
+    <a href="valeo.html#%D1%86%D0%B5%D0%BB%D1%8C%20%D1%81%D1%81%D1%8B%D0%BB%D0%BA%D0%B8">%-encoded non-ASCII fragment</a>
+    <br />
     <a href="faurecia.html">Without fragment</a>
     <br />
     <a href="faurecia.html#">With empty fragment</a>

--- a/samples/src/ixds-test/document1.html
+++ b/samples/src/ixds-test/document1.html
@@ -507,7 +507,9 @@ Profit Loss double tagged:
     </div>
     <h3>Cross-document links</h3>
     <p>
-    <a href="faurecia.html#link-target">With fragment</a>
+    <a href="faurecia.html#link-target">With fragment to id</a>
+    <br />
+    <a href="valeo.html#name-link-target">With fragment to name</a>
     <br />
     <a href="faurecia.html">Without fragment</a>
     <br />

--- a/samples/src/ixds-test/document1.html
+++ b/samples/src/ixds-test/document1.html
@@ -505,5 +505,25 @@ Profit Loss double tagged:
         <i />
       </p>
     </div>
+    <h3>Cross-document links</h3>
+    <p>
+    <a href="faurecia.html#link-target">With fragment</a>
+    <br />
+    <a href="faurecia.html">Without fragment</a>
+    <br />
+    <a href="faurecia.html#">With empty fragment</a>
+    <br />
+    <a href="faurecia.html#does not exist">With non-existent fragment</a>
+    </p>
+    <p>
+    <a href="https://www.workiva.com">Absolute link</a>
+    </p>
+    <p>
+    <a href="doesnotexist.html">File not in document set</a>
+    </p>
+    <p style="height: 45px">
+    </p>
+    <p>
+    </p>
   </body>
 </html>

--- a/samples/src/ixds-test/faurecia.html
+++ b/samples/src/ixds-test/faurecia.html
@@ -368,5 +368,9 @@
     <p>
       Figure tagged in three reports <ix:nonFraction decimals="0" contextRef="c1" id="fx3" name="ifrs-full:WagesAndSalaries" unitRef="u1" sign="-" format="ixt2:numdotdecimal">1,234</ix:nonFraction>.
     </p>
+    <h2 id="link-target">Linkable section</h2>
+    <p>
+    This section can be linked to from another document.
+    </p>
   </body>
 </html>

--- a/samples/src/ixds-test/valeo.html
+++ b/samples/src/ixds-test/valeo.html
@@ -267,6 +267,8 @@
     </div>
       </div>
     </div>
+    <a name="name-link-target" />
+    <h3>Link target</h2>
     <p>
       Figure tagged in two reports <ix:nonFraction decimals="0" contextRef="c1" id="fx4" name="ifrs-full:EmployeeBenefitsExpense" unitRef="u1" sign="-" format="ixt2:numdotdecimal">1,234</ix:nonFraction>.
     </p>

--- a/samples/src/ixds-test/valeo.html
+++ b/samples/src/ixds-test/valeo.html
@@ -275,5 +275,7 @@
     <p>
       Figure tagged in three reports <ix:nonFraction decimals="0" contextRef="c1" id="fx5" name="ifrs-full:WagesAndSalaries" unitRef="u1" sign="-" format="ixt2:numdotdecimal">1,234</ix:nonFraction>.
     </p>
+    <h3 id="цель ссылки">Non-ASCII link target</h2>
+    <p>
   </body>
 </html>


### PR DESCRIPTION
This PR changes the handling of any hyperlinks in an iXBRL document in the viewer.

If viewing a document set, and the hyperlink is to a filename in the same directory, and that file is part of the current document set, the viewer will switch to the tab for that document, and scroll to the element specified by the fragment, if any.

Otherwise, the link will be opened in a new tab.

This PR also fixes a bug where the viewer pane is pushed off the bottom of the screen when the document set tab bar is visible.