### PR TITLE
Ensure that <script> tags always use default namespace (#282)

### DIFF
--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -300,17 +300,21 @@ class IXBRLViewerBuilder:
             if child.tag == '{http://www.w3.org/1999/xhtml}body':
                 child.append(etree.Comment("BEGIN IXBRL VIEWER EXTENSIONS"))
 
-                e = etree.fromstring("<script xmlns='http://www.w3.org/1999/xhtml' type='text/javascript' />")
+                # Insert <script> tags, and make sure that they are in the
+                # default namespace, so that browsers in HTML mode will find
+                # them.
+                nsmap = { None: "http://www.w3.org/1999/xhtml" }
+                e = etree.SubElement(child, "{http://www.w3.org/1999/xhtml}script", nsmap = nsmap)
+                e.set("type", "text/javascript")
                 e.set("src", scriptUrl)
                 # Don't self close
                 e.text = ''
-                child.append(e)
 
                 # Putting this in the header can interfere with character set
-                # auto detection
-                e = etree.fromstring("<script xmlns='http://www.w3.org/1999/xhtml' type='application/x.ixbrl-viewer+json'></script>")
+                # auto detection due to its length
+                e = etree.SubElement(child, "{http://www.w3.org/1999/xhtml}script", nsmap = nsmap)
+                e.set("type", "application/x.ixbrl-viewer+json")
                 e.text = taxonomyDataJSON
-                child.append(e)
                 child.append(etree.Comment("END IXBRL VIEWER EXTENSIONS"))
                 break
 


### PR DESCRIPTION
Certain input documents could cause the generated viewer to use prefixed `<script>` tags (`<xhtml:script>` rather than `<script>`).  Doing so will either cause the viewer to load completely, or the viewer will load, then fail with "Could not find viewer data") (the failure mode depends on whether the browser treats the file as HTML or XHTML).

The arrangement that triggers the bug is where the input document uses a default HTML5 namespace, but also declares a non-default prefix for that namespace, and the non-default NS declaration appears first, i.e.:

```
<html 
  xmlns:xhtml="http://www.w3.org/1999/xhtml"  
  xmlns="http://www.w3.org/1999/xhtml"
  >
```

A real world example of this is [this filing](https://filings.xbrl.org/549300CSLHPO6Y1AZN37/2021-12-31/ESEF/SE/0/)

This PR fixes this, so that the inserted `<script>` tags always use the default namespace.

Fixes #282 