### PR TITLE
Include version number in viewer

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -179,6 +179,7 @@ limitations under the License.
     <div class="inspector-foot powered-by">
         <span data-i18n="inspector.poweredBy">Powered by</span>
         <a href="https://www.workiva.co.uk/solutions/xbrl-and-ixbrl" target="_blank"><img alt="Workiva logo (opens in new window)" src="../img/workiva.svg" /></a>
+        <div class="version"></div>
     </div>
     <div class="failed-to-load-mask"></div>
   </div>

--- a/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
@@ -99,6 +99,7 @@ iXBRLViewer.prototype._loadInspectorHTML = function () {
     $('<link id="ixv-favicon" type="image/x-icon" rel="shortcut icon" />')
         .attr('href', require('../img/favicon.ico'))
         .appendTo('head');
+    $('.inspector-foot .version').text(__VERSION__);
 }
 
 iXBRLViewer.prototype._reparentDocument = function () {

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -905,9 +905,19 @@
       margin: 0;
       box-sizing: border-box;
       border-top: @simple-border;
+      position: relative;
 
       img {
         height: 14px;
+      }
+
+      .version {
+        position: absolute;
+        top: 0;
+        right: 5px;
+        font-size: small;
+        line-height: 3rem;
+        color: #999;
       }
     }
 

--- a/iXBRLViewerPlugin/viewer/webpack.common.js
+++ b/iXBRLViewerPlugin/viewer/webpack.common.js
@@ -53,5 +53,6 @@ module.exports = {
   plugins: [
     // Ignore all locale files of moment.js
     new webpack.IgnorePlugin({ resourceRegExp: /^\.\/locale$/, contextRegExp: /moment$/ }),
+    new webpack.DefinePlugin({ __VERSION__: JSON.stringify(process.env.VIEWER_VERSION) })
   ]
 };

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   },
   "scripts": {
     "test": "jest",
-    "dev": "webpack --config iXBRLViewerPlugin/viewer/webpack.dev.js",
-    "prod": "webpack --config iXBRLViewerPlugin/viewer/webpack.prod.js",
+    "dev": "VIEWER_VERSION=`git describe --tags --dirty`-dev webpack --config iXBRLViewerPlugin/viewer/webpack.dev.js",
+    "prod": "VIEWER_VERSION=`git describe --tags --dirty` webpack --config iXBRLViewerPlugin/viewer/webpack.prod.js",
     "stylelint": "stylelint iXBRLViewerPlugin/viewer/src/less/*.less",
     "i18n": "i18next -c iXBRLViewerPlugin/viewer/i18next-parser.config.js"
   },


### PR DESCRIPTION
#### Reason for change

Fixes #368 

#### Description of change

The viewer now shows the version number in the bottom right of the inspector.  The version number is obtained with `git describe --tags --dirty`, with `-dev` appended if it's a dev build.

There's nothing to stop the version number overlapping with the Workiva logo, but production builds should have a fairly short version number (e.g. `1.1.52`)

![image](https://user-images.githubusercontent.com/45077928/223559224-7a786932-b3f6-4464-87b9-bf86acefbec3.png)

#### Steps to Test

Build viewer, open any document, confirm that version identifier is shown in bottom right corner.

**review**:
@Workiva/xt
@paulwarren-wk
