### PR TITLE
Fix scroll to fact for documents in quirks mode

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -482,7 +482,10 @@ Viewer.prototype.isFullyVisible = function (node) {
         }
         ancestor = ancestor.parent();
     } 
-    const de = ancestor.closest("html").get(0);
+    // In quirks mode, clientHeight of body is viewport height.  In standards
+    // mode, clientHeight of html is viewport height.
+    const quirksMode = node.ownerDocument.compatMode != 'CSS1Compat';
+    const de = quirksMode ? ancestor : ancestor.closest("html").get(0);
     return r1.left > 0 && r1.top > 0 && r1.right < de.clientWidth && r1.bottom < de.clientHeight;
 }
 


### PR DESCRIPTION
Scroll-to-fact does not work correctly on documents that are rendered in quirks mode, due to an error in obtaining the viewport height.

This can be seen whenever a fact is selected that is not already on the screen, for example:

* Using the prev/next tag buttons
* Using a fragment in the URL to deep link to a fact
* Clicking on a fact in search results

On affected documents, the viewer will not scroll as it mistakenly concludes that the fact is already visible.

Sample docs:

* [This Aviva filing](https://filings.xbrl.org/YF0Y5B0IB8SM0ZFG9G81/2021-12-31/ESEF/GB/0/) renders in quirks mode (broken without this PR).  
* [This Pandora filing](https://filings.xbrl.org/5299007OWYZ6I1E46843/2021-12-31/ESEF/DK/1/PAND-2021-12-31/) renders in standards mode and works currently.

Note that the filings.xbrl.org viewer already has this fix applied.

From https://developer.mozilla.org/en-US/docs/Web/API/Element/clientHeight:

> When clientHeight is used on the root element (the `<html>` element), (or on `<body>` if the document is in quirks mode), the viewport's height (excluding any scrollbar) is returned. [This is a special case of clientHeight](https://www.w3.org/TR/2016/WD-cssom-view-1-20160317/#dom-element-clientheight).