### PR TITLE
XT-2234: Fix Export Table button flickering on initial hover

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/less/viewer.less
+++ b/iXBRLViewerPlugin/viewer/src/less/viewer.less
@@ -122,7 +122,8 @@ div.ixbrl-table-handle {
     width: 9rem;
     height: initial;
     left: -0.1rem;
-    padding: 2 * @export-handle-size - 0.1rem 0 0 0;
+    padding: 0;
+    z-index: 1;
 
     & > span {
       &::before {


### PR DESCRIPTION
Correct issue with flickering button by removing padding and applying z-index so hovering over the edge doesn't cause repeated hiding and displaying of the button.

### Steps to Test
Generate an iXBRL viewer with a table ([example](https://wk-dev.wdesk.org/a/QWNjb3VudB81NjY1NDgyMjU5NTYyNDk2/doc/8b3355952b204310846a4a998d50c8a3/r/-1/v/1/sec/8b3355952b204310846a4a998d50c8a3_33?dev=true)) and confirm that hovering along the edge of the button does not cause flickering. (See video in ticket for example)