### PR TITLE
Fix Arelle local viewer

### DIFF
--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -202,7 +202,7 @@ class IXBRLViewerBuilder:
         dts = self.dts
 
         logHandler = dts.modelManager.cntlr.logHandler
-        if not hasattr(logHandler, "logRecordBuffer"):
+        if getattr(logHandler, "logRecordBuffer") is None:
             raise IXBRLViewerBuilderError("Logging is not configured to use a buffer.  Unable to retrieve validation messages")
 
         errors = []

--- a/iXBRLViewerPlugin/localviewer.py
+++ b/iXBRLViewerPlugin/localviewer.py
@@ -41,7 +41,7 @@ class iXBRLViewerLocalViewer(LocalViewer):
                 _file = os.path.filepart(_file)
             if not _fileExists:
                 self.cntlr.addToLog("http://localhost:{}/{}".format(self.port,file), messageCode="localViewer:fileNotFound",level=logging.DEBUG)
-            return static_file(_file, root=_fileDir, more_headers=self.noCacheHeaders) # extra_headers modification to py-bottle
+            return static_file(_file, root=_fileDir, headers=self.noCacheHeaders) # extra_headers modification to py-bottle
         return static_file(file, root="/") # probably can't get here unless path is wrong
 
 localViewer = iXBRLViewerLocalViewer("iXBRL Viewer",  os.path.dirname(__file__))

--- a/iXBRLViewerPlugin/localviewer.py
+++ b/iXBRLViewerPlugin/localviewer.py
@@ -50,7 +50,7 @@ def launchLocalViewer(cntlr, modelXbrl):
     from arelle import LocalViewer
     try:
         viewerBuilder = IXBRLViewerBuilder(cntlr.modelManager.modelXbrl)
-        iv = viewerBuilder.createViewer(scriptUrl="/ixbrlviewer.js")
+        iv = viewerBuilder.createViewer(scriptUrl="/ixbrlviewer.js", showValidations = False)
         # first check if source file was in an archive (e.g., taxonomy package)
         _archiveFilenameParts = archiveFilenameParts(modelXbrl.modelDocument.filepath)
         if _archiveFilenameParts is not None:


### PR DESCRIPTION
This fixes a regression in the Arelle GUI local viewer behaviour reported as #275.

To reproduce, open the Arelle GUI, enable the iXBRL viewer plugin, and check View ->iXBRL Viewer -> launch viewer on load.

Open any iXBRL report, and note the stack trace reported in the log as per #275.

With this PR, the report should open with the viewer enabled in a browser window.

The stack trace was masking two further problems:

1. Arelle in GUI mode doesn't appear to use a log buffer, so we can't get validation messages.  The PR disables showing validation messages in the viewer.
2. `localviewer.py` was using incorrect/out-of-date arguments for Arelle's `static_file` function.

Fixes #275 