### PR TITLE
Big decimal truncation

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/util.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.js
@@ -39,10 +39,12 @@ export function momentToHuman(d, adjust) {
  * Format a number with a thousands separator, and the specified number of
  * decimal places.
  */
-export function formatNumber(v, d) {
-    var n = Number(v);
-    var s = d === undefined ? n.toString() : n.toFixed(Math.max(0, d));
-    return s.replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ",");
+export function formatNumber(value, decimals) {
+    const n = Number(value);
+    const s = decimals === undefined ? n.toString() : n.toFixed(Math.max(0, decimals));
+    const parts = s.split('.');
+    parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+    return parts.join('.');
 }
 
 /* 

--- a/iXBRLViewerPlugin/viewer/src/js/util.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.js
@@ -14,6 +14,7 @@
 
 import dateFormat from "dateformat"
 import moment from "moment";
+import Decimal from "decimal.js";
 
 /* 
  * Takes a moment.js oject and converts it to a human readable date, or date
@@ -40,8 +41,8 @@ export function momentToHuman(d, adjust) {
  * decimal places.
  */
 export function formatNumber(value, decimals) {
-    const n = Number(value);
-    const s = decimals === undefined ? n.toString() : n.toFixed(Math.max(0, decimals));
+    const n = Decimal(value);
+    const s = decimals === undefined ? n.toFixed() : n.toFixed(Math.max(0, decimals));
     const parts = s.split('.');
     parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",");
     return parts.join('.');

--- a/iXBRLViewerPlugin/viewer/src/js/util.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.test.js
@@ -92,6 +92,10 @@ describe("formatNumber", () => {
     test("Format negative number number, add some decimals", () => {
         expect(formatNumber(-123456,3)).toBe("-123,456.000")
     });
+
+    test("Format number, add some decimals", () => {
+        expect(formatNumber(12345678,4)).toBe("12,345,678.0000")
+    });
 });
 
 describe("wrapLabel", () => {

--- a/iXBRLViewerPlugin/viewer/src/js/util.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.test.js
@@ -97,8 +97,16 @@ describe("formatNumber", () => {
         expect(formatNumber(12345678,4)).toBe("12,345,678.0000")
     });
 
-    test("Format number, add some decimals", () => {
-        expect(formatNumber("10000000000.00000003",undefined)).toBe("10,000,000,000.00000003")
+    test("Format decimal with large number of digits", () => {
+        expect(formatNumber("10000000000.00000003", undefined)).toBe("10,000,000,000.00000003")
+    });
+
+    test("Format decimal with large number of digits", () => {
+        expect(formatNumber("10000000000.000000030", undefined)).toBe("10,000,000,000.00000003")
+    });
+
+    test("Format decimal with large number of digits", () => {
+        expect(formatNumber("10000000000.000000030", 10)).toBe("10,000,000,000.0000000300")
     });
 });
 

--- a/iXBRLViewerPlugin/viewer/src/js/util.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.test.js
@@ -96,6 +96,10 @@ describe("formatNumber", () => {
     test("Format number, add some decimals", () => {
         expect(formatNumber(12345678,4)).toBe("12,345,678.0000")
     });
+
+    test("Format number, add some decimals", () => {
+        expect(formatNumber("10000000000.00000003",undefined)).toBe("10,000,000,000.00000003")
+    });
 });
 
 describe("wrapLabel", () => {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "webpack-merge": "^4.2.2"
   },
   "devDependencies": {
+    "decimal.js": "^10.4.1",
     "i18next-parser": "^6.0.0"
   },
   "license": "Apache-2.0"


### PR DESCRIPTION
This PR avoids decimals with a large number of significant figures from being truncated when displayed in the fact inspector.

The last three [new tests](https://github.com/Workiva/ixbrl-viewer/compare/master...paulwarren-wk:ixbrl-viewer:big-decimal-truncation?expand=1#diff-4abe2da922e1dfef10090104939b6a0292fad5a67f35a09a27fa3528f7785e71R100) in this PR all fail under the old code.

This adds a dependency on `decimal.js`. I have another branch with draft support for Calculations 1.1 which also relies on `decimal.js`, so the new dependency will not be exclusively for this.

This fixes XT-1279