### PR TITLE
XT-1977: Fix nested .ixbrl-element hover outlines

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/less/viewer.less
+++ b/iXBRLViewerPlugin/viewer/src/less/viewer.less
@@ -47,6 +47,16 @@ span {
   }
 }
 
+span {
+  &.ixbrl-element {
+    display: inline-block;
+
+    & > * {
+      display: flex;
+    }
+  }
+}
+
 .ixbrl-element {
   cursor: pointer;
 }


### PR DESCRIPTION
Exploit properties of inline-block and flex display to keep consistent line height regardless of element nesting

### Steps to Test:

Generate iXBRL viewer from document (has nested tags, ideally with a nested tag that spans more than one line, has paragraph text above and below to ensure consistent line heights). Can provide example doc on request. Ensure consistent hover/selection box sizing in individual and nested tagged elements.