### PR TITLE
Fix same-document links

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -152,7 +152,7 @@ Viewer.prototype._updateLink = function(n) {
                 e.preventDefault(); 
             });
         }
-        else {
+        else if (file) {
             // Open target in a new browser tab.  Without this, links will
             // replace the contents of the current iframe in the viewer, which
             // leaves the viewer in a confusing state.


### PR DESCRIPTION
### Description
- Fixes same document hyperlinking
    -  Master's behavior was that a new tab was opened and the link didn't take you to the location within the document
    
### Steps to Test
1. Create an ixbrl file with a link to a different location within itself (preferrably a different page so you can verify it actually scrolls)
2. Generate an ixbrl-viewer using master
    a. Verify that clicking on the hyperlink opens a new tab and doesn't take you to the desired location within the doc
3. Generate an ixbrl-viewer using this branch
    a. Verify that clicking on the hyperlink doesn't open a new tab and navigates you within the document
  
  
### please review:
@paulwarren-wk @derekgengenbacher-wf @austinmatherne-wk 