### PR TITLE
Fix highlighting of absolutely positioned elements within text tags

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/ixnode.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixnode.js
@@ -31,6 +31,7 @@ export function IXNode(id, wrapperNodes, docIndex) {
     this.continuations = [];
     this.docIndex = docIndex;
     this.footnote = false;
+    this.isContinuation = false;
     this.id = id;
     this.isHidden = false;
     this.htmlHidden = false;

--- a/iXBRLViewerPlugin/viewer/src/js/ixnode.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixnode.js
@@ -18,15 +18,15 @@
  * May correspond to either a nonNumeric/nonFraction element, or a continuation
  * element.
  * 
- * The wrapperNode property is a jQuery object for the "containing" element
- * which will either be an inserted div or span wrapper, or the nearest
- * enclosing td or th.
+ * The wrapperNodes property is a jQuery object for the "containing" elements
+ * which will be a node list containng an inserted div or span wrapper, any
+ * absolutely positioned elements or the nearest enclosing td or th.
  */
 
 var docOrderindex = 0;
 
-export function IXNode(id, wrapperNode, docIndex) {
-    this.wrapperNode = wrapperNode;
+export function IXNode(id, wrapperNodes, docIndex) {
+    this.wrapperNodes = wrapperNodes;
     this.escaped = false;
     this.continuations = [];
     this.docIndex = docIndex;
@@ -41,8 +41,10 @@ IXNode.prototype.continuationIds = function () {
     return this.continuations.map(n => n.id);
 }
 
-IXNode.prototype.textContent = function () {
+IXNode.prototype.textContent = function () { 
     return [this].concat(this.continuations)
-        .map(n => n.wrapperNode.text())
+        // The first wrapperNode is always the wrapper for the actual IX node,
+        // so will give the full text content.
+        .map(n => n.wrapperNodes.first().text())
         .join(" ");
 }

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -196,6 +196,8 @@ Viewer.prototype._findOrCreateWrapperNode = function(domNode) {
     /* Otherwise, insert a <span> as wrapper */
     if (node.length == 0) {
         node = this._wrapNode(domNode);
+        // Create a node set of current node and all absolutely positioned
+        // descendants.
         node = node.find("*").addBack().filter(function () {
             return (this == node[0] || $(this).css("position") == "absolute");
         });

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -648,14 +648,14 @@ Viewer.prototype.highlightAllTags = function (on, namespaceGroups) {
     var viewer = this;
     if (on) {
         $(".ixbrl-element", this._contents).each(function () {
-            const factId = $(this).data('ivid')[0];
-            const ixn = viewer._ixNodeMap[factId];
-            if (!ixn.isContinuation) {
-                const elements = viewer.elementsForItemIds([factId].concat(ixn.continuationIds()));
+            // Find the first ixn for this element that isn't a continuation.
+            const ixn = $(this).data('ivid').map(id => viewer._ixNodeMap[id]).filter(ixn => !ixn.isContinuation)[0];
+            if (ixn != undefined) {
+                const elements = viewer.elementsForItemIds([ixn.id].concat(ixn.continuationIds()));
                 elements.addClass("ixbrl-highlight");
 
-                if (!ixn.footnote && !ixn.isContinuation) {
-                    const i = groups[report.getItemById(factId).conceptQName().prefix];
+                if (!ixn.footnote) {
+                    const i = groups[report.getItemById(ixn.id).conceptQName().prefix];
                     if (i !== undefined) {
                         elements.addClass("ixbrl-highlight-" + i);
                     }

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -181,28 +181,28 @@ Viewer.prototype._findOrCreateWrapperNode = function(domNode) {
     const v = this;
     /* Is the element the only significant content within a <td> or <th> ? If
      * so, use that as the wrapper element. */
-    var node = $(domNode).closest("td,th").eq(0);
+    var nodes = $(domNode).closest("td,th").eq(0);
     const innerText = $(domNode).text();
-    if (node.length == 1 && innerText.length > 0) {
+    if (nodes.length == 1 && innerText.length > 0) {
         // Use indexOf rather than a single regex because innerText may
         // be too long for the regex engine 
-        const outerText = $(node).text();
+        const outerText = $(nodes).text();
         const start = outerText.indexOf(innerText);
         const wrapper = outerText.substring(0, start) + outerText.substring(start + innerText.length);
         if (/[0-9A-Za-z]/.test(wrapper)) {
-            node = $();
+            nodes = $();
         } 
     }
     /* Otherwise, insert a <span> as wrapper */
-    if (node.length == 0) {
-        node = this._wrapNode(domNode);
+    if (nodes.length == 0) {
+        nodes = this._wrapNode(domNode);
         // Create a node set of current node and all absolutely positioned
         // descendants.
-        node = node.find("*").addBack().filter(function () {
-            return (this == node[0] || $(this).css("position") == "absolute");
+        nodes = nodes.find("*").addBack().filter(function () {
+            return (this == nodes[0] || $(this).css("position") == "absolute");
         });
     }
-    node.each(function (i) {
+    nodes.each(function (i) {
         if (this.getBoundingClientRect().height == 0) {
             $(this).addClass("ixbrl-no-highlight"); 
         }
@@ -213,7 +213,7 @@ Viewer.prototype._findOrCreateWrapperNode = function(domNode) {
             $(this).addClass("ixbrl-sub-element"); 
         }
     });
-    return node;
+    return nodes;
 }
 
 

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -565,9 +565,7 @@ Viewer.prototype.selectElementByClick = function (e) {
             sameContentAncestorId = ids[0];
         }
     });
-    // Uniquify IDs, maintain order, remove duplicates.
-    const uniqueItemIDList = itemIDList.filter((item, pos, arr) => arr.indexOf(item) == pos );
-    this.selectElement(sameContentAncestorId, uniqueItemIDList);
+    this.selectElement(sameContentAncestorId, itemIDList);
 }
 
 Viewer.prototype._mouseEnter = function (e) {

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -533,7 +533,10 @@ Viewer.prototype.selectElementByClick = function (e) {
     var sameContentAncestorId;
     // If the user clicked on a sub-element, treat as if we clicked the first
     // non-sub-element ancestor in the DOM hierarchy - which would typically be
-    // the corresponding ixbrl-element.
+    // the corresponding ixbrl-element (or one of the corresponding
+    // ixbrl-elements, in the case of nested tags)
+    // This is important in order to guarantee that sameContentAncestorId gets
+    // assigned below.
     if (e.hasClass('ixbrl-sub-element')) {
         e = e.parents('.ixbrl-element:not(.ixbrl-sub-element)').first();
     }

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -647,23 +647,22 @@ Viewer.prototype.highlightAllTags = function (on, namespaceGroups) {
     var report = this._report;
     var viewer = this;
     if (on) {
-        $(".ixbrl-element", this._contents).each(function () {
-            // Find the first ixn for this element that isn't a continuation.
-            // Choosint the first means that we're arbitrarily choosing a highlight
-            // color for an element that is double tagged in a table cell.
-            const ixn = $(this).data('ivid').map(id => viewer._ixNodeMap[id]).filter(ixn => !ixn.isContinuation)[0];
-            if (ixn != undefined) {
-                const elements = viewer.elementsForItemIds([ixn.id].concat(ixn.continuationIds()));
-                elements.addClass("ixbrl-highlight");
-
-                if (!ixn.footnote) {
+        $(".ixbrl-element", this._contents)
+            .addClass("ixbrl-highlight")
+            .each(function () {
+                // Find the first ixn for this element that isn't a continuation or footnote.
+                // Choosing the first means that we're arbitrarily choosing a highlight
+                // color for an element that is double tagged in a table cell.
+                const ixn = $(this).data('ivid').map(id => viewer._ixNodeMap[id]).filter(ixn => !ixn.isContinuation && !ixn.footnote)[0];
+                if (ixn != undefined) {
+                    const elements = viewer.elementsForItemIds([ixn.id].concat(ixn.continuationIds()));
                     const i = groups[report.getItemById(ixn.id).conceptQName().prefix];
                     if (i !== undefined) {
                         elements.addClass("ixbrl-highlight-" + i);
                     }
                 }
-            }
         });
+        $(".ixbrl-sub-element", this._contents).addClass("ixbrl-highlight");
     }
     else {
         $(".ixbrl-element, .ixbrl-sub-element", this._contents).removeClass (function (i, className) {

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -232,10 +232,10 @@ Viewer.prototype._findOrCreateWrapperNode = function(domNode) {
 //                         ixbrl-element.  These require separate highlighting.
 //   .ixbrl-no-highlight   a zero-height .ixbrl-element - no highlighting or 
 //                         borders applied
-//   .ixbrl-element-non-fraction,
-//   .ixbrl-element-non-numeric,
+//   .ixbrl-element-nonfraction,
+//   .ixbrl-element-nonnumeric,
 //   .ixbrl-continuation, 
-//   .ixbrl-footnote       
+//   .ixbrl-element-footnote       
 //                         Indicates type of element being wrapped
 //
 // All ixbrl-elements have "ivid" data added, which is a list of the ID
@@ -374,8 +374,7 @@ Viewer.prototype.contents = function() {
 // moving to the next/prev element
 //
 Viewer.prototype._selectAdjacentTag = function (offset, currentItem) {
-    // XXX needs review.  Is only used to establish first and last facts in document.
-    const elements = $(".ixbrl-element:not(.ixbrl-continuation)", this.currentDocument().contents());
+    const elements = $(".ixbrl-element-nonfraction, .ixbrl-element-nonnumeric, .ixbrl-element-footnote", this.currentDocument().contents());
     var nextId;
 
     if (currentItem !== null) {
@@ -631,8 +630,7 @@ Viewer.prototype.highlightAllTags = function (on, namespaceGroups) {
     var report = this._report;
     var viewer = this;
     if (on) {
-        // XXX Needs review.
-        $(".ixbrl-element:not(.ixbrl-continuation)", this._contents).each(function () {
+        $(".ixbrl-element-nonfraction, .ixbrl-element-nonnumeric, .ixbrl-element-footnote", this._contents).each(function () {
             var factId = $(this).data('ivid')[0];
             var ixn = viewer._ixNodeMap[factId];
             var elements = viewer.elementsForItemIds([factId].concat(ixn.continuationIds()));
@@ -675,7 +673,6 @@ Viewer.prototype.zoomOut = function () {
 Viewer.prototype.factsInSameTable = function (fact) {
     var facts = [];
     const e = this.elementsForItemId(fact.id);
-    // XXX does this de-duplicate?
     e.closest("table").find(".ixbrl-element").each(function () {
         facts = facts.concat($(this).data('ivid'));
     });

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -201,12 +201,8 @@ Viewer.prototype._findOrCreateWrapperNode = function(domNode) {
             return (this == node[0] || $(this).css("position") == "absolute");
         });
     }
-    /* If we use an enclosing table cell as the wrapper, we may have
-     * multiple tags in a single element. */
     node.each(function (i) {
-        var ivids = $(this).data('ivid') || [];
-        ivids.push(domNode.getAttribute("id"));
-        $(this).addClass("ixbrl-element").data('ivid', ivids);
+        $(this).addClass("ixbrl-element")
         if (this.getBoundingClientRect().height == 0) {
             $(this).addClass("ixbrl-no-highlight"); 
         }
@@ -215,6 +211,19 @@ Viewer.prototype._findOrCreateWrapperNode = function(domNode) {
         }
     });
     return node;
+}
+
+
+// Adds the specified ID to the "ivid" data list on each element in the
+// provided jQuery node set
+Viewer.prototype._addIdToNodes = function(nodes, id) {
+    /* If we use an enclosing table cell as the wrapper, we may have
+     * multiple tags in a single element. */
+    nodes.each(function (i) {
+        const ivids = $(this).data('ivid') || [];
+        ivids.push(id);
+        $(this).data('ivid', ivids);
+    })
 }
 
 //
@@ -265,6 +274,7 @@ Viewer.prototype._preProcessiXBRL = function(n, docIndex, inHidden) {
         } else {
             nodes = this._findOrCreateWrapperNode(n);
         }
+        this._addIdToNodes(nodes, id);
         /* We may have already created an IXNode for this ID from a -sec-ix-hidden
          * element */
         var ixn = this._ixNodeMap[id];

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -649,6 +649,8 @@ Viewer.prototype.highlightAllTags = function (on, namespaceGroups) {
     if (on) {
         $(".ixbrl-element", this._contents).each(function () {
             // Find the first ixn for this element that isn't a continuation.
+            // Choosint the first means that we're arbitrarily choosing a highlight
+            // color for an element that is double tagged in a table cell.
             const ixn = $(this).data('ivid').map(id => viewer._ixNodeMap[id]).filter(ixn => !ixn.isContinuation)[0];
             if (ixn != undefined) {
                 const elements = viewer.elementsForItemIds([ixn.id].concat(ixn.continuationIds()));

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -542,6 +542,9 @@ Viewer.prototype.selectElementByClick = function (e) {
     if (e.hasClass('ixbrl-sub-element')) {
         e = e.parents('.ixbrl-element:not(.ixbrl-sub-element)').first();
     }
+    // Now find all iXBRL IDs on all ancestors in document order, making a note
+    // of the first one (sameContentAncestorId) that has exactly the same
+    // content as "e"
     e.parents(".ixbrl-element").addBack().filter(':not(.ixbrl-sub-element)').each(function () { 
         const ids = viewer._ixIdsForElement($(this));
         itemIDList = itemIDList.concat(ids); 

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -200,10 +200,6 @@ Viewer.prototype._findOrCreateWrapperNode = function(domNode) {
         node = node.find("*").addBack().filter(function () {
             return (this == node[0] || $(this).css("position") == "absolute");
         });
-
-        //if (absoluteNodes.length > 1) {
-        //    console.log(absoluteNodes);
-        //}
     }
     /* If we use an enclosing table cell as the wrapper, we may have
      * multiple tags in a single element. */

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -537,6 +537,8 @@ Viewer.prototype.selectElementByClick = function (e) {
     // ixbrl-elements, in the case of nested tags)
     // This is important in order to guarantee that sameContentAncestorId gets
     // assigned below.
+    // We can't just ignore clicks on sub elements altogether because they are
+    // likely to be rendered outside the "enclosing" ixbrl-element.
     if (e.hasClass('ixbrl-sub-element')) {
         e = e.parents('.ixbrl-element:not(.ixbrl-sub-element)').first();
     }

--- a/iXBRLViewerPlugin/viewer/src/less/viewer.less
+++ b/iXBRLViewerPlugin/viewer/src/less/viewer.less
@@ -17,12 +17,7 @@
 @import "common.less";
 @import (reference) "icons.less";
 
-.iv-ixbrl-fact {
-  background-color: yellow;
-  cursor: pointer;
-}
-
-.ixbrl-highlight {
+.ixbrl-highlight:not(.ixbrl-no-highlight) {
   background-color: @highlight-default !important;
 
   &.ixbrl-highlight-1 {
@@ -36,29 +31,31 @@
 
 div,
 span {
-  &.ixbrl-selected {
-    outline: solid 2px @primary-focus;
-    outline-offset: 1px;
-  }
+  &:not(.ixbrl-no-highlight) {
+      &.ixbrl-selected {
+        outline: solid 2px @primary-focus;
+        outline-offset: 1px;
+      }
 
-  &.ixbrl-element:hover:not(.ixbrl-selected) {
-    outline: dashed 2px @primary-focus;
-    outline-offset: 1px;
+      &.ixbrl-element:hover:not(.ixbrl-selected) {
+        outline: dashed 2px @primary-focus;
+        outline-offset: 1px;
+      }
   }
 }
 
-.ixbrl-element {
+.ixbrl-element:not(.ixbrl-no-highlight) {
   cursor: pointer;
-}
 
-.ixbrl-related {
-  outline: dashed 2px @related-fact;
-  outline-offset: 1px;
+  &.ixbrl-related {
+    outline: dashed 2px @related-fact;
+    outline-offset: 1px;
+  }
 }
 
 td,
 th {
-  &.ixbrl-selected {
+  &.ixbrl-selected:not(.ixbrl-no-highlight) {
     outline: solid 2px @primary-focus !important;
     outline-offset: -1px !important;
   }

--- a/iXBRLViewerPlugin/viewer/src/less/viewer.less
+++ b/iXBRLViewerPlugin/viewer/src/less/viewer.less
@@ -37,14 +37,18 @@ span {
       outline-offset: 1px;
     }
 
-    &.ixbrl-element:hover:not(.ixbrl-selected) {
-      outline: dashed 2px @primary-focus;
-      outline-offset: 1px;
+    &.ixbrl-element,
+    &.ixbrl-sub-element {
+      &:hover:not(.ixbrl-selected) {
+        outline: dashed 2px @primary-focus;
+        outline-offset: 1px;
+      }
     }
   }
 }
 
-.ixbrl-element:not(.ixbrl-no-highlight) {
+.ixbrl-element:not(.ixbrl-no-highlight),
+.ixbrl-sub-element:not(.ixbrl-no-highlight) {
   cursor: pointer;
 
   &.ixbrl-related {
@@ -60,7 +64,8 @@ th {
     outline-offset: -1px !important;
   }
 
-  &.ixbrl-element:hover:not(.ixbrl-selected) {
+  &.ixbrl-element:hover:not(.ixbrl-selected),
+  &.ixbrl-sub-element:hover:not(.ixbrl-selected) {
     outline: dashed 2px @primary-focus !important;
     outline-offset: -1px !important;
   }

--- a/iXBRLViewerPlugin/viewer/src/less/viewer.less
+++ b/iXBRLViewerPlugin/viewer/src/less/viewer.less
@@ -32,15 +32,15 @@
 div,
 span {
   &:not(.ixbrl-no-highlight) {
-      &.ixbrl-selected {
-        outline: solid 2px @primary-focus;
-        outline-offset: 1px;
-      }
+    &.ixbrl-selected {
+      outline: solid 2px @primary-focus;
+      outline-offset: 1px;
+    }
 
-      &.ixbrl-element:hover:not(.ixbrl-selected) {
-        outline: dashed 2px @primary-focus;
-        outline-offset: 1px;
-      }
+    &.ixbrl-element:hover:not(.ixbrl-selected) {
+      outline: dashed 2px @primary-focus;
+      outline-offset: 1px;
+    }
   }
 }
 


### PR DESCRIPTION
If an `<ix:nonNumeric>` element contains absolutely positioned elements, those elements will not be highlighted by either fact selection (blue outline) or background color if "highlight all facts" is used.  Further, if the only content of the `<ix:nonNumeric>` element is absolutely positioned elements, this will lead to an outline around an empty element:

![image](https://user-images.githubusercontent.com/45077928/117011584-dff81d80-ace5-11eb-97a9-8368edd524bb.png)

(note small square in top left of each paragraph)

This PR fixes both of these issues, by applying separate highlighting to absolutely positioned sub elements, and removing highlighting from any element with zero height.

The issue addressed is likely to become common with the introduction of block tagging on ESEF documents that have been converted from PDF, and individual lines are often absolutely positioned `<div>` elements.

The end result is a bit messier than on a "normal" document, where a tagged paragraph would have a single border, but it would be hard to do better:

![image](https://user-images.githubusercontent.com/45077928/192631402-5f995a5a-be52-47ab-a41e-4cd1ad779b9c.png)

The issue can be seen with the sample on #138, "testdoc" in samples, and in
[this report](https://github.com/Workiva/ixbrl-viewer/files/9659519/7437009IVYWGEE4S7B77-2021-12-31-en.zip)

Fixes #139 