### PR TITLE
Show warning dialog on more than 10,000 continuation elements

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -180,6 +180,7 @@ limitations under the License.
         <span data-i18n="inspector.poweredBy">Powered by</span>
         <a href="https://www.workiva.co.uk/solutions/xbrl-and-ixbrl" target="_blank"><img alt="Workiva logo (opens in new window)" src="../img/workiva.svg" /></a>
     </div>
+    <div class="failed-to-load-mask"></div>
   </div>
   <div class="dialog-mask">
   </div>

--- a/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
@@ -15,7 +15,7 @@
 import interact from 'interactjs'
 import $ from 'jquery'
 import { iXBRLReport } from "./report.js";
-import { Viewer } from "./viewer.js";
+import { Viewer, DocumentTooLargeError } from "./viewer.js";
 import { Inspector } from "./inspector.js";
 
 export function iXBRLViewer(options) {
@@ -226,7 +226,17 @@ iXBRLViewer.prototype.load = function () {
                         if (iv.options.showValidationWarningOnStart) {
                             inspector.showValidationWarning();
                         }
-                    });
+                    })
+                    .catch(err => {
+                        if (err instanceof DocumentTooLargeError) {
+                            $('#ixv .loader').remove();
+                            $('#inspector').addClass('failed-to-load');
+                        }
+                        else {
+                            throw err;
+                        }
+
+                    })
             }
         }, 250);
     }, 0);

--- a/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
@@ -19,11 +19,15 @@ import { Viewer, DocumentTooLargeError } from "./viewer.js";
 import { Inspector } from "./inspector.js";
 
 export function iXBRLViewer(options) {
-    this.options = options || {};
     this._plugins = [];
     this.inspector = new Inspector(this);
     this.viewer = null;
-    this.options = options || {};
+    options = options || {};
+    const defaults = {
+        showValidationWarningOnStart: false,
+        continuationElementLimit: 10000
+    }
+    this.options = {...defaults, ...options};
 }
 
 /*

--- a/iXBRLViewerPlugin/viewer/src/js/messagebox.js
+++ b/iXBRLViewerPlugin/viewer/src/js/messagebox.js
@@ -51,4 +51,10 @@ export class MessageBox extends Dialog {
 
         super.show(this);
     }
+
+    showAsync() {
+        return new Promise((resolve, reject) => {
+            this.show(() => resolve(true), () => resolve(false));
+        });
+    }
 }

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -51,7 +51,7 @@ Viewer.prototype._checkContinuationCount = function() {
             }
         });
     }
-    return new Promise(r => r());
+    return Promise.resolve();
 }
 
 Viewer.prototype.initialize = function() {

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -20,8 +20,6 @@ import { setDefault } from './util.js';
 import { DocOrderIndex } from './docOrderIndex.js';
 import { MessageBox } from './messagebox.js';
 
-const CONTINUATION_LIMIT = 10000;
-
 export class DocumentTooLargeError extends Error {}
 
 export function Viewer(iv, iframes, report) {
@@ -39,8 +37,8 @@ export function Viewer(iv, iframes, report) {
 }
 
 Viewer.prototype._checkContinuationCount = function() {
-        const continuationCount = Object.keys(this.continuationOfMap).length
-    if (continuationCount > CONTINUATION_LIMIT) {
+    const continuationCount = Object.keys(this.continuationOfMap).length
+    if (continuationCount > this._iv.options.continuationElementLimit) {
         const contents = $('<div></div>')
             .append($('<p></p>').text(`This document contains a very large number of iXBRL elements (found ${continuationCount} ix:continuation elements).`))
             .append($('<p></p>').text('You may experience performance problems viewing this document, or the viewer may not load at all.'))

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -18,6 +18,11 @@ import { escapeRegex } from './util.js'
 import { IXNode } from './ixnode.js';
 import { setDefault } from './util.js';
 import { DocOrderIndex } from './docOrderIndex.js';
+import { MessageBox } from './messagebox.js';
+
+const CONTINUATION_LIMIT = 10000;
+
+export class DocumentTooLargeError extends Error {}
 
 export function Viewer(iv, iframes, report) {
     this._iv = iv;
@@ -33,31 +38,55 @@ export function Viewer(iv, iframes, report) {
     this._currentDocumentIndex = 0;
 }
 
+Viewer.prototype._checkContinuationCount = function() {
+        const continuationCount = Object.keys(this.continuationOfMap).length
+    if (continuationCount > CONTINUATION_LIMIT) {
+        const contents = $('<div></div>')
+            .append($('<p></p>').text(`This document contains a very large number of iXBRL elements (found ${continuationCount} ix:continuation elements).`))
+            .append($('<p></p>').text('You may experience performance problems viewing this document, or the viewer may not load at all.'))
+            .append($('<p></p>').text('Do you want to continue trying to load this document?'));
+
+        const mb = new MessageBox("Large document warning", contents, "Continue", "Cancel");
+        return mb.showAsync().then((result) => {
+            if (!result) {
+                throw new DocumentTooLargeError("Too many continuations");
+            }
+        });
+    }
+    return new Promise(r => r());
+}
+
 Viewer.prototype.initialize = function() {
-    return new Promise((resolve, reject) => {
+    return new Promise(async (resolve, reject) => {
         var viewer = this;
         viewer._buildContinuationMaps();
-        viewer._iframes.each(function (docIndex) { 
-            $(this).data("selected", docIndex == viewer._currentDocumentIndex);
-            viewer._preProcessiXBRL($(this).contents().find("body").get(0), docIndex);
-        });
-
-        /* Call plugin promise for each document in turn */
-        (async function () {
-            for (var docIndex = 0; docIndex < viewer._iframes.length; docIndex++) {
-                await viewer._iv.pluginPromise('preProcessiXBRL', viewer._iframes.eq(docIndex).contents().find("body").get(0), docIndex);
-            }
-        })()
-            .then(() => viewer._iv.setProgress("Preparing document") )
+        viewer._checkContinuationCount()
+            .catch(err => { throw err })
             .then(() => {
-                this._report.setIXNodeMap(this._ixNodeMap);
-                this._applyStyles();
-                this._bindHandlers();
-                this.scale = 1;
-                this._setTitle(0);
-                this._addDocumentSetTabs();
-                resolve();
-            });
+
+                viewer._iframes.each(function (docIndex) { 
+                    $(this).data("selected", docIndex == viewer._currentDocumentIndex);
+                    viewer._preProcessiXBRL($(this).contents().find("body").get(0), docIndex);
+                });
+
+                /* Call plugin promise for each document in turn */
+                (async function () {
+                    for (var docIndex = 0; docIndex < viewer._iframes.length; docIndex++) {
+                        await viewer._iv.pluginPromise('preProcessiXBRL', viewer._iframes.eq(docIndex).contents().find("body").get(0), docIndex);
+                    }
+                })()
+                    .then(() => viewer._iv.setProgress("Preparing document") )
+                    .then(() => {
+                        this._report.setIXNodeMap(this._ixNodeMap);
+                        this._applyStyles();
+                        this._bindHandlers();
+                        this.scale = 1;
+                        this._setTitle(0);
+                        this._addDocumentSetTabs();
+                        resolve();
+                    });
+            })
+            .catch(err => reject(err));
     });
 }
 

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -931,6 +931,18 @@
     &.footnote-mode .footnote-mode-off {
       display: none;
     }
+
+    .failed-to-load-mask {
+      display: none;
+    }
+
+    &.failed-to-load .failed-to-load-mask {
+      display: block;
+      background-color: rgb(0 0 0 / 50%);
+      position: absolute;
+      width: 100%;
+      height: 100%;
+    }
   }
 
   .fact-link {


### PR DESCRIPTION
This PR introduces a check on the number of continuation elements in a document, and offers to gracefully stop trying to load if there are more than 10,000.  

We now display the following dialog:

![image](https://user-images.githubusercontent.com/45077928/214678452-e8b4149b-f8fb-40e1-890a-b8107d6eb9f7.png)

This dialog comes up fairly quickly, as the initial scan for continuation elements is fairly cheap.  

If you choose "Cancel" the loading mask is removed, but the inspector is grayed out:

![image](https://user-images.githubusercontent.com/45077928/214678507-49b33448-5201-476d-8b37-c83ae113a8bc.png)

This fixes #358, where a document with 70,000 continuation elements would cause the viewer to hang when loading, and would typically leave the browser tab unresponsive for several minutes.