### PR TITLE
Show footnotes on hidden facts

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -253,7 +253,7 @@ Fact.prototype.footnotes = function () {
 }
 
 Fact.prototype.isHidden = function () {
-    return this.ixNode.wrapperNode.length == 0;
+    return this.ixNode.isHidden;
 }
 
 Fact.prototype.isHTMLHidden = function () {

--- a/iXBRLViewerPlugin/viewer/src/js/ixnode.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixnode.js
@@ -32,6 +32,7 @@ export function IXNode(id, wrapperNode, docIndex) {
     this.docIndex = docIndex;
     this.footnote = false;
     this.id = id;
+    this.isHidden = false;
     this.htmlHidden = false;
     this.docOrderindex = docOrderindex++;
 }

--- a/iXBRLViewerPlugin/viewer/src/js/outline.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/outline.test.js
@@ -351,21 +351,21 @@ describe("Section grouping", () => {
 
         // Make f1c hidden.  We now have ELR1*2 ELR3*1 ELR1*2
         // The first ELR1 run should be selected.
-        report.getItemById("f1c").ixNode.wrapperNode = $('');
+        report.getItemById("f1c").ixNode.isHidden = true;
         outline = new DocumentOutline(report);
         expect(outline.sortedSections()).toEqual(["elr1", "elr3"]);
         expect(outline.sections["elr1"].id).toEqual("f1a");
         expect(outline.sections["elr3"].id).toEqual("f2");
 
         // Make f1a hidden.  f1b-[f1c]-f1d is now the longest run.
-        report.getItemById("f1a").ixNode.wrapperNode = $('');
+        report.getItemById("f1a").ixNode.isHidden = true;
         outline = new DocumentOutline(report);
         expect(outline.sortedSections()).toEqual(["elr1", "elr3"]);
         expect(outline.sections["elr1"].id).toEqual("f1b");
         expect(outline.sections["elr3"].id).toEqual("f2");
 
         // Hide f2.  We now have a single run for ELR1
-        report.getItemById("f2").ixNode.wrapperNode = $('');
+        report.getItemById("f2").ixNode.isHidden = true;
         outline = new DocumentOutline(report);
         expect(outline.sortedSections()).toEqual(["elr1"]);
         expect(outline.sections["elr1"].id).toEqual("f1");

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -215,10 +215,10 @@ Viewer.prototype._preProcessiXBRL = function(n, docIndex, inHidden) {
         && !n.hasAttribute("target")) {
         var node;
         const id = n.getAttribute("id");
-        if (!inHidden) {
-            node = this._findOrCreateWrapperNode(n);
-        } else {
+        if (inHidden) {
             node = $(n);
+        } else {
+            node = this._findOrCreateWrapperNode(n);
         }
         /* We may have already created an IXNode for this ID from a -sec-ix-hidden
          * element */

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -213,10 +213,12 @@ Viewer.prototype._preProcessiXBRL = function(n, docIndex, inHidden) {
     // have ID attributes.
     if (n.nodeType == 1 && (name == 'NONNUMERIC' || name == 'NONFRACTION' || name == 'CONTINUATION' || isFootnote)
         && !n.hasAttribute("target")) {
-        var node = $();
+        var node;
         const id = n.getAttribute("id");
         if (!inHidden) {
             node = this._findOrCreateWrapperNode(n);
+        } else {
+            node = $(n);
         }
         /* We may have already created an IXNode for this ID from a -sec-ix-hidden
          * element */
@@ -227,6 +229,9 @@ Viewer.prototype._preProcessiXBRL = function(n, docIndex, inHidden) {
         }
         if (node.is(':hidden')) {
             ixn.htmlHidden = true;
+        }
+        if (inHidden) {
+            ixn.isHidden = true;
         }
         if (n.getAttribute("continuedAt")) {
             this._continuedAtMap[id] = { 

--- a/samples/build-viewer.py
+++ b/samples/build-viewer.py
@@ -21,7 +21,7 @@ import os
 import sys
 import glob
 import argparse
-import iXBRLViewerPlugin
+import iXBRLViewerPlugin.iXBRLViewer
 from arelle.plugin import inlineXbrlDocumentSet
 
 class CntlrCreateViewer(Cntlr.Cntlr):
@@ -55,10 +55,10 @@ class CntlrCreateViewer(Cntlr.Cntlr):
         self.modelManager.validate()
 
         try:
-            viewerBuilder = iXBRLViewerPlugin.IXBRLViewerBuilder(xbrl)
+            viewerBuilder = iXBRLViewerPlugin.iXBRLViewer.IXBRLViewerBuilder(xbrl)
             viewer = viewerBuilder.createViewer(scriptUrl = scriptUrl)
             viewer.save(outPath)
-        except IXBRLViewerBuilderError as e:
+        except iXBRLViewerPlugin.iXBRLViewer.IXBRLViewerBuilderError as e:
             print(e.message)
             sys.exit(1)
 

--- a/samples/src/ixds-test/document1.html
+++ b/samples/src/ixds-test/document1.html
@@ -25,6 +25,10 @@
   <body xmlns="http://www.w3.org/1999/xhtml">
     <div style="display: none">
       <ix:header>
+        <ix:hidden>
+          <ix:nonFraction format="ixt:numdotdecimal" unitRef="u1" id="f-hidden" name="ifrs:DeferredTaxAssets" contextRef="c3" decimals="0">123456</ix:nonFraction>
+          <ix:footnote xml:lang="en" id="fn-f-hidden">This is a footnote</ix:footnote>
+        </ix:hidden>
         <ix:references>
           <link:schemaRef xlink:type="simple" xlink:href="http://xbrl.ifrs.org/taxonomy/2017-03-09/full_ifrs_entry_point_2017-03-09-es.xsd" />
           <link:schemaRef xlink:href="http://xbrl.ifrs.org/taxonomy/2017-03-09/full_ifrs_doc_entry_point_2017-03-09.xsd" xlink:type="simple" />
@@ -187,6 +191,7 @@
           <xbrli:unit id="EUR">
             <xbrli:measure>iso4217:EUR</xbrli:measure>
           </xbrli:unit>
+          <ix:relationship arcrole="http://www.xbrl.org/2003/arcrole/fact-footnote" linkRole="http://www.xbrl.org/2003/role/link" fromRefs="f-hidden" toRefs="fn-f-hidden"/>
         </ix:resources>
       </ix:header>
     </div>


### PR DESCRIPTION
#### Description:
Show footnotes on hidden facts

#### Testing:
Create a viewer from this [doc](https://github.com/Workiva/ixbrl-viewer/files/8566016/footnote-on-hidden-fact.zip) . Then pull this branch locally, build the javascript and drop it into a folder with the ixbrl-viewer docs. Update the doc to point at the new javascript. Start up a simple python server from the ixbrl-viewer directory and then navigate to the html doc. Do a search for `AccumulatedDeferredInvestmentTaxCredits`. The first 7 facts should be hidden. Click through them and verify that the footnotes are shown for some of the facts. 



**review**:
@Workiva/xt