### PR TITLE
Prevent CSS from being incorrectly escaped

### DIFF
--- a/iXBRLViewerPlugin/xhtmlserialize.py
+++ b/iXBRLViewerPlugin/xhtmlserialize.py
@@ -38,4 +38,4 @@ class XHTMLSerializer:
 
     def serialize(self, xmlDocument, fout):
         self._expandEmptyTags(xmlDocument)
-        fout.write(etree.tostring(xmlDocument, method="xml", encoding="utf-8", xml_declaration=True))
+        fout.write(etree.tostring(xmlDocument, method="html", encoding="utf-8"))

--- a/tests/unit_tests/iXBRLViewerPlugin/test_xhtmlserialize.py
+++ b/tests/unit_tests/iXBRLViewerPlugin/test_xhtmlserialize.py
@@ -14,6 +14,16 @@ class TestXHTMLSerializer(unittest.TestCase):
     def _html(self, s):
         return '<html xmlns="http://www.w3.org/1999/xhtml"><head></head><body>%s</body></html>' % s
 
+    def _htmlHead(self, s):
+        return '<html xmlns="http://www.w3.org/1999/xhtml"><head>%s</head><body></body></html>' % s   
+
+    def _serialize(self, html):
+        doc = lxml.etree.fromstring(html)
+        f = io.BytesIO()
+        writer = XHTMLSerializer()
+        writer.serialize(doc, f)
+        return f.getvalue().decode('utf-8')     
+
     def _checkTagExpansion(self, html_in, html_out):
         writer = XHTMLSerializer()
         doc = lxml.etree.fromstring(self._html(html_in))
@@ -41,11 +51,11 @@ class TestXHTMLSerializer(unittest.TestCase):
 
     def test_serialize(self):
         htmlsrc = self._html("<p>hello</p>")
-        doc = lxml.etree.fromstring(htmlsrc)
-        f = io.BytesIO()
+        serialized = self._serialize(htmlsrc)
+        self.assertEqual(serialized, htmlsrc)
 
-        writer = XHTMLSerializer()
-        writer.serialize(doc, f)
-
-        # XML declaration should be added.
-        self.assertEqual(f.getvalue().decode('utf-8'), "<?xml version='1.0' encoding='utf-8'?>\n" + htmlsrc)
+    def test_serializeCss(self):
+        # Do not escape > character in CSS style tag
+        htmlsrc = self._html('<style type="text/css">li > p { color: red; }</style>')
+        serialized = self._serialize(htmlsrc)
+        self.assertEqual(serialized, htmlsrc)


### PR DESCRIPTION
#### Reason for change
By writing out the html with an xml method, the characters in the entire document are escaped, including content in `<script>` and `<style>` tags. In style tags css the child combinator (`>`) can be used, which is not functioning anymore after it is incorrectly escaped to `&gt;`.

#### Description of change
Changed the lxml.etree toString method parameter to write out using the html method.

#### Steps to Test
Added automated testcase for this situation.
Test manually by adding viewer to ixbrl report that uses > operator in the css in a style tag. Expected result is that this operator remains untouched.

**review**:
@Workiva/xt
@paulwarren-wk
