### PR TITLE
Improve load performance

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -259,7 +259,7 @@ export class Fact {
     }
 
     isHTMLHidden() {
-        return this.ixNode.htmlHidden;
+        return this.ixNode.htmlHidden();
     }
 
     widerConcepts() {

--- a/iXBRLViewerPlugin/viewer/src/js/ixnode.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixnode.js
@@ -34,7 +34,6 @@ export class IXNode {
         this.footnote = false;
         this.id = id;
         this.isHidden = false;
-        this.htmlHidden = false;
         this.docOrderindex = docOrderindex++;
     }
 
@@ -54,5 +53,9 @@ export class IXNode {
             // so will give the full text content.
             .map(n => n.wrapperNodes.first().text())
             .join(" ");
+    }
+
+    htmlHidden() {
+        return this.wrapperNodes.is(':hidden');
     }
 }

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -124,7 +124,7 @@ Viewer.prototype._wrapNode = function(n) {
     var wrapper = "<span>";
     const nn = n.getElementsByTagName("*");
     for (var i = 0; i < nn.length; i++) {
-        if($(nn[i]).css("display") === "block") {
+        if(nn[i].style.display === "block") {
             wrapper = '<div>';
             break;
         }
@@ -204,19 +204,22 @@ Viewer.prototype._findOrCreateWrapperNode = function(domNode) {
         nodes = this._wrapNode(domNode);
         // Create a node set of current node and all absolutely positioned
         // descendants.
-        nodes = nodes.find("*").addBack().filter(function () {
-            return (this == nodes[0] || $(this).css("position") == "absolute");
+        nodes = nodes.find("*").addBack().filter(function (n, e) {
+            // node list will include ix:* elements, with no style property.
+            // Can't trivially use instanceof HTMLElement in an iframe.
+            return (this == nodes[0] || ('style' in this && this.style.position === "absolute"));
         });
     }
     nodes.each(function (i) {
-        if (this.getBoundingClientRect().height == 0 && $(this).css('display') !== 'inline') {
-            $(this).addClass("ixbrl-no-highlight"); 
+        // getBoundingClientRect blocks on layout, so only do it if we've actually got absolute nodes
+        if (nodes.length > 1 && this.style.display !== 'inline' && this.getBoundingClientRect().height == 0) {
+            this.classList.add("ixbrl-no-highlight");
         }
         if (i == 0) {
-            $(this).addClass("ixbrl-element")
+            this.classList.add("ixbrl-element");
         }
         else {
-            $(this).addClass("ixbrl-sub-element"); 
+            this.classList.add("ixbrl-sub-element");
         }
     });
     return nodes;

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -124,7 +124,7 @@ Viewer.prototype._wrapNode = function(n) {
     var wrapper = "<span>";
     const nn = n.getElementsByTagName("*");
     for (var i = 0; i < nn.length; i++) {
-        if(nn[i].style.display === "block") {
+        if ('style' in nn[i] && nn[i].style.display === "block") {
             wrapper = '<div>';
             break;
         }

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -124,7 +124,7 @@ Viewer.prototype._wrapNode = function(n) {
     var wrapper = "<span>";
     const nn = n.getElementsByTagName("*");
     for (var i = 0; i < nn.length; i++) {
-        if ('style' in nn[i] && nn[i].style.display === "block") {
+        if (getComputedStyle(nn[i]).getPropertyValue('display') === "block") {
             wrapper = '<div>';
             break;
         }
@@ -205,9 +205,7 @@ Viewer.prototype._findOrCreateWrapperNode = function(domNode) {
         // Create a node set of current node and all absolutely positioned
         // descendants.
         nodes = nodes.find("*").addBack().filter(function (n, e) {
-            // node list will include ix:* elements, with no style property.
-            // Can't trivially use instanceof HTMLElement in an iframe.
-            return (this == nodes[0] || ('style' in this && this.style.position === "absolute"));
+            return (this == nodes[0] || (getComputedStyle(this).getPropertyValue('position') === "absolute"));
         });
     }
     nodes.each(function (i) {

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -60,6 +60,7 @@ Viewer.prototype.initialize = function() {
         viewer._buildContinuationMaps();
         viewer._checkContinuationCount()
             .catch(err => { throw err })
+            .then(() => viewer._iv.setProgress("Pre-processing document"))
             .then(() => {
 
                 viewer._iframes.each(function (docIndex) { 

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -210,7 +210,7 @@ Viewer.prototype._findOrCreateWrapperNode = function(domNode) {
     }
     nodes.each(function (i) {
         // getBoundingClientRect blocks on layout, so only do it if we've actually got absolute nodes
-        if (nodes.length > 1 && this.style.display !== 'inline' && this.getBoundingClientRect().height == 0) {
+        if (nodes.length > 1 && getComputedStyle(this).getPropertyValue("display") !== 'inline' && this.getBoundingClientRect().height == 0) {
             this.classList.add("ixbrl-no-highlight");
         }
         if (i == 0) {

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -324,9 +324,6 @@ Viewer.prototype._preProcessiXBRL = function(n, docIndex, inHidden) {
                 ixn = new IXNode(id, nodes, docIndex);
                 this._ixNodeMap[id] = ixn;
             }
-            if (nodes.is(':hidden')) {
-                ixn.htmlHidden = true;
-            }
             if (inHidden) {
                 ixn.isHidden = true;
                 nodes.addClass("ixbrl-element-hidden");


### PR DESCRIPTION
#### Reason for change

Reduce viewer loading time.

#### Description of change

This PR avoids two operations done during the pre-process iXBRL phase that trigger a reflow of the document.  On the attached test document on my laptop this reduces the pre-process phase from 18 seconds to 1 second.

* The `is(":hidden")` check, which is used to display the "concealed fact" warning in the inspector, is now done on demand.
* The check for zero-size nodes (because they contain absolutely positioned nodes) is now only done on elements that actually contain absolutely positioned nodes.  Many documents won't contain absolutely positioned content at all.  

#### Steps to Test

Try opening the attached IXDS in the viewer, and note the time taken to load before and after applying this PR:

[0000078003-20-000014-xbrl (1).zip](https://github.com/Workiva/ixbrl-viewer/files/10831330/0000078003-20-000014-xbrl.1.zip)

**review**:
@Workiva/xt
@paulwarren-wk
