### PR TITLE
Fix scroll-to-fact with scaled content

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -378,7 +378,9 @@ Viewer.prototype.selectPrevTag = function (currentFact) {
     this._selectAdjacentTag(-1, currentFact);
 }
 
-// Calculate the intersection of two rectangles
+/*
+ * Calculate the intersection of two rectangles
+ */
 Viewer.prototype.intersect = function(r1, r2) {
     const r3 = {
         left: Math.max(r1.left, r2.left),
@@ -391,53 +393,39 @@ Viewer.prototype.intersect = function(r1, r2) {
     return r3;
 }
 
-Viewer.prototype.scrollRect = function(r1) {
-    const scrollx = window.pageXOffset || document.documentElement.scrollLeft;
-    const scrolly = window.pageYOffset || document.documentElement.scrollTop;
-    return {
-        left: r1.left + scrollx,
-        top: r1.top + scrolly,
-        right: r1.right + scrollx,
-        bottom: r1.bottom + scrolly,
-        width: r1.width,
-        height: r1.height
-    };
-}
-
 Viewer.prototype.isScrollableElement = function (domNode) {
     const overflow = $(domNode).css('overflow-y');
     return (domNode.clientHeight > 0 && domNode.clientHeight < domNode.scrollHeight
         && (overflow == "auto" || overflow == 'scroll'));
 }
 
-
+/*
+ * Determine if the element is fully visible within all scrollable ancestors
+ */
 Viewer.prototype.isFullyVisible = function (node) {
     var r1 = node.getBoundingClientRect();
     const r2 = node.getBoundingClientRect();
-    node = node.parentElement;
-    const element = $(node);
-    do {
-        if (element.is('body')) { 
-            return r1.left > 0 && r1.top > 0 && r1.right < window.innerWidth && r1.bottom < window.innerHeight;
+    var ancestor = $(node.parentElement);
+    while (!ancestor.is('body')) {
+        if (this.isScrollableElement(ancestor[0])) {
+            r1 = this.intersect(r1, ancestor[0].getBoundingClientRect());
         }
-        else if (this.isScrollableElement(node) || element.is('html')) {
-            r1 = this.intersect(r1, node.getBoundingClientRect());
-        }
+        // If the width or height of the intersection is less than the original
+        // element, then it's not fully visible.
         if (r1.width < r2.width || r1.height < r2.height) {
             return false;
         }
-        node = node.parentElement;
-    } while (node && (element[0] = node));
-    return true;
+        ancestor = ancestor.parent();
+    } 
+    const de = ancestor.closest("html").get(0);
+    return r1.left > 0 && r1.top > 0 && r1.right < de.clientWidth && r1.bottom < de.clientHeight;
 }
 
-/* Make the specified element visible by scrolling any scrollable ancestors */
+/* If the specified element is not fully visible, scroll it into the center of
+ * the viewport */
 Viewer.prototype.showElement = function(e) {
-    /* offsetTop gives the position relative to the nearest positioned element.
-     * Scrollable elements are not necessarily positioned. */
     var ee = e.get(0);
     if (!this.isFullyVisible(ee)) {
-        console.log("Scrolling");
         ee.scrollIntoView({ block: "center" });
     }
 }

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -394,9 +394,17 @@ Viewer.prototype.intersect = function(r1, r2) {
 }
 
 Viewer.prototype.isScrollableElement = function (domNode) {
-    const overflow = $(domNode).css('overflow-y');
-    return (domNode.clientHeight > 0 && domNode.clientHeight < domNode.scrollHeight
-        && (overflow == "auto" || overflow == 'scroll'));
+    const overflowy = $(domNode).css('overflow-y');
+    if (domNode.clientHeight > 0 && domNode.clientHeight < domNode.scrollHeight
+        && (overflowy == "auto" || overflowy == 'scroll')) {
+        return true;
+    }
+    const overflowx = $(domNode).css('overflow-x');
+    if (domNode.clientWidth > 0 && domNode.clientWidth < domNode.scrollWidth
+        && (overflowx == "auto" || overflowx == 'scroll')) {
+        return true;
+    }
+    return false;
 }
 
 /*
@@ -426,7 +434,7 @@ Viewer.prototype.isFullyVisible = function (node) {
 Viewer.prototype.showElement = function(e) {
     var ee = e.get(0);
     if (!this.isFullyVisible(ee)) {
-        ee.scrollIntoView({ block: "center" });
+        ee.scrollIntoView({ block: "center", inline: "center" });
     }
 }
 

--- a/samples/src/scrollable-div/scrollable-div.html
+++ b/samples/src/scrollable-div/scrollable-div.html
@@ -279,6 +279,7 @@ Profit Loss double tagged: <ix:nonFraction name="ifrs:ProfitLoss" contextRef="c1
 
         </table>
     
+        <div style="transform: matrix(1,0,0,0.1,0,0); font-size: 160px" >
         <h3>Styled via inline stylesheet</h3>
 
         <table class="time-series">
@@ -298,6 +299,7 @@ Profit Loss double tagged: <ix:nonFraction name="ifrs:ProfitLoss" contextRef="c1
             <tr ><td >2013</td><td ><ix:nonFraction name="ifrs:CostOfSales" contextRef="c10" unitRef="u1"  id="f32"  format="ixt:numdotdecimal" decimals="0">5,336</ix:nonFraction></td></tr>
 
         </table>
+        </div>
 
 
         <h3>Table export test</h3>

--- a/samples/src/scrollable-div/scrollable-div.html
+++ b/samples/src/scrollable-div/scrollable-div.html
@@ -279,27 +279,25 @@ Profit Loss double tagged: <ix:nonFraction name="ifrs:ProfitLoss" contextRef="c1
 
         </table>
     
-        <div style="transform: matrix(1,0,0,0.1,0,0); font-size: 160px" >
-        <h3>Styled via inline stylesheet</h3>
+            <h3>Styled using inline stylesheet</h3>
 
-        <table class="time-series">
-            
-            
-            
-            <tr ><td >2018</td><td ><ix:nonFraction name="ifrs:CostOfSales" contextRef="c5" unitRef="u1"  id="f22"  format="ixt:numdotdecimal" decimals="0">9,000</ix:nonFraction></td></tr>
+            <table class="time-series">
+                
+                
+                
+                <tr ><td >2018</td><td ><ix:nonFraction name="ifrs:CostOfSales" contextRef="c5" unitRef="u1"  id="f22"  format="ixt:numdotdecimal" decimals="0">9,000</ix:nonFraction></td></tr>
 
-            <tr ><td >2017</td><td ><ix:nonFraction name="ifrs:CostOfSales" contextRef="c6" unitRef="u1"  id="f24"  format="ixt:numdotdecimal" decimals="0">8,750</ix:nonFraction></td></tr>
+                <tr ><td >2017</td><td ><ix:nonFraction name="ifrs:CostOfSales" contextRef="c6" unitRef="u1"  id="f24"  format="ixt:numdotdecimal" decimals="0">8,750</ix:nonFraction></td></tr>
 
-            <tr ><td >2016</td><td ><ix:nonFraction name="ifrs:CostOfSales" contextRef="c7" unitRef="u1"  id="f26"  format="ixt:numdotdecimal" decimals="0">6,750</ix:nonFraction></td></tr>
+                <tr ><td >2016</td><td ><ix:nonFraction name="ifrs:CostOfSales" contextRef="c7" unitRef="u1"  id="f26"  format="ixt:numdotdecimal" decimals="0">6,750</ix:nonFraction></td></tr>
 
-            <tr ><td >2015</td><td ><ix:nonFraction name="ifrs:CostOfSales" contextRef="c8" unitRef="u1"  id="f28"  format="ixt:numdotdecimal" decimals="0">6,500</ix:nonFraction></td></tr>
+                <tr ><td >2015</td><td ><ix:nonFraction name="ifrs:CostOfSales" contextRef="c8" unitRef="u1"  id="f28"  format="ixt:numdotdecimal" decimals="0">6,500</ix:nonFraction></td></tr>
 
-            <tr ><td >2014</td><td ><ix:nonFraction name="ifrs:CostOfSales" contextRef="c9" unitRef="u1"  id="f30"  format="ixt:numdotdecimal" decimals="0">6,509</ix:nonFraction></td></tr>
+                <tr ><td >2014</td><td ><ix:nonFraction name="ifrs:CostOfSales" contextRef="c9" unitRef="u1"  id="f30"  format="ixt:numdotdecimal" decimals="0">6,509</ix:nonFraction></td></tr>
 
-            <tr ><td >2013</td><td ><ix:nonFraction name="ifrs:CostOfSales" contextRef="c10" unitRef="u1"  id="f32"  format="ixt:numdotdecimal" decimals="0">5,336</ix:nonFraction></td></tr>
+                <tr ><td >2013</td><td ><ix:nonFraction name="ifrs:CostOfSales" contextRef="c10" unitRef="u1"  id="f32"  format="ixt:numdotdecimal" decimals="0">5,336</ix:nonFraction></td></tr>
 
-        </table>
-        </div>
+            </table>
 
 
         <h3>Table export test</h3>
@@ -359,31 +357,36 @@ Profit Loss double tagged: <ix:nonFraction name="ifrs:ProfitLoss" contextRef="c1
             </tbody>
         </table>
 
-        <h3>Prior period tests</h3>
+        <div style="overflow: auto; width: 100%; height: 300px;">
+            <div style="transform: matrix(0.1,0,0,0.1,0,0); font-size: 160px; transform-origin: top left " >
 
-        
-        
+                <h3 style="width: 1000%">Scaled content in scrollable div</h3>
 
-        <table class="accounts">
-            
-            
-            <thead>
-                <tr>
-                    <th></th>
-                    <th>2018</th>
-                    <th>2017</th>
-                    <th>3 months to <br></br>31 Dec 2018</th>
-                    <th>3 months to <br></br>31 Dec 2017</th>
-                </tr>
+                <table class="accounts" style="width: 6000px; border-spacing: 20px;">
+                    
+                    
+                    <thead>
+                        <tr>
+                            <th></th>
+                            <th>2018</th>
+                            <th>2017</th>
+                            <th>3 months to <br></br>31 Dec 2018</th>
+                            <th>3 months to <br></br>31 Dec 2017</th>
+                        </tr>
 
-            </thead>
-            <tbody>
-            <tr ><td >Licence fee income</td><td class="figure" ><ix:nonFraction name="ifrs:LicenceFeeIncome" contextRef="c5" unitRef="u1"  id="f63"  format="ixt:numdotdecimal" decimals="0">123,000</ix:nonFraction></td><td class="figure" ><ix:nonFraction name="ifrs:LicenceFeeIncome" contextRef="c6" unitRef="u1"  id="f64"  format="ixt:numdotdecimal" decimals="0">99,000</ix:nonFraction></td><td class="figure" ><ix:nonFraction name="ifrs:LicenceFeeIncome" contextRef="c11" unitRef="u1"  id="f65"  format="ixt:numdotdecimal" decimals="0">35,000</ix:nonFraction></td><td class="figure" ><ix:nonFraction name="ifrs:LicenceFeeIncome" contextRef="c12" unitRef="u1"  id="f66"  format="ixt:numdotdecimal" decimals="0">22,000</ix:nonFraction></td></tr>
+                    </thead>
+                    <tbody>
+                    <tr ><td >Licence fee income</td><td class="figure" ><ix:nonFraction name="ifrs:LicenceFeeIncome" contextRef="c5" unitRef="u1"  id="f63"  format="ixt:numdotdecimal" decimals="0">123,000</ix:nonFraction></td><td class="figure" ><ix:nonFraction name="ifrs:LicenceFeeIncome" contextRef="c6" unitRef="u1"  id="f64"  format="ixt:numdotdecimal" decimals="0">99,000</ix:nonFraction></td><td class="figure" ><ix:nonFraction name="ifrs:LicenceFeeIncome" contextRef="c11" unitRef="u1"  id="f65"  format="ixt:numdotdecimal" decimals="0">35,000</ix:nonFraction></td><td class="figure" ><ix:nonFraction name="ifrs:LicenceFeeIncome" contextRef="c12" unitRef="u1"  id="f66"  format="ixt:numdotdecimal" decimals="0">22,000</ix:nonFraction></td></tr>
 
-            <tr ><td >Finance Income (Cost)</td><td class="figure" ><ix:nonFraction name="ifrs:FinanceIncomeCost" contextRef="c5" unitRef="u1"  id="f68"  format="ixt:numdotdecimal" decimals="0">88,000</ix:nonFraction></td><td class="figure" >(<ix:nonFraction name="ifrs:FinanceIncomeCost" contextRef="c6" unitRef="u1"  id="f69"  format="ixt:numdotdecimal" decimals="0" sign="-">67,000</ix:nonFraction>)</td><td class="figure" >(<ix:nonFraction name="ifrs:FinanceIncomeCost" contextRef="c11" unitRef="u1"  id="f70"  format="ixt:numdotdecimal" decimals="0" sign="-">35,000</ix:nonFraction>)</td><td class="figure" >(<ix:nonFraction name="ifrs:FinanceIncomeCost" contextRef="c12" unitRef="u1"  id="f71"  format="ixt:numdotdecimal" decimals="0" sign="-">22,000</ix:nonFraction>)</td></tr>
+                    <tr ><td >Finance Income (Cost)</td><td class="figure" ><ix:nonFraction name="ifrs:FinanceIncomeCost" contextRef="c5" unitRef="u1"  id="f68"  format="ixt:numdotdecimal" decimals="0">88,000</ix:nonFraction></td><td class="figure" >(<ix:nonFraction name="ifrs:FinanceIncomeCost" contextRef="c6" unitRef="u1"  id="f69"  format="ixt:numdotdecimal" decimals="0" sign="-">67,000</ix:nonFraction>)</td><td class="figure" >(<ix:nonFraction name="ifrs:FinanceIncomeCost" contextRef="c11" unitRef="u1"  id="f70"  format="ixt:numdotdecimal" decimals="0" sign="-">35,000</ix:nonFraction>)</td><td class="figure" >(<ix:nonFraction name="ifrs:FinanceIncomeCost" contextRef="c12" unitRef="u1"  id="f71"  format="ixt:numdotdecimal" decimals="0" sign="-">22,000</ix:nonFraction>)</td></tr>
 
-            </tbody>
-        </table>
+                    </tbody>
+                </table>
+
+
+            </div>
+        </div>
+
         </div>
             
         


### PR DESCRIPTION
This PR fixes the logic used to scroll the browser window (if necessary) whenever a fact is focused (e.g. using the next/prev tag buttons, or when clicking in search results).

[This ESEF filing](https://filings.xbrl.org/R0MUWSFPU8MPRO8K5P83/2021-12-31/ESEF/FR/0/) lays out each page at 10 times its intended size, and then scales it down to the correct size using a CSS transform.  This broke the previous scroll-to-fact logic, resulting in the browser often scrolling to a different page when attempting to focus on a fact.

This PR restores the intended functionality, which is that if the target fact is already fully visible, it will be focused without scrolling.  Otherwise, the browser will scroll to put the target fact in the center of viewport.

A simpler test document is available in `samples/src/scrollable-div`.

Unfortunately, highlighting of the selected fact in the above document still does not work correctly, as the highlight is 1px outline, which gets transformed to an invisible 0.1px border.  





