### PR TITLE
Fix rgba() declarations

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
@@ -87,7 +87,7 @@ iXBRLViewer.prototype.pluginPromise = function (methodName, ...args) {
 iXBRLViewer.prototype._loadInspectorHTML = function () {
     /* Insert HTML and CSS styles into body */
     $(require('../html/inspector.html')).prependTo('body');
-    var inspector_css = require('css-loader!less-loader!../less/inspector.less').toString(); 
+    var inspector_css = require('css-loader!../less/inspector.less').toString(); 
     $('<style id="ixv-style"></style>')
         .prop("type", "text/css")
         .text(inspector_css)

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -85,7 +85,7 @@
         width: 20px;
         height: 20px;
         border: solid 1px #bbb;
-        background-color: rgba(225 225 225 70%);
+        background-color: rgba(225, 225, 225, 70%);
         justify-content: center;
         display: flex;
         align-items: center;
@@ -104,7 +104,7 @@
 
       .zoom-in:hover,
       .zoom-out:hover {
-        background-color: rgba(128 128 128 70%);
+        background-color: rgba(128, 128, 128, 70%);
       }
     }
 
@@ -962,7 +962,7 @@
   }
 
   .dialog-mask {
-    background-color: rgba(0 0 0 60%);
+    background-color: rgba(0, 0, 0, 60%);
     position: fixed;
     top: 0;
     bottom: 0;

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -85,7 +85,7 @@
         width: 20px;
         height: 20px;
         border: solid 1px #bbb;
-        background-color: rgba(225, 225, 225, 70%);
+        background-color: rgb(225 225 225 / 70%);
         justify-content: center;
         display: flex;
         align-items: center;
@@ -104,7 +104,7 @@
 
       .zoom-in:hover,
       .zoom-out:hover {
-        background-color: rgba(128, 128, 128, 70%);
+        background-color: rgb(128 128 128 / 70%);
       }
     }
 
@@ -962,7 +962,7 @@
   }
 
   .dialog-mask {
-    background-color: rgba(0, 0, 0, 60%);
+    background-color: rgb(0 0 0 / 60%);
     position: fixed;
     top: 0;
     bottom: 0;

--- a/iXBRLViewerPlugin/viewer/src/less/loader.less
+++ b/iXBRLViewerPlugin/viewer/src/less/loader.less
@@ -19,7 +19,7 @@
     left: 0;
     width: 100%;
     height: 100%;
-    background-color: rgba(0 0 0 85%);
+    background-color: rgba(0, 0, 0, 85%);
     z-index: 10;
   }
 
@@ -50,7 +50,7 @@
   }
 
   .loader.loading .text::before {
-    border: 3px solid rgba(255 255 255 10%);
+    border: 3px solid rgba(255, 255, 255, 10%);
   }
 
   .loader.loading .text::after {

--- a/iXBRLViewerPlugin/viewer/src/less/loader.less
+++ b/iXBRLViewerPlugin/viewer/src/less/loader.less
@@ -19,7 +19,7 @@
     left: 0;
     width: 100%;
     height: 100%;
-    background-color: rgba(0, 0, 0, 85%);
+    background-color: rgb(0 0 0 / 85%);
     z-index: 10;
   }
 
@@ -50,7 +50,7 @@
   }
 
   .loader.loading .text::before {
-    border: 3px solid rgba(255, 255, 255, 10%);
+    border: 3px solid rgb(255 255 255 / 10%);
   }
 
   .loader.loading .text::after {

--- a/iXBRLViewerPlugin/viewer/webpack.common.js
+++ b/iXBRLViewerPlugin/viewer/webpack.common.js
@@ -41,7 +41,7 @@ module.exports = {
                         loader: "less-loader",
                         options: {
                             lessOptions: {
-                                math: "parens"
+                                math: "parens-division"
                             }
                         }
                     }]

--- a/iXBRLViewerPlugin/viewer/webpack.common.js
+++ b/iXBRLViewerPlugin/viewer/webpack.common.js
@@ -34,6 +34,17 @@ module.exports = {
                             keepClosingSlash: true
                         }
                     }]
+                },
+                {
+                    test: /\.less$/,
+                    use: [ { 
+                        loader: "less-loader",
+                        options: {
+                            lessOptions: {
+                                math: "parens"
+                            }
+                        }
+                    }]
                 }
             ]
 


### PR DESCRIPTION
This PR fixes some of the changes made in 2285634111f81c26d67d997a66259de120761a31 which replaced commas in `rgba` declarations with spaces:

```diff
-    border: 3px solid rgba(255, 255, 255, 0.1);
+    border: 3px solid rgba(255 255 255 10%);
```

This was in response to a stylelint update, which caused it to object to the `rgba(r,g,b,a)` notation, but the correct replacement is `rgb(r g b / a)` (`rgba(r g b a)` is invalid).   

Unfortunately, by default, less treats `b / a` as a pre-processed division operation, so this PR also tweaks how the less is imported so that `math: strict` is specified as a [less option](https://lesscss.org/usage/#less-options-math), which prevents less from treating `b / a` as a calculation.

Without this PR, various things are broken in the viewer:

* The gray loading mask is no longer present when documents load in the viewer.  
* The zoom icons in the viewer have a completely transparent background, rather than slightly grayed out.
* There is no gray mask when dialogs are displayed.