### PR TITLE
XT-2526: Fix build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ ARG GIT_TAG
 WORKDIR /build/
 
 COPY package.json /build/
-RUN npm update --location=global && \
-    npm install --include=dev
+RUN npm install --include=dev
 
 COPY . /build/
 


### PR DESCRIPTION
### Description
The latest CI builds are failing due to a jfrog auth issue with the latest version of npm (9.1.1) and the workiva build tool.

This issue has been reported to the build team, in the meantime don't update npm to an incompatible version in docker build.

### Steps to test
* CI build completes
