### PR TITLE
Fix the save viewer functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .idea
 .vscode
-node_modules/*
+node_modules/
+iXBRLViewerPlugin/viewer/dist
+iXBRLViewerPlugin/
+*/__pycache__

--- a/iXBRLViewerPlugin/__init__.py
+++ b/iXBRLViewerPlugin/__init__.py
@@ -97,7 +97,7 @@ def iXBRLViewerMenuCommand(cntlr):
     dialog = SaveViewerDialog(cntlr)
     if dialog.accepted and dialog.filename():
         viewerBuilder = IXBRLViewerBuilder(modelXbrl)
-        iv = viewerBuilder.createViewer(scriptUrl=dialog.scriptUrl())
+        iv = viewerBuilder.createViewer(scriptUrl=dialog.scriptUrl(), showValidations=False)
         if iv is not None:
             iv.save(dialog.filename())
 
@@ -133,10 +133,12 @@ def viewMenuExtender(cntlr, viewMenu, *args, **kwargs):
     cntlr.launchIXBRLViewer.trace("w", setLaunchIXBRLViewer)
     erViewMenu.add_checkbutton(label=_("Launch viewer on load"), underline=0, variable=cntlr.launchIXBRLViewer, onvalue=True, offvalue=False)
 
+
 def guiRun(cntlr, modelXbrl, attach, *args, **kwargs):
     """ run iXBRL Viewer using GUI interactions for a single instance or testcases """
     if cntlr.hasGui and cntlr.launchIXBRLViewer.get() and modelXbrl.modelDocument.type in (Type.INLINEXBRL, Type.INLINEXBRLDOCUMENTSET):
         launchLocalViewer(cntlr, modelXbrl)
+
 
 __pluginInfo__ = {
     'name': 'ixbrl-viewer',


### PR DESCRIPTION
#### Reason for change
#370

#### Description of change
- Starts logging on load (similar to edgar renderer [1](https://github.com/Arelle/EdgarRenderer/blob/60d4b56fcd2a79356724196664d2e56b5e8b1251/__init__.py#L12960), [2](https://github.com/Arelle/EdgarRenderer/blob/60d4b56fcd2a79356724196664d2e56b5e8b1251/__init__.py#L1565))
- Allows viewer to be saved after its loaded

#### Steps to Test
- Run on the filing from the issue

**review**:
@Workiva/xt
@paulwarren-wk
