### PR TITLE
Handle continuations for items in non-default target document

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/accordian.js
+++ b/iXBRLViewerPlugin/viewer/src/js/accordian.js
@@ -24,14 +24,14 @@ export function Accordian(options) {
 }
 
 Accordian.prototype.addCard = function(title, body, selected, data) {
-    var a = this;
-    var card = $('<div class="card"></div>')
+    const a = this;
+    const card = $('<div class="card"></div>')
         .append($('<div class="title"></div>')
             .append(title)
             .click(function () {
                 var thisCard = $(this).closest(".card");
                 if (thisCard.hasClass("active")) {
-                    if (!options.alwaysOpen) {
+                    if (!a.options.alwaysOpen) {
                         thisCard.removeClass("active");
                     }
                 }

--- a/iXBRLViewerPlugin/viewer/src/js/docOrderIndex.js
+++ b/iXBRLViewerPlugin/viewer/src/js/docOrderIndex.js
@@ -1,0 +1,37 @@
+// Copyright 2022 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export class DocOrderIndex {
+    constructor() {
+        this.index = [];
+    }
+
+    addItem(id, docIndex) {
+        this.index.push({id: id, docIndex: docIndex});
+    }
+
+    getAdjacentItem(id, offset) {
+        const currentIndex = this.index.findIndex(n => n.id == id);
+        const l = this.index.length;
+        return this.index[(currentIndex + offset + l) % l].id;
+    }
+
+    getFirstInDocument(docIndex) {
+        return this.index.filter(n => n.docIndex == docIndex)[0].id;
+    }
+
+    getLastInDocument(docIndex) {
+        return this.index.filter(n => n.docIndex == docIndex).at(-1).id;
+    }
+}

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -506,7 +506,7 @@ Inspector.prototype._footnotesHTML = function (fact) {
 
 Inspector.prototype.viewerMouseEnter = function (id) {
     $('.calculations .item').filter(function () {   
-        return $.inArray(id, $.map($(this).data('ivid'), function (f)  { return f.id })) > -1 
+        return $.inArray(id, $.map($(this).data('ivid'), f => f.id )) > -1 
     }).addClass('linked-highlight');
     $('#inspector .search .results tr').filter(function () {   
         return $(this).data('ivid') == id;

--- a/iXBRLViewerPlugin/viewer/src/js/ixnode.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixnode.js
@@ -31,7 +31,6 @@ export function IXNode(id, wrapperNodes, docIndex) {
     this.continuations = [];
     this.docIndex = docIndex;
     this.footnote = false;
-    this.isContinuation = false;
     this.id = id;
     this.isHidden = false;
     this.htmlHidden = false;

--- a/iXBRLViewerPlugin/viewer/src/js/ixnode.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixnode.js
@@ -42,6 +42,12 @@ IXNode.prototype.continuationIds = function () {
     return this.continuations.map(n => n.id);
 }
 
+// Return IX IDs for all IX elements in the continuation chain, including the
+// head.
+IXNode.prototype.chainIXIds = function () { 
+    return [this.id].concat(this.continuationIds());
+}
+
 IXNode.prototype.textContent = function () { 
     return [this].concat(this.continuations)
         // The first wrapperNode is always the wrapper for the actual IX node,

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -641,7 +641,7 @@ Viewer.prototype.highlightAllTags = function (on, namespaceGroups) {
                 // Choosing the first means that we're arbitrarily choosing a
                 // highlight color for an element that is double tagged in a
                 // table cell.
-                const ixn = $(this).data('ivid').map(id => viewer._ixNodeMap[id]).filter(!ixn.footnote)[0];
+                const ixn = $(this).data('ivid').map(id => viewer._ixNodeMap[id]).filter(ixn => !ixn.footnote)[0];
                 if (ixn != undefined) {
                     const elements = viewer.elementsForItemIds(ixn.chainIXIds());
                     const i = groups[report.getItemById(ixn.id).conceptQName().prefix];

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -704,6 +704,10 @@ Viewer.prototype.showDocumentForItemId = function(itemId) {
     this.selectDocument(this._ixNodeMap[itemId].docIndex);
 }
 
+Viewer.prototype.currentDocument = function () {
+    return this._iframes.eq(this._currentDocumentIndex);
+}
+
 Viewer.prototype.selectDocument = function (docIndex) {
     this._currentDocumentIndex = docIndex;
     $('#ixv #viewer-pane .ixds-tabs .tab')

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -229,7 +229,10 @@ Viewer.prototype._buildContinuationMaps = function() {
         while (nextContinuationMap[id] !== undefined) {
             id = nextContinuationMap[id];
             itemContinuations.push(id);
-            setDefault(this.continuationOfMap, id, []).push(itemId)
+            if (this.continuationOfMap[id] !== undefined) {
+                console.log("Continuation '" + id + "' is a continuation of multiple items.");
+            }
+            this.continuationOfMap[id] = itemId;
         }
     }
     this.itemContinuationMap = itemContinuationMap;
@@ -284,14 +287,9 @@ Viewer.prototype._preProcessiXBRL = function(n, docIndex, inHidden) {
             }
 
             // For a continuation, store the IX ID(s) of the item(s), not the continuation
-            if (isContinuation) {
-                for (const headId of this.continuationOfMap[id]) {
-                    this._addIdToNode(nodes.first(), headId);
-                }
-            }
-            else {
-                this._addIdToNode(nodes.first(), id);
-            }
+            const headId = isContinuation ? this.continuationOfMap[id] : id;
+            this._addIdToNode(nodes.first(), headId);
+
             // We may have already created an IXNode for this ID from a -sec-ix-hidden
             // element 
             var ixn = this._ixNodeMap[id];

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -202,7 +202,7 @@ Viewer.prototype._addIdToNode = function(node, id) {
 }
 
 Viewer.prototype._buildContinuationMaps = function() {
-    // map of next item in continuation chain
+    // map of element id to next element id in continuation chain
     const nextContinuationMap = {};
     // map of items in default target document to all their continuations
     const itemContinuationMap = {};

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -35,9 +35,9 @@ export function Viewer(iv, iframes, report) {
 Viewer.prototype.initialize = function() {
     return new Promise((resolve, reject) => {
         var viewer = this;
+        viewer._buildContinuationMaps();
         viewer._iframes.each(function (docIndex) { 
-            $(this).data("selected", docIndex == 0);
-            viewer._buildContinuationMaps($(this).contents().find("body"), docIndex);
+            $(this).data("selected", docIndex == viewer._currentDocumentIndex);
             viewer._preProcessiXBRL($(this).contents().find("body").get(0), docIndex);
         });
 
@@ -201,12 +201,12 @@ Viewer.prototype._addIdToNode = function(node, id) {
     node.data('ivid', ivids);
 }
 
-Viewer.prototype._buildContinuationMaps = function(body, docIndex, inHidden) {
+Viewer.prototype._buildContinuationMaps = function() {
     // map of next item in continuation chain
     const nextContinuationMap = {};
     // map of items in default target document to all their continuations
     const itemContinuationMap = {};
-    body.find('*').each(function () {
+    this._iframes.contents().find("body *").each(function () {
         const name = localName(this.nodeName).toUpperCase();
         if (['NONNUMERIC', 'NONFRACTION', 'FOOTNOTE', 'CONTINUATION'].includes(name)) {
             const nodeId = this.getAttribute('id');
@@ -699,10 +699,6 @@ Viewer.prototype._setTitle = function (docIndex) {
 
 Viewer.prototype.showDocumentForItemId = function(itemId) {
     this.selectDocument(this._ixNodeMap[itemId].docIndex);
-}
-
-Viewer.prototype.currentDocument = function () {
-    return this._iframes.filter(function () { return $(this).data("selected") });
 }
 
 Viewer.prototype.selectDocument = function (docIndex) {

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -283,9 +283,15 @@ Viewer.prototype._preProcessiXBRL = function(n, docIndex, inHidden) {
                 nodes = this._findOrCreateWrapperNode(n);
             }
 
-            // For a continuation, store the IX ID of the item, not the continuation
-            const headId = isContinuation ? this.continuationOfMap[id] : id;
-            this._addIdToNode(nodes.first(), headId);
+            // For a continuation, store the IX ID(s) of the item(s), not the continuation
+            if (isContinuation) {
+                for (const headId of this.continuationOfMap[id]) {
+                    this._addIdToNode(nodes.first(), headId);
+                }
+            }
+            else {
+                this._addIdToNode(nodes.first(), id);
+            }
             // We may have already created an IXNode for this ID from a -sec-ix-hidden
             // element 
             var ixn = this._ixNodeMap[id];


### PR DESCRIPTION
This PR address a bug encountered where a document contains `ix:continuation` elements for facts or footnotes that are not in the default target document.   The viewer should ignore facts that are not in the default target document, but continuations for such elements were not being ignored (they don't have a `target` attribute so they can't be trivially ignored).  This lead to an exception when they were clicked on, or when they were selected using next/prev tag.

The bug can be seen in [this filing](https://filings.xbrl.org/5299004SWFL5JAN4W830/2022-06-30/ESEF/DK/0/5299004SWFL5JAN4W830-2022-06-30-en/reports/ixbrlviewer.html)

Open the viewer, press the "next tag" button and note that "June 30, 2022" is highlighted, but there are no fact details in the inspector, and we have an exception on the console.  Similarly, clicking on this text causes an exception.

This PR finds all orphaned continuation elements, and removes them so that they can't be clicked on, and are not included in the next/prev tag list.