### PR TITLE
Fix display of chart

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/chart.js
+++ b/iXBRLViewerPlugin/viewer/src/js/chart.js
@@ -232,7 +232,7 @@ IXBRLChart.prototype._showAnalyseDimensionChart = function() {
 
 IXBRLChart.prototype.setChartSize = function () {
     var c = this.node;
-    var nh = c.height() - $('.other-aspects').height() - 16;
+    var nh = c.height() - $('.other-aspects', this.node).outerHeight() - 16;
     $('.chart-container',c).height(nh);
     $('canvas',c).attr('height',nh).height(nh);
 


### PR DESCRIPTION
This PR fixes a rendering issue with the chart that causes the chart to overlap with the dimension selectors at the bottom of the dialog.

Before:

![image](https://user-images.githubusercontent.com/45077928/194140352-fa2e12b8-3d86-4dad-acd3-cf2e8459e031.png)

After:

![image](https://user-images.githubusercontent.com/45077928/194140520-33b980f7-2882-45d5-81e5-fafccebe4f34.png)

This issue is that the code to allow space for the dimension selectors was picking the hidden `.other-aspects` from the dialog  template, rather than the currently displayed dialog.