### PR TITLE
Stub viewer mode

### DIFF
--- a/iXBRLViewerPlugin/__init__.py
+++ b/iXBRLViewerPlugin/__init__.py
@@ -42,8 +42,6 @@ import argparse
 import traceback
 import sys
 
-import traceback
-import sys
 
 def iXBRLViewerCommandLineOptionExtender(parser, *args, **kwargs):
     parser.add_option("--save-viewer",
@@ -62,6 +60,10 @@ def iXBRLViewerCommandLineOptionExtender(parser, *args, **kwargs):
     # Force logging to use a buffer so that messages are retained and can be
     # retrieved for inclusion with the viewer.
     parser.add_option("--logToBuffer", action="store_true", dest="logToBuffer", default=True, help=argparse.SUPPRESS)
+    parser.add_option("--use-stub-viewer",
+                      action="store_true",
+                      dest="useStubViewer",
+                      help="Use stub viewer for faster loading of inspector")
 
 def iXBRLViewerCommandLineXbrlRun(cntlr, options, *args, **kwargs):
     # extend XBRL-loaded run processing for this option
@@ -76,7 +78,7 @@ def iXBRLViewerCommandLineXbrlRun(cntlr, options, *args, **kwargs):
         out = getattr(options, 'saveViewerFile') or kwargs.get("responseZipStream")
         if out:
             viewerBuilder = IXBRLViewerBuilder(modelXbrl)
-            iv = viewerBuilder.createViewer(scriptUrl=options.viewerURL, showValidations = options.validationMessages)
+            iv = viewerBuilder.createViewer(scriptUrl=options.viewerURL, showValidations = options.validationMessages, useStubViewer=options.useStubViewer)
             if iv is not None:
                 iv.save(out, outBasenameSuffix=VIEWER_BASENAME_SUFFIX, outzipFilePrefix=VIEWER_BASENAME_SUFFIX)
     except IXBRLViewerBuilderError as ex:

--- a/iXBRLViewerPlugin/__init__.py
+++ b/iXBRLViewerPlugin/__init__.py
@@ -63,7 +63,7 @@ def iXBRLViewerCommandLineOptionExtender(parser, *args, **kwargs):
     parser.add_option("--use-stub-viewer",
                       action="store_true",
                       dest="useStubViewer",
-                      help="Use stub viewer for faster loading of inspector")
+                      help="Use stub viewer for faster loading of inspector (requires web server)")
     parser.add_option("--viewer-suffix",
                       action="store",
                       default="",

--- a/iXBRLViewerPlugin/__init__.py
+++ b/iXBRLViewerPlugin/__init__.py
@@ -64,6 +64,11 @@ def iXBRLViewerCommandLineOptionExtender(parser, *args, **kwargs):
                       action="store_true",
                       dest="useStubViewer",
                       help="Use stub viewer for faster loading of inspector")
+    parser.add_option("--viewer-suffix",
+                      action="store",
+                      default="",
+                      dest="viewerBasenameSuffix",
+                      help="Suffix for basename of viewer files")
 
 def iXBRLViewerCommandLineXbrlRun(cntlr, options, *args, **kwargs):
     # extend XBRL-loaded run processing for this option
@@ -80,7 +85,7 @@ def iXBRLViewerCommandLineXbrlRun(cntlr, options, *args, **kwargs):
             viewerBuilder = IXBRLViewerBuilder(modelXbrl)
             iv = viewerBuilder.createViewer(scriptUrl=options.viewerURL, showValidations = options.validationMessages, useStubViewer=options.useStubViewer)
             if iv is not None:
-                iv.save(out, outBasenameSuffix=VIEWER_BASENAME_SUFFIX, outzipFilePrefix=VIEWER_BASENAME_SUFFIX)
+                iv.save(out, outzipFilePrefix=VIEWER_BASENAME_SUFFIX)
     except IXBRLViewerBuilderError as ex:
         print(ex.message)
     except Exception as ex:

--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -365,6 +365,7 @@ class IXBRLViewerBuilder:
         dts.info("viewer:info", "Creating iXBRL viewer")
 
         if dts.modelDocument.type == Type.INLINEXBRLDOCUMENTSET:
+
             # Sort by object index to preserve order in which files were specified.
             xmlDocsByFilename = {
                 os.path.basename(self.outputFilename(doc.filepath)): deepcopy(doc.xmlDocument)
@@ -372,10 +373,14 @@ class IXBRLViewerBuilder:
             }
             self.taxonomyData["docSetFiles"] = list(xmlDocsByFilename.keys())
 
-            for filename, xmlDocument in xmlDocsByFilename.items():
-                iv.addFile(iXBRLViewerFile(filename, xmlDocument))
+            if useStubViewer:
+                xmlDocument = self.getStubDocument()
+                iv.addFile(iXBRLViewerFile("ixbrlviewer.html", xmlDocument))
+            else:
+                xmlDocument = next(iter(xmlDocsByFilename.values()))
 
-            xmlDocument = next(iter(xmlDocsByFilename.values()))
+            for filename, docSetXMLDoc in xmlDocsByFilename.items():
+                iv.addFile(iXBRLViewerFile(filename, docSetXMLDoc))
 
         elif useStubViewer:
             xmlDocument = self.getStubDocument()

--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -21,6 +21,7 @@ import json
 import math
 import re
 import pycountry
+import urllib.parse
 from arelle.ValidateXbrlCalcs import inferredDecimals
 from arelle.ModelRelationshipSet import ModelRelationshipSet
 from .xhtmlserialize import XHTMLSerializer
@@ -352,6 +353,8 @@ class IXBRLViewerBuilder:
         self.roleMap.getPrefix(XbrlConst.dimensionDefault, "d-d")
         self.roleMap.getPrefix(WIDER_NARROWER_ARCROLE, "w-n")
 
+        docSetFiles = None
+
         for f in dts.facts:
             self.addFact(f)
 
@@ -371,7 +374,7 @@ class IXBRLViewerBuilder:
                 os.path.basename(self.outputFilename(doc.filepath)): deepcopy(doc.xmlDocument)
                 for doc in sorted(dts.modelDocument.referencesDocument.keys(), key=lambda x: x.objectIndex)
             }
-            self.taxonomyData["docSetFiles"] = list(xmlDocsByFilename.keys())
+            docSetFiles = list(xmlDocsByFilename.keys())
 
             if useStubViewer:
                 xmlDocument = self.getStubDocument()
@@ -385,7 +388,7 @@ class IXBRLViewerBuilder:
         elif useStubViewer:
             xmlDocument = self.getStubDocument()
             filename = self.outputFilename(os.path.basename(dts.modelDocument.filepath))
-            self.taxonomyData["docSetFiles"] = [ filename ]
+            docSetFiles = [ filename ]
             iv.addFile(iXBRLViewerFile("ixbrlviewer.html", xmlDocument))
             iv.addFile(iXBRLViewerFile(filename, dts.modelDocument.xmlDocument))
 
@@ -393,6 +396,9 @@ class IXBRLViewerBuilder:
             xmlDocument = deepcopy(dts.modelDocument.xmlDocument)
             filename = os.path.basename(dts.modelDocument.filepath)
             iv.addFile(iXBRLViewerFile(filename, xmlDocument))
+
+        if docSetFiles is not None:
+            self.taxonomyData["docSetFiles"] = list(urllib.parse.quote(f) for f in docSetFiles)
 
         if not self.addViewerToXMLDocument(xmlDocument, scriptUrl):
             return None
@@ -413,7 +419,6 @@ class iXBRLViewer:
 
     def addFile(self, ivf):
         self.files.append(ivf)
-
 
     def save(self, outPath, outzipFilePrefix=""):
         """

--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -24,6 +24,8 @@ import pycountry
 from arelle.ValidateXbrlCalcs import inferredDecimals
 from arelle.ModelRelationshipSet import ModelRelationshipSet
 from .xhtmlserialize import XHTMLSerializer
+from lxml import etree
+import os
 
 import os
 import logging
@@ -201,6 +203,7 @@ class IXBRLViewerBuilder:
                 rels.setdefault(self.roleMap.getPrefix(arcrole),{})[self.roleMap.getPrefix(ELR)] = rr
         return rels
 
+<<<<<<< HEAD
     def validationErrors(self):
         dts = self.dts
 
@@ -327,7 +330,11 @@ class IXBRLViewerBuilder:
                 return True
         return False
 
-    def createViewer(self, scriptUrl="js/dist/ixbrlviewer.js", showValidations = True):
+    def getStubDocument(self):
+        with open(os.path.join(os.path.dirname(__file__),"stubviewer.html")) as fin:
+            return etree.parse(fin)
+
+    def createViewer(self, scriptUrl="js/dist/ixbrlviewer.js", useStubViewer = False, showValidations = True):
         """
         Create an iXBRL file with XBRL data as a JSON blob, and script tags added
         """
@@ -365,6 +372,13 @@ class IXBRLViewerBuilder:
                 iv.addFile(iXBRLViewerFile(filename, xmlDocument))
 
             xmlDocument = next(iter(xmlDocsByFilename.values()))
+
+        elif useStubViewer:
+            xmlDocument = self.getStubDocument()
+            filename = os.path.basename(dts.modelDocument.filepath)
+            self.taxonomyData["docSetFiles"] = [ filename ]
+            iv.addFile(iXBRLViewerFile("ixbrlviewer.html", xmlDocument))
+            iv.addFile(iXBRLViewerFile(filename, dts.modelDocument.xmlDocument))
 
         else:
             xmlDocument = deepcopy(dts.modelDocument.xmlDocument)

--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -208,7 +208,6 @@ class IXBRLViewerBuilder:
                 rels.setdefault(self.roleMap.getPrefix(arcrole),{})[self.roleMap.getPrefix(ELR)] = rr
         return rels
 
-<<<<<<< HEAD
     def validationErrors(self):
         dts = self.dts
 

--- a/iXBRLViewerPlugin/localviewer.py
+++ b/iXBRLViewerPlugin/localviewer.py
@@ -49,8 +49,10 @@ localViewer = iXBRLViewerLocalViewer("iXBRL Viewer",  os.path.dirname(__file__))
 def launchLocalViewer(cntlr, modelXbrl):
     from arelle import LocalViewer
     try:
-        viewerBuilder = IXBRLViewerBuilder(cntlr.modelManager.modelXbrl)
-        iv = viewerBuilder.createViewer(scriptUrl="/ixbrlviewer.js", showValidations = False)
+        ixds = cntlr.modelManager.modelXbrl.type == Type.INLINEXBRLDOCUMENTSET:
+        basenameSuffix = '' if xds else VIEWER_BASENAME_SUFFIX
+        viewerBuilder = IXBRLViewerBuilder(cntlr.modelManager.modelXbrl, basenameSuffix = basenameSuffix, showValidations = False)
+        iv = viewerBuilder.createViewer(scriptUrl="/ixbrlviewer.js")
         # first check if source file was in an archive (e.g., taxonomy package)
         _archiveFilenameParts = archiveFilenameParts(modelXbrl.modelDocument.filepath)
         if _archiveFilenameParts is not None:
@@ -59,16 +61,16 @@ def launchLocalViewer(cntlr, modelXbrl):
             outDir = modelXbrl.modelDocument.filepathdir
         _localhost = localViewer.init(cntlr, outDir)
         # for IXDS, outPath must be a directory name, suffix is applied in saving files
-        if len(iv.files) > 1:
+        if ixds:
             # save files in a separate directory from source files
             _localhost += "/" + VIEWER_BASENAME_SUFFIX
             outDir = os.path.join(outDir, VIEWER_BASENAME_SUFFIX)
             os.makedirs(outDir, exist_ok=True)
-            iv.save(outDir) # no changes to html inline files so inter-file refereences still can work
+            iv.save(outDir) 
             htmlFile = iv.files[0].filename
         else:
-            iv.save(outDir, outBasenameSuffix=VIEWER_BASENAME_SUFFIX)
-            htmlFile = "{0[0]}{1}{0[1]}".format(os.path.splitext(modelXbrl.modelDocument.basename), VIEWER_BASENAME_SUFFIX)
+            iv.save(outDir)
+            htmlFile = viewerBuilder.outputFilename(modelXbrl.modelDocument.basename)
         import webbrowser
         webbrowser.open(url="{}/{}".format(_localhost, htmlFile))
     except Exception as ex:

--- a/iXBRLViewerPlugin/localviewer.py
+++ b/iXBRLViewerPlugin/localviewer.py
@@ -49,7 +49,7 @@ localViewer = iXBRLViewerLocalViewer("iXBRL Viewer",  os.path.dirname(__file__))
 def launchLocalViewer(cntlr, modelXbrl):
     from arelle import LocalViewer
     try:
-        ixds = cntlr.modelManager.modelXbrl.type == Type.INLINEXBRLDOCUMENTSET:
+        ixds = cntlr.modelManager.modelXbrl.type == Type.INLINEXBRLDOCUMENTSET
         basenameSuffix = '' if xds else VIEWER_BASENAME_SUFFIX
         viewerBuilder = IXBRLViewerBuilder(cntlr.modelManager.modelXbrl, basenameSuffix = basenameSuffix, showValidations = False)
         iv = viewerBuilder.createViewer(scriptUrl="/ixbrlviewer.js")

--- a/iXBRLViewerPlugin/localviewer.py
+++ b/iXBRLViewerPlugin/localviewer.py
@@ -15,6 +15,7 @@
 from arelle.LocalViewer import LocalViewer
 from arelle.webserver.bottle import static_file
 from arelle.FileSource import archiveFilenameParts
+from arelle import ModelDocument
 import os, shutil
 import logging
 import zipfile, sys, traceback
@@ -49,10 +50,10 @@ localViewer = iXBRLViewerLocalViewer("iXBRL Viewer",  os.path.dirname(__file__))
 def launchLocalViewer(cntlr, modelXbrl):
     from arelle import LocalViewer
     try:
-        ixds = cntlr.modelManager.modelXbrl.type == Type.INLINEXBRLDOCUMENTSET
-        basenameSuffix = '' if xds else VIEWER_BASENAME_SUFFIX
-        viewerBuilder = IXBRLViewerBuilder(cntlr.modelManager.modelXbrl, basenameSuffix = basenameSuffix, showValidations = False)
-        iv = viewerBuilder.createViewer(scriptUrl="/ixbrlviewer.js")
+        ixds = cntlr.modelManager.modelXbrl.modelDocument.type == ModelDocument.Type.INLINEXBRLDOCUMENTSET
+        basenameSuffix = '' if ixds else VIEWER_BASENAME_SUFFIX
+        viewerBuilder = IXBRLViewerBuilder(cntlr.modelManager.modelXbrl, basenameSuffix = basenameSuffix)
+        iv = viewerBuilder.createViewer(scriptUrl="/ixbrlviewer.js", showValidations = False)
         # first check if source file was in an archive (e.g., taxonomy package)
         _archiveFilenameParts = archiveFilenameParts(modelXbrl.modelDocument.filepath)
         if _archiveFilenameParts is not None:

--- a/iXBRLViewerPlugin/stubviewer.html
+++ b/iXBRLViewerPlugin/stubviewer.html
@@ -1,0 +1,8 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>iXBRL Viewer</title>
+    </head>
+    <body>
+        <h1>iXBRL Viewer</h1>
+    </body>
+</html>

--- a/iXBRLViewerPlugin/stubviewer.html
+++ b/iXBRLViewerPlugin/stubviewer.html
@@ -2,7 +2,6 @@
     <head>
         <title>iXBRL Viewer</title>
     </head>
-    <body>
-        <h1>iXBRL Viewer</h1>
+    <body class="ixv-stub-viewer">
     </body>
 </html>

--- a/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
@@ -210,7 +210,6 @@ iXBRLViewer.prototype.load = function () {
                     viewer.initialize()
                         .then(() => inspector.initialize(report, viewer))
                         .then(() => {
-                            inspector.setViewer(viewer);
                             interact('#viewer-pane').resizable({
                                 edges: { left: false, right: ".resize", bottom: false, top: false},
                                 restrictEdges: {
@@ -252,7 +251,8 @@ iXBRLViewer.prototype.load = function () {
 
                         });
                 }
-            });
+            }, 250);
+        });
     }, 0);
 }
 

--- a/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
@@ -180,13 +180,15 @@ iXBRLViewer.prototype.load = function () {
             $('#ixv .loader').removeClass("loading");
             return;
         }
-        var report = new iXBRLReport(JSON.parse(taxonomyData));
-        if (report.isDocumentSet()) {
-            var ds = report.documentSetFiles();
-            for (var i = stubViewer ? 0 : 1; i < ds.length; i++) {
-                var iframe = $("<iframe />").attr("src", ds[i]).appendTo("#ixv #iframe-container");
-                iframes = iframes.add(iframe);
-            }
+        const report = new iXBRLReport(JSON.parse(taxonomyData));
+        const ds = report.documentSetFiles();
+        var hasExternalIframe = false;
+        for (var i = stubViewer ? 0 : 1; i < ds.length; i++) {
+            const iframe = $("<iframe />").attr("src", ds[i]).appendTo("#ixv #iframe-container");
+            iframes = iframes.add(iframe);
+            hasExternalIframe = true;
+        }
+        if (hasExternalIframe) {
             iv._checkDocumentSetBrowserSupport();
         }
 

--- a/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
@@ -165,7 +165,14 @@ iXBRLViewer.prototype.load = function () {
     setTimeout(function () {
 
         iv._loadInspectorHTML();
-        var iframes = $(iv._reparentDocument());
+        var iframes;
+        const stubViewer = $('body').hasClass('ixv-stub-viewer');
+        if (!stubViewer) {
+            iframes = $(iv._reparentDocument());
+        } 
+        else {
+            iframes = $();
+        }
 
         var taxonomyData = iv._getTaxonomyData();
         if (taxonomyData === null) {
@@ -176,7 +183,7 @@ iXBRLViewer.prototype.load = function () {
         var report = new iXBRLReport(JSON.parse(taxonomyData));
         if (report.isDocumentSet()) {
             var ds = report.documentSetFiles();
-            for (var i = 1; i < ds.length; i++) {
+            for (var i = stubViewer ? 0 : 1; i < ds.length; i++) {
                 var iframe = $("<iframe />").attr("src", ds[i]).appendTo("#ixv #iframe-container");
                 iframes = iframes.add(iframe);
             }

--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -310,7 +310,7 @@ iXBRLReport.prototype.documentSetFiles = function() {
 }
 
 iXBRLReport.prototype.isDocumentSet = function() {
-    return this.data.docSetFiles !== undefined;
+    return this.documentSetFiles().length > 1;
 }
 
 iXBRLReport.prototype.usesAnchoring = function() {

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -99,7 +99,7 @@ function localName(e) {
 }
 
 Viewer.prototype._addDocumentSetTabs = function() {
-    if (this._report.isDocumentSet()) {
+    if (this._report.isDocumentSet() && this._report.documentSetFiles().length > 1) {
         $('#ixv .ixds-tabs').show();
         var ds = this._report.documentSetFiles();
         var viewer = this;

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -99,7 +99,7 @@ function localName(e) {
 }
 
 Viewer.prototype._addDocumentSetTabs = function() {
-    if (this._report.isDocumentSet() && this._report.documentSetFiles().length > 1) {
+    if (this._report.isDocumentSet()) {
         $('#ixv .ixds-tabs').show();
         var ds = this._report.documentSetFiles();
         var viewer = this;

--- a/samples/build-viewer.py
+++ b/samples/build-viewer.py
@@ -39,7 +39,7 @@ class CntlrCreateViewer(Cntlr.Cntlr):
                 self.addToLog("Failed to load package", messageCode="error", file=p)
         PackageManager.rebuildRemappings(self)
     
-    def createViewer(self, f, scriptUrl=None, outPath=None):
+    def createViewer(self, f, scriptUrl=None, outPath=None, useStubViewer=False):
         if os.path.isdir(f):
             files = glob.glob(os.path.join(f, "*.xhtml")) + glob.glob(os.path.join(f, "*.html")) + glob.glob(os.path.join(f, "*.htm"))
             files.sort()
@@ -56,7 +56,7 @@ class CntlrCreateViewer(Cntlr.Cntlr):
 
         try:
             viewerBuilder = iXBRLViewerPlugin.iXBRLViewer.IXBRLViewerBuilder(xbrl)
-            viewer = viewerBuilder.createViewer(scriptUrl = scriptUrl)
+            viewer = viewerBuilder.createViewer(scriptUrl = scriptUrl, useStubViewer = useStubViewer)
             viewer.save(outPath)
         except iXBRLViewerPlugin.iXBRLViewer.IXBRLViewerBuilderError as e:
             print(e.message)
@@ -66,6 +66,9 @@ parser = argparse.ArgumentParser(description="Create iXBRL Viewer instances")
 parser.add_argument("--package-dir", "-p", help="Path to directory containing taxonomy packages")
 parser.add_argument("--viewer-url", "-u", help="URL to ixbrlviewer.js", default="ixbrlviewer.js")
 parser.add_argument("--out", "-o", help="File or directory to write output to", default="viewer.html")
+parser.add_argument("--use-stub-viewer",
+                    action="store_true",
+                    help="Use stub viewer for faster loading of inspector (requires web server)")
 parser.add_argument('files', metavar='FILES', nargs='+',
                     help='Files to process')
 args = parser.parse_args()
@@ -89,4 +92,4 @@ if args.package_dir:
     cntlr.loadPackagesFromDir(args.package_dir)
 
 for f in args.files:
-    cntlr.createViewer(f, outPath = args.out, scriptUrl = args.viewer_url)
+    cntlr.createViewer(f, outPath = args.out, scriptUrl = args.viewer_url, useStubViewer = args.use_stub_viewer)


### PR DESCRIPTION
#### Reason for change

To reduce the delay between opening a report and the loading mask and progress information being displayed, which can be a significant amount of time on large documents.

This change also reduces the modifications made to the source document, as no `<script>` tags are inserted.  The only  changes made to the source document are the addition of `id` attributes on any `ix` elements that don't already have them.

#### Description of change

The change adds two new command line options:

* `--use-stub-viewer` - if specified, stub viewer mode is enabled.
* `--viewer-suffix` - a suffix that will be inserted into generated filenames.

When using stub viewer mode, the path given to `--save-viewer` should be a directory.  The viewer will output two files:

* `ixbrlviewer.html` - a small HTML file containing the `<script>` reference and JSON data.
* A file with the same name as the input file, with the viewer suffix (if specified) inserted before the file extension.

The viewer  is opened by opening the `ixbrlviewer.html` file.  Due to security restrictions, this needs to be open on a web server (this is the same restriction that applies to Inline XBRL document sets).

#### Steps to Test

Generate a viewer for any file using the command line and adding the `--use-stub-viewer` option and specifying a directory to `--save-viewer`.  Optionally specify a suffix, such as `--viewer-suffix=-viewer`.

This code has been in use on the filings.xbrl.org fork of the viewer for some time, and can be seen on any filing there (e.g. https://filings.xbrl.org/969500N6AVPA51648T62/2022-12-31/ESEF/FR/1/rexel-2022-12-31-fr/reports/ixbrlviewer.html)

**review**:
@Workiva/xt
@paulwarren-wk
