### PR TITLE
Fix scroll-to-fact in documents with elements with overflowing content

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -377,7 +377,9 @@ Viewer.prototype.showElement = function(e) {
             lastPositionedElement = ee;
             childOffset += ee.offsetTop;
         }
-        if (ee.clientHeight > 0 && ee.clientHeight < ee.scrollHeight) {
+        const overflow = $(ee).css('overflow-y');
+        if (ee.clientHeight > 0 && ee.clientHeight < ee.scrollHeight 
+            && (overflow == "auto" || overflow == 'scroll' || ee.nodeName.toUpperCase() == 'HTML')) {
             /* This is a scrollable element.  Calculate the position of the
              * child we're trying to show within it. */
             var childPosition = childOffset - ee.offsetTop;

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -358,6 +358,13 @@ Viewer.prototype.selectPrevTag = function (currentFact) {
     this._selectAdjacentTag(-1, currentFact);
 }
 
+
+Viewer.prototype.isScrollableElement = function (domNode) {
+    const overflow = $(domNode).css('overflow-y');
+    return (domNode.clientHeight > 0 && domNode.clientHeight < domNode.scrollHeight 
+        && (overflow == "auto" || overflow == 'scroll' || domNode.nodeName.toUpperCase() == 'HTML'));
+}
+
 /* Make the specified element visible by scrolling any scrollable ancestors */
 Viewer.prototype.showElement = function(e) {
     /* offsetTop gives the position relative to the nearest positioned element.
@@ -377,9 +384,7 @@ Viewer.prototype.showElement = function(e) {
             lastPositionedElement = ee;
             childOffset += ee.offsetTop;
         }
-        const overflow = $(ee).css('overflow-y');
-        if (ee.clientHeight > 0 && ee.clientHeight < ee.scrollHeight 
-            && (overflow == "auto" || overflow == 'scroll' || ee.nodeName.toUpperCase() == 'HTML')) {
+        if (this.isScrollableElement(ee)) {
             /* This is a scrollable element.  Calculate the position of the
              * child we're trying to show within it. */
             var childPosition = childOffset - ee.offsetTop;


### PR DESCRIPTION
This PR fixes a bug whereby navigating to a fact did not reliably scroll to the right location.  It can be seen with this document:

https://filings.xbrl.org/5299007OWYZ6I1E46843/2021-12-31/ESEF/DK/0/

And can be seen with this direct link:

https://filings.xbrl.org/5299007OWYZ6I1E46843/2021-12-31/ESEF/DK/0/5299007OWYZ6I1E46843-2021-12-31-en/reports/ixbrlviewer.html#f-ixv-4

This selects the Revenue element, but unless you have a really tall screen, the tag will be off the top of the page (it should be in the middle).

To reproduce manually:

* Open the above document in a viewer.
* Scroll to top of document.
* Search for "Revenue"
* Double click
* Viewer will be centered on the page containing the fact, not the fact itself.

The viewer employs the following logic to focus a fact:

* Find the element to focus
* Find the nearest scrollable ancestor
* Center the current element within the visible area of that ancestor
* The scrollable element becomes the current element, and we continue up the tree.

The issue was that the viewer was misidentifying some facts as scrollable when they weren't (scroll height larger than client height, but `overflow-y` not set to `visible` or `auto`).  In the sample above, the page divs were being treated as  scrollable, so the whole page was being centered, and if the page is taller  than the screen, facts at the top or bottom of the page will not be scrolled into view.

Confusingly, it's the `<body>` element that reports itself as  `overflow-y: auto` but the `<html>` element that has a scroll height large than client height, hence the special casing of the `<html>` element. 

Reviewing this code, I realise the algorithm is still slightly flawed: If you have nested scrollable elements, and the inner one is taller than the view port, and the fact to be focused is at the very beginning or end of the inner scroll area, it won't be able to center the scroll area on the fact, and so centering the inner scroll area within the outer scroll area may not get the fact on the page.  Fixing is non-trivial, and I don't think this will ever come up in reality.  The code to cope with nested scroll areas was introduced because we've  seen filings where the scroll area is not the HTML body, but a fixed `<div>` element inside the body. i.e. there's still a single scrollable element, it's just not the body.  I don't think reports that actually have multiple scroll areas is likely. 

