### PR TITLE
Don't require <tr> tags to be visible for table export.

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/tableExport.js
+++ b/iXBRLViewerPlugin/viewer/src/js/tableExport.js
@@ -41,7 +41,7 @@ export class TableExport {
         const report = this._report;
         let maxRowLength = 0;
         const rows = [];
-        table.find("tr:visible").each(function () {
+        table.find("tr").each(function () {
             const row = [];
             $(this).find("td:visible, th:visible").each(function () {
                 const colspan = $(this).attr("colspan");


### PR DESCRIPTION
This PR fixes an issue with table export not detecting table cells where the `<tr>` elements have `display: contents`.

The code currently searches for `tr:visible td:visible` and `display: contents` doesn't count as "visible"

For the purposes of exporting table contents, we only really care about whether the table cells themselves are visible.

