### PR TITLE
XT-2790 Fix escaping of style element contents (add custom XHTML serializer)

### DIFF
--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -396,8 +396,8 @@ class iXBRLViewer:
                 for f in self.files:
                     self.dts.info("viewer:info", "Saving in output zip %s" % f.filename)
                     fout = attrdict(write=lambda s: zout.writestr(_outPrefix + f.filename, s))
-                    writer = XHTMLSerializer()
-                    writer.serialize(f.xmlDocument, fout)
+                    writer = XHTMLSerializer(fout)
+                    writer.serialize(f.xmlDocument)
                 zout.write(os.path.join(os.path.dirname(__file__), "viewer", "dist", "ixbrlviewer.js"), _outPrefix + "ixbrlviewer.js")
         elif os.path.isdir(outPath):
             # If output is a directory, write each file in the doc set to that
@@ -406,8 +406,8 @@ class iXBRLViewer:
                 filename = os.path.join(outPath, "{0[0]}{1}{0[1]}".format(os.path.splitext(f.filename), outBasenameSuffix))
                 self.dts.info("viewer:info", "Writing %s" % filename)
                 with open(filename, "wb") as fout:
-                    writer = XHTMLSerializer()
-                    writer.serialize(f.xmlDocument, fout)
+                    writer = XHTMLSerializer(fout)
+                    writer.serialize(f.xmlDocument)
 
         else:
             if len(self.files) > 1:
@@ -421,5 +421,5 @@ class iXBRLViewer:
             else:
                 self.dts.info("viewer:info", "Writing %s" % outPath)
                 with open("{0[0]}{1}{0[1]}".format(os.path.splitext(outPath), outBasenameSuffix), "wb") as fout:
-                    writer = XHTMLSerializer()
-                    writer.serialize(self.files[0].xmlDocument, fout)
+                    writer = XHTMLSerializer(fout)
+                    writer.serialize(self.files[0].xmlDocument)

--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -395,9 +395,9 @@ class iXBRLViewer:
             with zipfile.ZipFile(outPath, "a", zipfile.ZIP_DEFLATED, True) as zout:
                 for f in self.files:
                     self.dts.info("viewer:info", "Saving in output zip %s" % f.filename)
-                    fout = attrdict(write=lambda s: zout.writestr(_outPrefix + f.filename, s))
-                    writer = XHTMLSerializer(fout)
-                    writer.serialize(f.xmlDocument)
+                    with zout.open(_outPrefix + f.filename, "w") as fout:
+                        writer = XHTMLSerializer(fout)
+                        writer.serialize(f.xmlDocument)
                 zout.write(os.path.join(os.path.dirname(__file__), "viewer", "dist", "ixbrlviewer.js"), _outPrefix + "ixbrlviewer.js")
         elif os.path.isdir(outPath):
             # If output is a directory, write each file in the doc set to that

--- a/iXBRLViewerPlugin/xhtmlserialize.py
+++ b/iXBRLViewerPlugin/xhtmlserialize.py
@@ -92,8 +92,10 @@ class XHTMLSerializer:
         if s is None:
             return ''
         if escape_mode == EscapeMode.STYLE:
-            # Don't escape >
-            # & and < may only appear in a string or comment in CSS, so escape
+            # HTML does not understand XML escapes inside a style element.
+            # Don't escape ">".  Escaping isn't required by XML, but is common
+            # practice, so we do it elsewhere.
+            # "&" and "<" may only appear in a string or comment in CSS, so escape
             # as if they're in a string.
             return re.sub(r'([<&])', lambda m: "\\%06X" % ord(m.group(1)), s)
         return re.sub(r'([<>&])', lambda m: self.ENTITIES[m.group(0)], s)

--- a/iXBRLViewerPlugin/xhtmlserialize.py
+++ b/iXBRLViewerPlugin/xhtmlserialize.py
@@ -110,8 +110,9 @@ class XHTMLSerializer:
             # HTML does not understand XML escapes inside a style element.
             # Don't escape ">".  Escaping isn't required by XML, but is common
             # practice, so we do it elsewhere.
-            # "&" and "<" may only appear in a string or comment in CSS, so escape
-            # as if they're in a string.
+            # "&" and "<" are escaped using XML escapes.  This will break
+            # HTML/XHTML compatibility, but any source document using them
+            # wouldn't have been HTML compatible anyway.
             self.write(self.STYLE_ESCAPE_RE.sub(lambda m: self.escape_str(m[0]),s))
         else:
             self.write(self.ESCAPE_RE.sub(lambda m: self.escape_str(m[0]),s))

--- a/iXBRLViewerPlugin/xhtmlserialize.py
+++ b/iXBRLViewerPlugin/xhtmlserialize.py
@@ -17,6 +17,7 @@ from enum import Enum
 import re
 
 XHTML_NS = 'http://www.w3.org/1999/xhtml'
+XML_NS = 'http://www.w3.org/XML/1998/namespace'
 
 class EscapeMode(Enum):
     DEFAULT = 0
@@ -65,7 +66,10 @@ class XHTMLSerializer:
         qname = etree.QName(tag)
         if qname.namespace is None:
             return qname.localname
-        prefix = next(iter(sorted((p for p, ns in nsmap.items() if ns == qname.namespace and p is not None), key = self.prefix_sort)))
+        if qname.namespace == XML_NS:
+            prefix = 'xml'
+        else:
+            prefix = next(iter(sorted((p for p, ns in nsmap.items() if ns == qname.namespace and p is not None), key = self.prefix_sort)))
         return "%s:%s" % (prefix, qname.localname)
 
     def is_selfclosable(self, n):

--- a/iXBRLViewerPlugin/xhtmlserialize.py
+++ b/iXBRLViewerPlugin/xhtmlserialize.py
@@ -151,10 +151,20 @@ class XHTMLSerializer:
 
         self.write_escape_text(n.tail, escape_mode)
 
-    def serialize(self, element):
+    def write_xml_declaration(self, docinfo = None):
         if self.xml_declaration:
-            self.write('<?xml version="1.0" encoding="utf-8"?>\n')
+            version = "1.0"
+            standalone = ""
+            if docinfo is not None:
+                version = docinfo.xml_version
+                if docinfo.standalone:
+                    standalone = ' standalone="yes"'
+            self.write('<?xml version="%s" encoding="%s"%s?>\n' % (version, self.encoding, standalone))
+
+    def serialize(self, element):
         if hasattr(element, 'getroot'):
+            self.write_xml_declaration(element.docinfo)
+
             element = element.getroot()
             while element.getprevious() is not None:
                 element = element.getprevious()
@@ -166,5 +176,6 @@ class XHTMLSerializer:
                 element = element.getnext()
 
         else:
+            self.write_xml_declaration()
             self.write_element(element)
 

--- a/iXBRLViewerPlugin/xhtmlserialize.py
+++ b/iXBRLViewerPlugin/xhtmlserialize.py
@@ -93,7 +93,7 @@ class XHTMLSerializer:
         return sorted(self.xmlns_declaration(p, new_nsmap[p]) for p in changed)
 
     def escape_char(self, c):
-        return self.ENTITIES.get(c, '&#x%2X;' % ord(c))
+        return self.ENTITIES.get(c, '&#x%02X;' % ord(c))
 
     def write_escape_text(self, s, escape_mode):
         if s is None:
@@ -106,7 +106,7 @@ class XHTMLSerializer:
             # as if they're in a string.
             self.write(re.sub(r'([<&])', lambda m: "\\%06X" % ord(m.group(1)), s))
         else:
-            self.write(re.sub(r'([<>&\u0001-\u001F\u007F-\u009F])', lambda m: self.escape_char(m.group(0)),s))
+            self.write(re.sub(r'([<>&\u0001-\u0008\u000B\u000C\u000E\u001F\u007F-\u009F])', lambda m: self.escape_char(m.group(0)),s))
 
     def write_attributes(self, node):
         for qname, value in sorted((self.qname_for_attr(k, node.nsmap), v) for k, v in node.items()):

--- a/iXBRLViewerPlugin/xhtmlserialize.py
+++ b/iXBRLViewerPlugin/xhtmlserialize.py
@@ -117,7 +117,7 @@ class XHTMLSerializer:
         parts = [ name ] + self.namespace_declarations(n.nsmap, parent_nsmap) + self.attributes(n)
         self.write('<' + ' '.join(parts))
 
-        if qname.localname.lower() == 'style':
+        if qname.localname == 'style':
             inner_escape_mode = EscapeMode.STYLE
         else:
             inner_escape_mode = escape_mode

--- a/iXBRLViewerPlugin/xhtmlserialize.py
+++ b/iXBRLViewerPlugin/xhtmlserialize.py
@@ -127,7 +127,10 @@ class XHTMLSerializer:
         self.write_escape_text(n.tail, escape_mode)
 
     def write_processing_instruction(self, n, escape_mode):
-        self.write( '<?' + (n.target + ' ' + n.text).rstrip() + '?>')
+        self.write( '<?' + n.target )
+        if n.text != '':
+            self.write(' ' + n.text)
+        self.write('?>')
         self.write_escape_text(n.tail, escape_mode)
 
     def write_node(self, n, nsmap = {}, escape_mode = EscapeMode.DEFAULT):

--- a/iXBRLViewerPlugin/xhtmlserialize.py
+++ b/iXBRLViewerPlugin/xhtmlserialize.py
@@ -13,29 +13,125 @@
 # limitations under the License.
 
 from lxml import etree
+from enum import Enum
 import re
+
+XHTML_NS = 'http://www.w3.org/1999/xhtml'
+
+class EscapeMode(Enum):
+    DEFAULT = 0
+    STYLE = 1
 
 class XHTMLSerializer:
 
     # From https://www.w3.org/TR/html401/index/elements.html
-    selfClosableElements = (
+    SELF_CLOSABLE = (
         'area', 'base', 'basefont', 'br', 'col', 'frame', 'hr', 'img', 
         'input', 'isindex', 'link', 'meta', 'param'
     )
 
-    def _expandEmptyTags(self, xml):
-        """
-        Expand self-closing tags
+    ENTITIES = {
+        '>': '&gt;',
+        '<': '&lt;',
+        '"': '&quot;',
+        '&': '&amp;'
+        }
 
-        Self-closing tags cause problems for XHTML documents when treated as
-        HTML.  Tags that are required to be empty (e.g. <br>) are left as
-        self-closing.
-        """
-        for e in xml.iter('*'):
-            m = re.match(r'\{http://www\.w3\.org/1999/xhtml\}(.*)', e.tag)
-            if (m is None or m.group(1) not in XHTMLSerializer.selfClosableElements) and e.text is None:
-                e.text = ''
+    def __init__(self, xml_declaration = True, assume_xhtml = True):
+        self.xml_declaration = xml_declaration
+        self.assume_xhtml = assume_xhtml
 
-    def serialize(self, xmlDocument, fout):
-        self._expandEmptyTags(xmlDocument)
-        fout.write(etree.tostring(xmlDocument, method="xml", encoding="utf-8", xml_declaration=True))
+    def prefix_sort(self, p):
+        return p if p is not None else '0'
+
+    def tag_as_qname(self, tag, nsmap):
+        qname = etree.QName(tag)
+        if qname.namespace is None:
+            return qname.localname
+
+        prefix = next(iter(sorted((p for p, ns in nsmap.items() if ns == qname.namespace), key = self.prefix_sort)))
+
+        if prefix is None:
+            return qname.localname
+        else:
+            return "%s:%s" % (prefix, qname.localname)
+
+    def is_selfclosable(self, n):
+        qname = etree.QName(n)
+        return (
+                qname.localname in XHTMLSerializer.SELF_CLOSABLE
+                and (
+                    qname.namespace == XHTML_NS
+                    or (self.assume_xhtml and qname.namespace is None)))
+
+    def escape_attr(self, s):
+        return re.sub(r'([<>"&])', lambda m: self.ENTITIES[m.group(0)], s)
+
+    def xmlns_declaration(self, prefix, uri):
+        if prefix is None:
+            return 'xmlns="%s"' % self.escape_attr(uri)
+        return 'xmlns:%s="%s"' % (prefix, self.escape_attr(uri))
+
+    def namespace_declarations(self, new_nsmap, cur_nsmap):
+        changed = set(p[0] for p in (set(new_nsmap.items()) ^ set(cur_nsmap.items())))
+        return sorted(self.xmlns_declaration(p, new_nsmap[p]) for p in changed)
+
+    def escape_text(self, s, escape_mode):
+        if s is None:
+            return ''
+        if escape_mode == EscapeMode.STYLE:
+            # Don't escape >
+            # & and < may only appear in a string or comment in CSS, so escape
+            # as if they're in a string.
+            return re.sub(r'([<&])', lambda m: "\\%06X" % ord(m.group(1)), s)
+        return re.sub(r'([<>&])', lambda m: self.ENTITIES[m.group(0)], s)
+
+    def attributes(self, node):
+        return sorted(
+            '%s="%s"' % (self.tag_as_qname(k, node.nsmap), self.escape_attr(v))
+                for k, v in node.items()
+            )
+
+    def write_comment(self, n, escape_mode):
+        return '<!--' + n.text + '-->' + self.escape_text(n.tail, escape_mode)
+
+    def write_processing_instruction(self, n, escape_mode):
+        return '<?' + n.target + ' ' + n.text + '?>' + self.escape_text(n.tail, escape_mode)
+
+    def write_element(self, n, parent_nsmap = {}, escape_mode = EscapeMode.DEFAULT):
+        name = self.tag_as_qname(n.tag, n.nsmap)
+        qname = etree.QName(n.tag)
+        selfclose = len(n) == 0 and n.text is None and self.is_selfclosable(n)
+        parts = [ name ] + self.namespace_declarations(n.nsmap, parent_nsmap) + self.attributes(n)
+        s = '<' + ' '.join(parts)
+
+        if qname.localname.lower() == 'style':
+            inner_escape_mode = EscapeMode.STYLE
+        else:
+            inner_escape_mode = escape_mode
+
+        if selfclose:
+            s += '/>'
+        else:
+            s += '>'
+            s += self.escape_text(n.text, inner_escape_mode)
+
+            for child in n.iterchildren():
+                if isinstance(child, etree._Comment):
+                    s += self.write_comment(child, inner_escape_mode)
+                elif isinstance(child, etree._ProcessingInstruction):
+                    s += self.write_processing_instruction(child, inner_escape_mode)
+                else:
+                    s += self.write_element(child, n.nsmap, inner_escape_mode)
+            s += '</%s>' % name
+
+        s += self.escape_text(n.tail, escape_mode)
+
+        return s
+
+    def serialize(self, element, fout):
+        if hasattr(element, 'getroot'):
+            element = element.getroot()
+        if self.xml_declaration:
+            fout.write('<?xml version="1.0" encoding="utf-8"?>\n'.encode('utf-8'))
+        fout.write(self.write_element(element).encode('utf-8'))

--- a/iXBRLViewerPlugin/xhtmlserialize.py
+++ b/iXBRLViewerPlugin/xhtmlserialize.py
@@ -42,8 +42,8 @@ class XHTMLSerializer:
     MUST_ESCAPE_CHARS = r'<&\u0001-\u0008\u000B\u000C\u000E\u001F\u007F-\u009F'
     CDATA_END = r']]>'
 
-    ESCAPE_RE = re.compile('([' + MUST_ESCAPE_CHARS + '>]|' + CDATA_END + ')')
-    ATTR_ESCAPE_RE = re.compile('([' + MUST_ESCAPE_CHARS + '>"]|' + CDATA_END + ')')
+    ESCAPE_RE = re.compile('([' + MUST_ESCAPE_CHARS + '>])')
+    ATTR_ESCAPE_RE = re.compile('([' + MUST_ESCAPE_CHARS + '>"])')
     STYLE_ESCAPE_RE = re.compile('([' + MUST_ESCAPE_CHARS + ']|' + CDATA_END + ')')
 
     def __init__(self, fout, xml_declaration = True, assume_xhtml = True):

--- a/iXBRLViewerPlugin/xhtmlserialize.py
+++ b/iXBRLViewerPlugin/xhtmlserialize.py
@@ -81,7 +81,7 @@ class XHTMLSerializer:
                     or (self.assume_xhtml and qname.namespace is None)))
 
     def escape_attr(self, s):
-        return re.sub(r'([<>"&])', lambda m: self.ENTITIES[m.group(0)], s)
+        return re.sub(r'([<>"&\u0001-\u001F\u007F-\u009F])', lambda m: self.escape_char(m.group(0)), s)
 
     def xmlns_declaration(self, prefix, uri):
         if prefix is None:
@@ -91,6 +91,9 @@ class XHTMLSerializer:
     def namespace_declarations(self, new_nsmap, cur_nsmap):
         changed = set(p[0] for p in (set(new_nsmap.items()) ^ set(cur_nsmap.items())))
         return sorted(self.xmlns_declaration(p, new_nsmap[p]) for p in changed)
+
+    def escape_char(self, c):
+        return self.ENTITIES.get(c, '&#x%2X;' % ord(c))
 
     def write_escape_text(self, s, escape_mode):
         if s is None:
@@ -103,7 +106,7 @@ class XHTMLSerializer:
             # as if they're in a string.
             self.write(re.sub(r'([<&])', lambda m: "\\%06X" % ord(m.group(1)), s))
         else:
-            self.write(re.sub(r'([<>&])', lambda m: self.ENTITIES[m.group(0)], s))
+            self.write(re.sub(r'([<>&\u0001-\u001F\u007F-\u009F])', lambda m: self.escape_char(m.group(0)),s))
 
     def write_attributes(self, node):
         for qname, value in sorted((self.qname_for_attr(k, node.nsmap), v) for k, v in node.items()):

--- a/tests/unit_tests/iXBRLViewerPlugin/test_xhtmlserialize.py
+++ b/tests/unit_tests/iXBRLViewerPlugin/test_xhtmlserialize.py
@@ -17,8 +17,7 @@ class TestXHTMLSerializer(unittest.TestCase):
     def _checkTagExpansion(self, html_in, html_out):
         writer = XHTMLSerializer()
         doc = lxml.etree.fromstring(self._html(html_in))
-        writer._expandEmptyTags(doc)
-        self.assertEqual(lxml.etree.tostring(doc, encoding="unicode"), self._html(html_out))
+        self.assertEqual(writer.write_element(doc), self._html(html_out))
 
     def test_expandEmptyTags(self):
         self._checkTagExpansion('<div/>', '<div></div>')
@@ -48,4 +47,93 @@ class TestXHTMLSerializer(unittest.TestCase):
         writer.serialize(doc, f)
 
         # XML declaration should be added.
-        self.assertEqual(f.getvalue().decode('utf-8'), "<?xml version='1.0' encoding='utf-8'?>\n" + htmlsrc)
+        self.assertEqual(f.getvalue().decode('utf-8'), '<?xml version="1.0" encoding="utf-8"?>\n' + htmlsrc)
+
+    def test_custom_xml_serializer(self):
+        tests = (
+            # Self-closable elements should be collapsed
+            (
+                r'''<div><br></br><span></span></div>''',
+                r'''<div><br/><span></span></div>'''
+            ),
+
+            # Non-self-closable element should be expanded
+            (
+                r'''<div><span/></div>''',
+                r'''<div><span></span></div>'''
+            ),
+
+            # > is usually escaped
+            (
+                r'''<div> &lt;foo> &lt;bar&gt; &amp; </div>''',
+                r'''<div> &lt;foo&gt; &lt;bar&gt; &amp; </div>'''
+            ),
+
+            # > is not escaped in a style tag
+            (
+                r'''<style>div &gt; p { color: #777 }</style>''',
+                r'''<style>div > p { color: #777 }</style>''',
+            ),
+
+            # < and & can appear in CSS string
+            (
+                r'''<style>span::before { content: "&lt;&amp;" }</style>''',
+                r'''<style>span::before { content: "\00003C\000026" }</style>''',
+            ),
+
+            # also escaped this way in comments, which is harmless
+            (
+                r'''<style>span { color: #777 } /* &lt;span> elements are styled this way */ </style>''',
+                r'''<style>span { color: #777 } /* \00003Cspan> elements are styled this way */ </style>''',
+            ),
+
+            (
+                r'''<div xmlns="http://www.w3.org/1999/xhtml"><svg xmlns="http://www.w3.org/2000/svg"></svg></div>''',
+                r'''<div xmlns="http://www.w3.org/1999/xhtml"><svg xmlns="http://www.w3.org/2000/svg"></svg></div>''',
+            ),
+            (
+                r'''<xhtml:div xmlns:xhtml="http://www.w3.org/1999/xhtml"><svg xmlns="http://www.w3.org/2000/svg"></svg></xhtml:div>''',
+                r'''<xhtml:div xmlns:xhtml="http://www.w3.org/1999/xhtml"><svg xmlns="http://www.w3.org/2000/svg"></svg></xhtml:div>''',
+            ),
+
+            # Default and prefixed namespace for same URI.  Serialiser prefers unprefixed
+            (
+                r'''<xhtml:div xmlns="http://www.w3.org/1999/xhtml" xmlns:xhtml="http://www.w3.org/1999/xhtml"><svg xmlns="http://www.w3.org/2000/svg"></svg></xhtml:div>''',
+                r'''<div xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/1999/xhtml"><svg xmlns="http://www.w3.org/2000/svg"></svg></div>''',
+            ),
+
+            # Text and tail and comment handling
+            (
+                r'''<div>Text<span>text</span>tail<!-- comment -->after comment<span>text</span>tail</div>''',
+                r'''<div>Text<span>text</span>tail<!-- comment -->after comment<span>text</span>tail</div>'''
+            ),
+
+            (
+                r'''<div><?my-pi attr1="val1" attr2="val2" ?></div>''',
+                r'''<div><?my-pi attr1="val1" attr2="val2" ?></div>'''
+            ),
+
+            # attribute escaping
+            (
+                r'''<div attr1="'foo>&amp;'">abc</div>''',
+                r'''<div attr1="'foo&gt;&amp;'">abc</div>''',
+            ),
+            # Always uses double quotes
+            (
+                r'''<div attr1='"foo"'>abc</div>''',
+                r'''<div attr1="&quot;foo&quot;">abc</div>''',
+            ),
+
+        )
+
+
+        serializer = XHTMLSerializer(xml_declaration=False)
+        for (test_in, test_out) in tests:
+            x = lxml.etree.fromstring(test_in)
+            s = serializer.write_element(x)
+            assert s == test_out
+
+            # Round trip
+            x2 = lxml.etree.fromstring(s)
+            assert serializer.write_element(x2) == s
+

--- a/tests/unit_tests/iXBRLViewerPlugin/test_xhtmlserialize.py
+++ b/tests/unit_tests/iXBRLViewerPlugin/test_xhtmlserialize.py
@@ -140,6 +140,11 @@ class TestXHTMLSerializer(unittest.TestCase):
                 r'''<div attr1='"foo"'>abc</div>''',
                 r'''<div attr1="&quot;foo&quot;">abc</div>''',
             ),
+            # xml prefix doesn't need declaring
+            (
+                r'''<div xml:lang="en" attr='abc'>abc</div>''',
+                r'''<div attr="abc" xml:lang="en">abc</div>''',
+            ),
 
         )
 

--- a/tests/unit_tests/iXBRLViewerPlugin/test_xhtmlserialize.py
+++ b/tests/unit_tests/iXBRLViewerPlugin/test_xhtmlserialize.py
@@ -126,9 +126,20 @@ class TestXHTMLSerializer(unittest.TestCase):
                 r'''<div>Text<span>text</span>tail<!-- comment -->after comment<span>text</span>tail</div>'''
             ),
 
+            # PI trailing space handling
+            (
+                r'''<div><?my-pi attr1="val1" attr2="val2" ?></div>''',
+                r'''<div><?my-pi attr1="val1" attr2="val2" ?></div>'''
+            ),
+
             (
                 r'''<div><?my-pi attr1="val1" attr2="val2"?></div>''',
                 r'''<div><?my-pi attr1="val1" attr2="val2"?></div>'''
+            ),
+
+            (
+                r'''<div><?my-pi ?></div>''',
+                r'''<div><?my-pi?></div>'''
             ),
 
             # attribute escaping

--- a/tests/unit_tests/iXBRLViewerPlugin/test_xhtmlserialize.py
+++ b/tests/unit_tests/iXBRLViewerPlugin/test_xhtmlserialize.py
@@ -145,6 +145,11 @@ class TestXHTMLSerializer(unittest.TestCase):
                 r'''<div xml:lang="en" attr='abc'>abc</div>''',
                 r'''<div attr="abc" xml:lang="en">abc</div>''',
             ),
+            # control characters escaped
+            (
+                r'''<div foo="&#128;">abc&#x81;&#127;</div>''',
+                r'''<div foo="&#x80;">abc&#x81;&#x7F;</div>''',
+            ),
 
         )
 


### PR DESCRIPTION
#### Reason for change

At present, the XHTML produced by the viewer builder escapes `<`, `&` and `>` throughout the document.  This is fine as long as the result is treated as XHTML.   Ordinary HTML expects different escaping to `<style>` and `<script>` elements.  In particular, an escaped `>` in a style element will not be recognised as valid CSS, resulting in different rendering in HTML and XHTML rendering mode.

#### Description of change

With this PR, the viewer does not escape `>` appearing within `<style>` elements (this is optional in XML/XHTML).

`<` and `&` are escaped as if they are appearing within a CSS string using `\NNNNNN` hex escapes (this is the only place other than comments in which they can legally appear in CSS).

This is an alternative solution for #384 .

#### Steps to Test

Create an iXBRL document with an inline style sheet, and a style rule such as:

```css
p > span { color: #f00 }
```

Create a viewer from it, and confirm that the `>` is not escaped in the resulting output.

**review**:
@Workiva/xt
@paulwarren-wk
