### PR TITLE
Add support for arelle pip installed plugin architecture

### DIFF
--- a/iXBRLViewerPlugin/__init__.py
+++ b/iXBRLViewerPlugin/__init__.py
@@ -140,6 +140,10 @@ def guiRun(cntlr, modelXbrl, attach, *args, **kwargs):
         launchLocalViewer(cntlr, modelXbrl)
 
 
+def load_plugin_url():
+    return __file__
+
+
 __pluginInfo__ = {
     'name': 'ixbrl-viewer',
     'version': '0.1',

--- a/setup.py
+++ b/setup.py
@@ -30,4 +30,9 @@ setup(
         'Programming Language :: Python :: 3.9',
     ],
     install_requires=get_requirements(),
+    entry_points={
+        'arelle.plugin': [
+            'plugin_info = iXBRLViewerPlugin:load_plugin_url'
+        ]
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     install_requires=get_requirements(),
     entry_points={
         'arelle.plugin': [
-            'plugin_info = iXBRLViewerPlugin:load_plugin_url'
+            'ixbrl-viewer = iXBRLViewerPlugin:load_plugin_url'
         ]
     }
 )


### PR DESCRIPTION
#### Description of change
Add support for arelle's pip installed plugin architecture https://github.com/Arelle/Arelle/pull/573

#### Steps to Test
Pip install this into arelle https://github.com/Arelle/Arelle/pull/573 branch and create an ixbrl-viewer

1. Pull both this and https://github.com/Arelle/Arelle/pull/573
2. from the arelle repo pip install <PATH_TO_ixbrl-viewer-repo>
3. from the arelle repo python arelleCmdLine.py -f filing.htm --save-viewer ixbrl-report-viewer.html --viewer-url https://cdn-prod.wdesk.com/ixbrl-viewer/1.1.44/ixbrlviewer.js

**review**:
@Workiva/xt
@paulwarren-wk
