### PR TITLE
Revert broken change to truncateLabel in #336

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/util.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.js
@@ -97,7 +97,8 @@ export function wrapLabel(str, maxwidth) {
  * adding an ellipsis if the label is actually shortened.
  */
 export function truncateLabel(label, length) {
-    let t = wrapLabel(label, length)[0];
+    let vv = wrapLabel(label, length)[0];
+    let t = vv[0];
     if (vv.length > 1) {
         t += ' \u2026';
     }


### PR DESCRIPTION
Fixes #343.

Display of footnote text was broken by an over enthusiastic attempt to simplify `truncateLabel`.  This reverts that change.