### PR TITLE
Wrap content containing an inline-block in an inline-block

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -181,7 +181,7 @@ Viewer.prototype._findOrCreateWrapperNode = function(domNode) {
         });
     }
     nodes.each(function (i) {
-        if (this.getBoundingClientRect().height == 0) {
+        if (this.getBoundingClientRect().height == 0 && $(this).css('display') !== 'inline') {
             $(this).addClass("ixbrl-no-highlight"); 
         }
         if (i == 0) {


### PR DESCRIPTION
This PR changes how the `ixbrl-no-highlight` class is used.  This class is added to wrapper nodes which contain only absolutely positioned children and thus have no intrinsic dimensions of their own, and should not be highlighted (their children are highlighted instead).

#363 contains a background image on an `inline-block` element, which we wrap in a `<span>`.  Despite containing the span with the image, `getBoundingClientRect()` reports a height of zero and as a result gets the `ixbrl-no-highlight` class added.  

This PR changes the behaviour so that `ixbrl-no-highlight` is never added to a span wrapper.  Despite apparently having "zero height", adding an outline to this element results in the correct area being highlighted, so this seems to be an oddity of `getBoudingClientRect()`.  

The reported width is non-zero, so an alternative fix might be to only add the no-highlight class if both width and height are zero.

Fixes #363 
