### PR TITLE
Fix handling of roleDef with no definition

### DIFF
--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -131,8 +131,9 @@ class IXBRLViewerBuilder:
         prefix = self.roleMap.getPrefix(elr)
         if self.taxonomyData.setdefault("roleDefs",{}).get(prefix, None) is None:
             rts = self.dts.roleTypes.get(elr, [])
-            label = next((rt.definition for rt in rts if rt.definition is not None), elr)
-            self.taxonomyData["roleDefs"].setdefault(prefix,{})["en"] = label
+            label = next((rt.definition for rt in rts if rt.definition is not None), None)
+            if label is not None:
+                self.taxonomyData["roleDefs"].setdefault(prefix,{})["en"] = label
 
     def addConcept(self, concept, dimensionType = None):
         if concept is None:

--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -130,10 +130,8 @@ class IXBRLViewerBuilder:
     def addELR(self, elr):
         prefix = self.roleMap.getPrefix(elr)
         if self.taxonomyData.setdefault("roleDefs",{}).get(prefix, None) is None:
-            rt = self.dts.roleTypes[elr]
-            label = elr
-            if len(rt) > 0:
-                label = rt[0].definition
+            rts = self.dts.roleTypes.get(elr, [])
+            label = next((rt.definition for rt in rts if rt.definition is not None), elr)
             self.taxonomyData["roleDefs"].setdefault(prefix,{})["en"] = label
 
     def addConcept(self, concept, dimensionType = None):

--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -149,6 +149,10 @@ iXBRLReport.prototype.prefixMap = function() {
     return this.data.prefixes;
 }
 
+iXBRLReport.prototype.roleMap = function() {
+    return this.data.roles;
+}
+
 iXBRLReport.prototype.qname = function(v) {
     return new QName(this.prefixMap(), v);
 }
@@ -283,8 +287,19 @@ iXBRLReport.prototype.getRoleLabel = function(rolePrefix, viewerOptions) {
     /* This is currently hard-coded to "en" as the generator does not yet
      * support generic labels, and instead provides the (non-localisable) role
      * definition as a single "en" label.
+     *
+     * Returns the ELR URI if there is no label
      */
-    return this.data.roleDefs[rolePrefix]["en"];
+    const labels = this.data.roleDefs[rolePrefix];
+    if (labels !== undefined) {
+        const label = labels["en"];
+        // Earlier versions of the generator added a "null" label if no labels
+        // were available.
+        if (label !== undefined && label !== null) {
+            return label;
+        }
+    }
+    return this.roleMap()[rolePrefix];
 }
 
 iXBRLReport.prototype.documentSetFiles = function() {

--- a/iXBRLViewerPlugin/viewer/src/js/report.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.test.js
@@ -24,6 +24,17 @@ var testReportData = {
         "eg": "http://www.example.com",
         "iso4217": "http://www.xbrl.org/2003/iso4217"
     },
+    "roles": {
+        "role1": "https://www.example.com/role1",
+        "role2": "https://www.example.com/role2",
+        "role3": "https://www.example.com/role3",
+        "role4": "https://www.example.com/role4"
+    },
+    "roleDefs": {
+        "role1": { "en": "Role 1 Label" },
+        "role2": { "en": null },
+        "role3": {}
+    },
     "concepts": {
         "eg:Concept1": {
             "labels": {
@@ -128,6 +139,23 @@ describe("Concept labels", () => {
 
         expect(testReport.getLabel('eg:Concept3', 'doc', true)).toBeUndefined();
         expect(testReport.getLabelOrName('eg:Concept3', 'doc', true)).toBe("eg:Concept3");
+    });
+
+});
+
+describe("ELR labels", () => {
+    const testReport = new iXBRLReport(testReportData);
+    test("Present", () => {
+        expect(testReport.getRoleLabel("role1")).toBe("Role 1 Label");
+    });
+    test("Null", () => {
+        expect(testReport.getRoleLabel("role2")).toBe("https://www.example.com/role2");
+    });
+    test("No label", () => {
+        expect(testReport.getRoleLabel("role3")).toBe("https://www.example.com/role3");
+    });
+    test("Not present in roleDef", () => {
+        expect(testReport.getRoleLabel("role4")).toBe("https://www.example.com/role4");
     });
 
 });

--- a/tests/unit_tests/iXBRLViewerPlugin/test_iXBRLViewer.py
+++ b/tests/unit_tests/iXBRLViewerPlugin/test_iXBRLViewer.py
@@ -362,18 +362,16 @@ class TestIXBRLViewer(unittest.TestCase):
 
     def test_addELR_no_definition(self):
         """
-        Adding an ELR with no definition should result in an "en" label with
-        the roleURI as its value
+        Adding an ELR with no definition should result in no entry in the roleDefs map
         """
         elr = "http://example.com/unknownELR"
         self.builder_1.addELR(elr)
         elrPrefix = self.builder_1.roleMap.getPrefix(elr)
-        self.assertEqual(self.builder_1.taxonomyData.get('roleDefs').get(elrPrefix).get("en"), elr)
+        self.assertEqual(self.builder_1.taxonomyData.get('roleDefs').get(elrPrefix), None)
 
     def test_addELR_with_definition(self):
         """
-        Adding an ELR with no definition should result in an "en" label with
-        the roleURI as its value
+        Adding an ELR with a definition should result in an "en" label with the definition as its value.
         """
         elr = "ELR"
         self.builder_1.addELR(elr)


### PR DESCRIPTION
This PR fixes a bug where the viewer would fail to load if the taxonomy contained a `<roleDef>` element without a `<definition>` element, and the role was included in the document outline view.

[Example report with missing definition elements](https://filings.xbrl.org/391200EUISAEF39QR618/2021-12-31/ESEF/MT/0/BrownsPharmaHoldingplc-2021-12-31.zip)

This construct resulted in `null` being included in the taxonomy data as the label for the role, with a resulting error when used with [`localeCompare`](https://github.com/paulwarren-wk/ixbrl-viewer/blob/fix-null-roleDef/iXBRLViewerPlugin/viewer/src/js/outline.js#L167)