### PR TITLE
XT-2147: Update Node to LTS release for builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.idea
+.github
+.vscode
+aviary.yaml
+CODEOWNERS
+Dockerfile
+node_modules

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,12 +35,6 @@ updates:
   - dependency-name: less-loader
     versions:
     - ">=7"
-  - dependency-name: stylelint
-    versions:
-    - ">=14"
-  - dependency-name: stylelint-config-standard
-    versions:
-    - ">=22"
   - dependency-name: webpack-cli
     versions:
     - ">=4"

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+.idea
+.vscode
 node_modules/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,4 +67,4 @@ ARG BUILD_ARTIFACTS_AUDIT=/audit/*
 RUN mkdir /audit/
 RUN pip freeze > /audit/pip.lock
 
-# FROM scratch
+FROM scratch

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
-FROM python:3.9-buster as build
+FROM node:16-slim as node-build
 
-ARG PIP_INDEX_URL
 ARG NPM_CONFIG__AUTH
 ARG NPM_CONFIG_REGISTRY=https://workivaeast.jfrog.io/workivaeast/api/npm/npm-prod/
 ARG NPM_CONFIG_ALWAYS_AUTH=true
 ARG GIT_TAG
 
-COPY requirements-dev.txt ./requirements-dev.txt
-COPY requirements.txt ./requirements.txt
-RUN pip install -r requirements-dev.txt
-
 WORKDIR /build/
-ADD . /build/
+
+COPY package.json /build/
+RUN npm update --location=global && \
+    npm install --include=dev
+
+COPY . /build/
 
 # The following command replaces the version string in setup.py and package.json
 # with the tagged version number from GIT_TAG or `0.0.0` if GIT_TAG is not set
@@ -19,18 +19,14 @@ ARG VERSION=${GIT_TAG:-0.0.0}
 RUN sed -i "s/version='0\.0\.0'/version='$VERSION'/" setup.py
 RUN sed -i "s/\"version\": \"0\.0\.0\"/\"version\": \"$VERSION\"/" package.json
 
-# build ixbrlviewer.js
-RUN apt-get update && apt-get install -y curl && \
-    curl -sL https://deb.nodesource.com/setup_10.x | bash && \
-    apt-get install -y nodejs build-essential
-RUN npm install
-RUN make prod
+# lint check .less files
+RUN npm run stylelint
 
 # javascript tests
 RUN npm run test
 
-# lint check .less files
-RUN npm run stylelint
+# build ixbrlviewer.js
+RUN npm run prod
 
 # Upload ixbrlviewer.js to github artifacts
 ARG BUILD_ARTIFACTS_GITHUB_RELEASE_ASSETS=/build/iXBRLViewerPlugin/viewer/dist/ixbrlviewer.js
@@ -39,6 +35,24 @@ ARG BUILD_ARTIFACTS_GITHUB_RELEASE_ASSETS=/build/iXBRLViewerPlugin/viewer/dist/i
 RUN mkdir /static_release
 RUN tar -czf /static_release/assets.tar.gz -C /build/iXBRLViewerPlugin/viewer/dist/ .
 ARG BUILD_ARTIFACTS_CDN=/static_release/assets.tar.gz
+
+# npm package creation
+RUN npm pack
+ARG BUILD_ARTIFACTS_NPM=/build/*.tgz
+
+FROM python:3.9-slim as python-build
+
+ARG PIP_INDEX_URL
+ARG GIT_TAG
+
+WORKDIR /build/
+
+COPY requirements*.txt /build/
+RUN pip install -U pip setuptools && \
+    pip install -r requirements-dev.txt
+
+COPY . /build/
+COPY --from=node-build /build/iXBRLViewerPlugin/viewer/dist /build/iXBRLViewerPlugin/viewer/dist
 
 # python tests
 ARG BUILD_ARTIFACTS_TEST=/test_reports/*.xml
@@ -49,12 +63,8 @@ RUN nosetests --with-xunit --xunit-file=/test_reports/results.xml --cover-html t
 ARG BUILD_ARTIFACTS_PYPI=/build/dist/*.tar.gz
 RUN python setup.py sdist
 
-# npm package creation
-RUN npm pack
-ARG BUILD_ARTIFACTS_NPM=/build/*.tgz
-
 ARG BUILD_ARTIFACTS_AUDIT=/audit/*
 RUN mkdir /audit/
 RUN pip freeze > /audit/pip.lock
 
-FROM scratch
+# FROM scratch

--- a/iXBRLViewerPlugin/viewer/src/less/fonts.less
+++ b/iXBRLViewerPlugin/viewer/src/less/fonts.less
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+@import (reference) "icons.less";
+
 @font-face {
-  font-family: "viewericons";
-  src: url('../fonts/viewer-icons-min.woff');
+  font-family: viewericons;
+  src: url("../fonts/viewer-icons-min.woff");
   font-weight: normal;
   font-style: normal;
 }
-
-@import (reference) "icons.less";

--- a/iXBRLViewerPlugin/viewer/src/less/form-controls.less
+++ b/iXBRLViewerPlugin/viewer/src/less/form-controls.less
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-input[type=text],
+input[type="text"],
 select,
 button {
-  padding: 7px 5px 7px 5px;
+  padding: 7px 5px;
   border: solid 1px @border-grey;
   border-radius: 5px;
   color: @text;

--- a/iXBRLViewerPlugin/viewer/src/less/icons.less
+++ b/iXBRLViewerPlugin/viewer/src/less/icons.less
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 .viewericon(@char) {
-  font-family: "viewericons";
+  font-family: viewericons;
   content: @char;
 }
 

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -85,7 +85,7 @@
         width: 20px;
         height: 20px;
         border: solid 1px #bbb;
-        background-color: rgba(225, 225, 225, 0.7);
+        background-color: rgba(225 225 225 70%);
         justify-content: center;
         display: flex;
         align-items: center;
@@ -104,7 +104,7 @@
 
       .zoom-in:hover,
       .zoom-out:hover {
-        background-color: rgba(128, 128, 128, 0.7);
+        background-color: rgba(128 128 128 70%);
       }
     }
 
@@ -940,7 +940,7 @@
   }
 
   .dialog-mask {
-    background-color: rgba(0, 0, 0, 0.6);
+    background-color: rgba(0 0 0 60%);
     position: fixed;
     top: 0;
     bottom: 0;

--- a/iXBRLViewerPlugin/viewer/src/less/loader.less
+++ b/iXBRLViewerPlugin/viewer/src/less/loader.less
@@ -19,7 +19,7 @@
     left: 0;
     width: 100%;
     height: 100%;
-    background-color: rgba(0, 0, 0, 0.85);
+    background-color: rgba(0 0 0 85%);
     z-index: 10;
   }
 
@@ -40,7 +40,7 @@
     height: 60px;
     width: 60px;
     position: absolute;
-    content: '';
+    content: "";
     top: 0;
     left: 50%;
     border-radius: 500rem;
@@ -50,7 +50,7 @@
   }
 
   .loader.loading .text::before {
-    border: 3px solid rgba(255, 255, 255, 0.1);
+    border: 3px solid rgba(255 255 255 10%);
   }
 
   .loader.loading .text::after {

--- a/iXBRLViewerPlugin/viewer/src/less/viewer.less
+++ b/iXBRLViewerPlugin/viewer/src/less/viewer.less
@@ -96,7 +96,7 @@ div.ixbrl-table-handle {
   top: -2 * @export-handle-size;
 
   &::after {
-    content: '';
+    content: "";
     position: absolute;
     left: -@export-handle-size;
     top: @export-handle-size;

--- a/package.json
+++ b/package.json
@@ -18,10 +18,12 @@
     "url": "git@github.com:Workiva/ixbrl-viewer.git"
   },
   "stylelint": {
+    "customSyntax": "postcss-less",
     "extends": "stylelint-config-standard",
     "rules": {
       "font-family-no-missing-generic-family-keyword": null,
-      "no-descending-specificity": null
+      "no-descending-specificity": null,
+      "property-no-vendor-prefix": null
     }
   },
   "author": "",
@@ -46,8 +48,9 @@
     "less-loader": "^6.0.0",
     "lunr": "^2.3.8",
     "moment": "^2.24.0",
-    "stylelint": "^13.13.1",
-    "stylelint-config-standard": "^21.0.0",
+    "postcss-less": "^6.0.0",
+    "stylelint": "^14.9.1",
+    "stylelint-config-standard": "^26.0.0",
     "webpack": "^4.42.0",
     "webpack-cli": "^3.3.11",
     "webpack-merge": "^4.2.2"


### PR DESCRIPTION
Also updates stylelint which was held back because it no longer supported old node versions.

Use this [service build](https://ci.webfilings.com/build/3723532) for testing