### PR TITLE
Improve behaviour of next/prev tag with double tagged items

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -129,8 +129,8 @@ Inspector.prototype.initializeViewer = function () {
     viewer.onSelect.add((id, eltSet) => this.selectItem(id, eltSet));
     viewer.onMouseEnter.add((id) => this.viewerMouseEnter(id));
     viewer.onMouseLeave.add(id => this.viewerMouseLeave(id));
-    $('.ixbrl-next-tag').click(() => viewer.selectNextTag());
-    $('.ixbrl-prev-tag').click(() => viewer.selectPrevTag());
+    $('.ixbrl-next-tag').click(() => viewer.selectNextTag(this._currentItem));
+    $('.ixbrl-prev-tag').click(() => viewer.selectPrevTag(this._currentItem));
     this.search();
 }
 

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -35,6 +35,7 @@ const SEARCH_PAGE_SIZE = 100
 export function Inspector(iv) {
     this._iv = iv;
     this._viewerOptions = new ViewerOptions()
+    this._currentItem = null;
 }
 
 Inspector.prototype.i18nInit = function () {

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -389,11 +389,13 @@ Viewer.prototype.selectElement = function (itemId, itemIdList) {
 
 // Handle a mouse click to select.  This finds all tagged elements that the
 // mouse click is within, and returns a list of item IDs for the items that
-// they're tagging.
-// The selected element is the highest ancestor which has the same content as
-// the clicked element.  This is so that when we have double tagged elements,
-// we select the first of the set, but where we have nested elements, we select
-// the innermost.
+// they're tagging.  This is so the inspector can show all items that were
+// under the click.
+// The initially selected element is the highest ancestor which is tagging
+// exactly the same content as the clicked element.  This is so that when we
+// have double tagged elements, we select the first of the set, but where we
+// have nested elements, we select the innermost, as this gives the most
+// intuitive behaviour when clicking "next".
 Viewer.prototype.selectElementByClick = function (e) {
     var itemIDList = [];
     var viewer = this;

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -161,7 +161,9 @@ Viewer.prototype._preProcessiXBRL = function(n, docIndex, inHidden) {
             var ivids = node.data('ivid') || [];
             ivids.push(id);
             node.addClass("ixbrl-element").data('ivid', ivids);
-            this._docOrderIDIndex.push(id);
+            if (name != 'CONTINUATION') {
+                this._docOrderIDIndex.push(id);
+            }
         }
         /* We may have already created an IXNode for this ID from a -sec-ix-hidden
          * element */

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -110,6 +110,24 @@ Viewer.prototype._addDocumentSetTabs = function() {
     }
 }
 
+
+// Wrap a node in a div or span.  If the node or any descendent has display:
+// block, a div is used, otherwise a span.
+// Returns the wrapper node
+Viewer.prototype._wrapNode = function(n) {
+    var wrapper = "<span>";
+    var nn = n.getElementsByTagName("*");
+    for (var i = 0; i < nn.length; i++) {
+        if($(nn[i]).css("display") === "block") {
+            wrapper = '<div>';
+            break;
+        }
+    }
+    $(n).wrap(wrapper);
+    return $(n).parent();
+}
+    
+
 Viewer.prototype._preProcessiXBRL = function(n, docIndex, inHidden) {
     var elt;
     var name = localName(n.nodeName).toUpperCase();
@@ -132,18 +150,9 @@ Viewer.prototype._preProcessiXBRL = function(n, docIndex, inHidden) {
                     node = $();
                 } 
             }
-            /* Otherwise, insert a <span> as wrapper */
+            // Otherwise, wrap in a div or span
             if (node.length == 0) {
-                var wrapper = "<span>";
-                var nn = n.getElementsByTagName("*");
-                for (var i = 0; i < nn.length; i++) {
-                    if($(nn[i]).css("display") === "block") {
-                        wrapper = '<div>';
-                        break;
-                    }
-                }
-                $(n).wrap(wrapper);
-                node = $(n).parent();
+                node = this._wrapNode(n);
             }
             /* If we use an enclosing table cell as the wrapper, we may have
              * multiple tags in a single element. */


### PR DESCRIPTION
The PR fixes and improves behaviour of the next/prev tag buttons in the presence of double-tagged facts.

Firstly, if you double tag a value which is the only content of a table cell, next/prev fact navigation would always skip over the second fact. This is now fixed, so next/prev will take you through each tag in turn.

Secondly, whenever you have double-tagged facts, clicking on the fact would show both in the inspector, but select the second (innermost) fact, meaning that "next" would take you onto a completely different fact.  This is now fixed so that it is the first fact that is selected, and "next" will take you to the second fact.   This logic is only applied for double tags (i.e. two tags with exactly the same content) not for other nested facts.

Fixes XT-1383