### PR TITLE
Support for Ukrainian currency symbols and company identifiers

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/i18n/en/currencies.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/en/currencies.json
@@ -3,6 +3,7 @@
     "unitFormatUSD": "US \u0024",
     "unitFormatEUR": "\u20AC",
     "unitFormatMXN": "MXN \u0024",
+    "unitFormatUAH": "\u20B4",
     "centsUSD": "cents",
     "centsEUR": "cents",
     "centsAUD": "cents",

--- a/iXBRLViewerPlugin/viewer/src/js/identifiers.js
+++ b/iXBRLViewerPlugin/viewer/src/js/identifiers.js
@@ -16,12 +16,13 @@ const schemes = {
     "http://standards.iso.org/iso/17442": { "name": "LEI", "url": "https://search.gleif.org/#/record/%s" },
     "http://www.sec.gov/CIK": { "name": "CIK", "url": "https://www.sec.gov/cgi-bin/browse-edgar?CIK=%s"},
     "http://www.companieshouse.gov.uk/": { "name": "UK CRN", "url": "https://beta.companieshouse.gov.uk/company/%08d"},
+    "https://www.minfin.gov.ua": { "name": "EDRPOU" },
 };
 
 export class Identifiers {
     static identifierURLForFact(fact) {
         const data = schemes[fact.identifier().namespace];
-        if (data !== undefined) {
+        if (data !== undefined && data.url !== undefined) {
             let url = data.url.replace('%s', fact.identifier().localname);
             url = url.replace(/%0(\d+)d/, function (match, width) { 
                 return fact.identifier().localname.padStart(width, "0");

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -608,12 +608,18 @@ Inspector.prototype._updateValue = function (item, showAll, context) {
 }
 
 Inspector.prototype._updateEntityIdentifier = function (fact, context) {
-    var url = Identifiers.identifierURLForFact(fact);
-    var cell = $('tr.entity-identifier td', context);
+    const cell = $('tr.entity-identifier td', context);
     cell.empty();
-    if (url) {
+    const url = Identifiers.identifierURLForFact(fact);
+    const name = Identifiers.identifierNameForFact(fact);
+    if (fact !== undefined) {
         $('<span></span>').text('['+Identifiers.identifierNameForFact(fact) + "] ").appendTo(cell)
-        $('<a target="_blank"></a>').attr('href',url).text(fact.identifier().localname).appendTo(cell)
+        if (url !== undefined) {
+            $('<a target="_blank"></a>').attr('href',url).text(fact.identifier().localname).appendTo(cell)
+        }
+        else {
+            $('<span></span>').text(fact.identifier().localname).appendTo(cell);
+        }
     }
     else {
         cell.text(fact.f.a.e);


### PR DESCRIPTION
#### Reason for change

To provide a better display of monetary figures in the fact inspector with Ukrainian reports, and facts using Ukrainian company identifiers (EDRPOU).

#### Description of change

The fact inspect now shows the currency symbol rather than the 3 letter code ("UAH")

![image](https://user-images.githubusercontent.com/45077928/220603052-a4d1186d-d4e3-4f05-a4e0-5dec05853800.png)

The inspector will also add a "EDRPOU" prefix for for Ukrainian company identifiers (e.g. "[EDRPOU] 12345"), rather than showing them as a QName (`e:12345`)

#### Steps to Test

Create an iXBRL report with a fact using units of `iso4217:UAH`  and using an entity scheme of `https://www.minfin.gov.ua`, and view the fact in the fact inspector.

**review**:
@Workiva/xt
@paulwarren-wk
