### PR TITLE
Ignore iXBRL elements that are not in the default target document

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -208,7 +208,11 @@ Viewer.prototype._findOrCreateWrapperNode = function(domNode) {
 Viewer.prototype._preProcessiXBRL = function(n, docIndex, inHidden) {
     const name = localName(n.nodeName).toUpperCase();
     const isFootnote = (name == 'FOOTNOTE');
-    if(n.nodeType == 1 && (name == 'NONNUMERIC' || name == 'NONFRACTION' || name == 'CONTINUATION' || isFootnote)) {
+    // Ignore iXBRL elements that are not in the default target document, as
+    // the viewer builder does not handle these, and does not ensure that they
+    // have ID attributes.
+    if (n.nodeType == 1 && (name == 'NONNUMERIC' || name == 'NONFRACTION' || name == 'CONTINUATION' || isFootnote)
+        && !n.hasAttribute("target")) {
         var node = $();
         const id = n.getAttribute("id");
         if (!inHidden) {

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -259,33 +259,44 @@ Viewer.prototype._preProcessiXBRL = function(n, docIndex, inHidden) {
     }
     else if(n.nodeType == 1) {
         // Handle SEC/ESEF links-to-hidden
-        if (n.hasAttribute('style')) {
-            const re = /(?:^|\s|;)-(?:sec|esef)-ix-hidden:\s*([^\s;]+)/;
-            var m = n.getAttribute('style').match(re);
-            if (m) {
-                const id = m[1];
-                node = $(n);
-                node.addClass("ixbrl-element").data('ivid', [id]);
-                this._docOrderIDIndex.push(id);
-                /* We may have already seen the corresponding ix element in the hidden
-                 * section */
-                var ixn = this._ixNodeMap[id];
-                if (ixn) {
-                    /* ... if so, update the node and docIndex so we can navigate to it */
-                    ixn.wrapperNode = node;
-                    ixn.docIndex = docIndex;
-                }
-                else {
-                    this._ixNodeMap[id] = new IXNode(id, node, docIndex);
-                }
+        const id = this._getIXHiddenLinkStyle(n);
+        if (id !== null) {
+            node = $(n);
+            node.addClass("ixbrl-element").data('ivid', [id]);
+            this._docOrderIDIndex.push(id);
+            /* We may have already seen the corresponding ix element in the hidden
+             * section */
+            var ixn = this._ixNodeMap[id];
+            if (ixn) {
+                /* ... if so, update the node and docIndex so we can navigate to it */
+                ixn.wrapperNode = node;
+                ixn.docIndex = docIndex;
+            }
+            else {
+                this._ixNodeMap[id] = new IXNode(id, node, docIndex);
             }
         }
         if (name == 'A') {
             this._updateLink(n);
         }
     }
-    for (var i=0; i < n.childNodes.length; i++) {
-        this._preProcessiXBRL(n.childNodes[i], docIndex, inHidden);
+    this._preProcessChildNodes(n, docIndex, inHidden);
+}
+
+Viewer.prototype._getIXHiddenLinkStyle = function(domNode) {
+    if (domNode.hasAttribute('style')) {
+        const re = /(?:^|\s|;)-(?:sec|esef)-ix-hidden:\s*([^\s;]+)/;
+        const m = domNode.getAttribute('style').match(re);
+        if (m) {
+            return m[1];
+        }
+    }
+    return null;
+}
+
+Viewer.prototype._preProcessChildNodes = function (domNode, docIndex, inHidden) {
+    for (const childNode of domNode.childNodes) {
+        this._preProcessiXBRL(childNode, docIndex, inHidden);
     }
 }
 


### PR DESCRIPTION
This fixes a bug whereby next/prev tag selection did not work reliably, and "highlight XBRL elements" did not work at all on some filings with multiple target documents.

The bug is triggered when facts in the non-default target document do not have an ID attribute.  The viewer relies on all facts having ID attributes, and the viewer generator adds ID attributes for all facts, but only for the current target document (which is always the default).

It would good to add proper support for multiple target documents, but this fix makes the default target document work reliably.

The problem can be seen with this filing:

https://filings.xbrl.org/5299007OWYZ6I1E46843/2021-12-31/ESEF/DK/0/

Steps to reproduce:

* Open viewer
* No tag should be selected
* Hit "next tag"
* Nothing happens.
* Manually scroll to a tagged section of the document
* Hit "Highlight XBRL Elements"
* Note that elements are not highlighted.

