### PR TITLE
Fix application of self-closing tags

### DIFF
--- a/iXBRLViewerPlugin/xhtmlserialize.py
+++ b/iXBRLViewerPlugin/xhtmlserialize.py
@@ -33,7 +33,7 @@ class XHTMLSerializer:
         """
         for e in xml.iter('*'):
             m = re.match(r'\{http://www\.w3\.org/1999/xhtml\}(.*)', e.tag)
-            if m is None or m.group(1) not in XHTMLSerializer.selfClosableElements and e.text is None:
+            if (m is None or m.group(1) not in XHTMLSerializer.selfClosableElements) and e.text is None:
                 e.text = ''
 
     def serialize(self, xmlDocument, fout):


### PR DESCRIPTION
This fixes a bug introduced in #342 that caused the content of tags in an iXBRL document to be replaced with an empty string.  We set content of tags with content of `None` to be `""` to prevent a self-closing tag being used, but due to operator precedence, this was also being inadvertently applied to tags with content, overwriting it. 

Fixes #344.