### PR TITLE
Fix viewer on Safari

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/util.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.js
@@ -39,10 +39,12 @@ export function momentToHuman(d, adjust) {
  * Format a number with a thousands separator, and the specified number of
  * decimal places.
  */
-export function formatNumber(v, d) {
-    var n = Number(v);
-    var s = d === undefined ? n.toString() : n.toFixed(Math.max(0, d));
-    return s.replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ",");
+export function formatNumber(value, decimals) {
+    const n = Number(value);
+    const s = decimals === undefined ? n.toString() : n.toFixed(Math.max(0, decimals));
+    const parts = s.split('.');
+    parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+    return parts.join('.');
 }
 
 /* 

--- a/iXBRLViewerPlugin/viewer/src/js/util.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.test.js
@@ -92,6 +92,10 @@ describe("formatNumber", () => {
     test("Format negative number number, add some decimals", () => {
         expect(formatNumber(-123456,3)).toBe("-123,456.000")
     });
+
+    test("Format number, add some decimals", () => {
+        expect(formatNumber(12345678,4)).toBe("12,345,678.0000")
+    });
 });
 
 describe("wrapLabel", () => {


### PR DESCRIPTION
The viewer currently completely fails to open on Safari.  Any report will result in a blank screen, and an error message on the console ("Invalid regular expression: invalid group specifier name").

This PR rewrites the `formatNumber` method to remove reliance on negative look behind assertions, which are not supported on Safari.