### PR TITLE
Highlighting CSS fixes

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/less/viewer.less
+++ b/iXBRLViewerPlugin/viewer/src/less/viewer.less
@@ -47,27 +47,34 @@ span {
   }
 }
 
-.ixbrl-element:not(.ixbrl-no-highlight),
-.ixbrl-sub-element:not(.ixbrl-no-highlight) {
-  cursor: pointer;
+:not(.ixbrl-no-highlight) {
+    &.ixbrl-element,
+    &.ixbrl-sub-element {
+      cursor: pointer;
 
-  &.ixbrl-related {
-    outline: dashed 2px @related-fact;
-    outline-offset: 1px;
-  }
+      &.ixbrl-related {
+        outline: dashed 2px @related-fact;
+
+        &:not(td):not(th) {
+            outline-offset: 1px;
+        }
+      }
+    }
 }
 
 td,
 th {
-  &.ixbrl-selected:not(.ixbrl-no-highlight) {
-    outline: solid 2px @primary-focus !important;
-    outline-offset: -1px !important;
-  }
+  &:not(.ixbrl-no-highlight) {
+      &.ixbrl-selected {
+        outline: solid 2px @primary-focus !important;
+        outline-offset: -1px !important;
+      }
 
-  &.ixbrl-element:hover:not(.ixbrl-selected),
-  &.ixbrl-sub-element:hover:not(.ixbrl-selected) {
-    outline: dashed 2px @primary-focus !important;
-    outline-offset: -1px !important;
+      &.ixbrl-element:hover:not(.ixbrl-selected),
+      &.ixbrl-sub-element:hover:not(.ixbrl-selected) {
+        outline: dashed 2px @primary-focus !important;
+        outline-offset: -1px !important;
+      }
   }
 
   &.ixbrl-related {
@@ -75,14 +82,16 @@ th {
   }
 }
 
-.ixbrl-related.ixbrl-linked-highlight,
-.ixbrl-linked-highlight {
+.ixbrl-related.ixbrl-linked-highlight:not(.ixbrl-no-highlight),
+.ixbrl-linked-highlight:not(.ixbrl-no-highlight) {
   .linked-highlight-text();
 }
 
-td.ixbrl-related.ixbrl-linked-highlight,
-td.ixbrl-linked-highlight {
+td.ixbrl-related.ixbrl-linked-highlight:not(.ixbrl-no-highlight),
+td.ixbrl-linked-highlight:not(.ixbrl-no-highlight) {
   .linked-highlight-cell();
+
+  outline-offset: -1px;
 }
 
 div.ixbrl-table-handle {

--- a/iXBRLViewerPlugin/viewer/src/less/viewer.less
+++ b/iXBRLViewerPlugin/viewer/src/less/viewer.less
@@ -48,33 +48,33 @@ span {
 }
 
 :not(.ixbrl-no-highlight) {
-    &.ixbrl-element,
-    &.ixbrl-sub-element {
-      cursor: pointer;
+  &.ixbrl-element,
+  &.ixbrl-sub-element {
+    cursor: pointer;
 
-      &.ixbrl-related {
-        outline: dashed 2px @related-fact;
+    &.ixbrl-related {
+      outline: dashed 2px @related-fact;
 
-        &:not(td):not(th) {
-            outline-offset: 1px;
-        }
+      &:not(td, th) {
+        outline-offset: 1px;
       }
     }
+  }
 }
 
 td,
 th {
   &:not(.ixbrl-no-highlight) {
-      &.ixbrl-selected {
-        outline: solid 2px @primary-focus !important;
-        outline-offset: -1px !important;
-      }
+    &.ixbrl-selected {
+      outline: solid 2px @primary-focus !important;
+      outline-offset: -1px !important;
+    }
 
-      &.ixbrl-element:hover:not(.ixbrl-selected),
-      &.ixbrl-sub-element:hover:not(.ixbrl-selected) {
-        outline: dashed 2px @primary-focus !important;
-        outline-offset: -1px !important;
-      }
+    &.ixbrl-element:hover:not(.ixbrl-selected),
+    &.ixbrl-sub-element:hover:not(.ixbrl-selected) {
+      outline: dashed 2px @primary-focus !important;
+      outline-offset: -1px !important;
+    }
   }
 
   &.ixbrl-related {


### PR DESCRIPTION
#### Reason for change

Fixes two highlighting related issues:

1. Where a tagged element has zero size (usually because the only content is absolutely positioned elements), we add an `ixbrl-no-highlight` class to avoid putting a border around it when the fact is selected.  We previously weren't filtering on this when highlighting related facts.  For example, when mouse-overing the "associated facts" section of footnote.
2. We apply a different outline offset to table cells (-1px) from other content (+1px).  Due to a CSS priority issue, this wasn't being applied correctly when highlighting related items in a calculation:

![image](https://user-images.githubusercontent.com/45077928/223269647-e7efcfd4-4922-4472-a6ab-a19cd7db38af.png)

(note green outlines are larger than blue outline)

#### Description of change

1. Is fixed by adding `:not(.ixbrl-no-highlight)` in additional places.
2. Is fixed by adding `:not(td, th)` on the default outline offset declaration.

#### Steps to Test

1. Requires a document with an element with absolutely positioned children and a footnote.  Select the footnote, and then mouseover the fact in the "associated facts" section.
2. Requires a document with a calculation where the contributing facts are in table cells.  Select the total, and check the size of the green dotted outline of the contributing facts.

**review**:
@Workiva/xt
@paulwarren-wk
