### PR TITLE
Improve load time

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -57,7 +57,7 @@ limitations under the License.
 
       <div class="search-controls search-mode-only">
         <div class="search-input">
-          <input id="ixbrl-search" type="text" aria-label="Search iXBRL report"/>
+          <input id="ixbrl-search" type="text" aria-label="Search iXBRL report" disabled="disabled" />
           <div class="filter-toggle"></div>
         </div>
         <div class="search-filters">
@@ -162,7 +162,8 @@ limitations under the License.
         </div>
         <div class="search-overlay">
           <div class="search-overlay-icon"></div>
-          <div class="search-overlay-text"><p class="title" data-i18n="inspector.factSearch">Fact Search</p><p class="text">Please enter some search terms</p></div>
+          <div class="search-overlay-text search-ready-only"><p class="title" data-i18n="inspector.factSearch">Fact Search</p><p class="text">Please enter some search terms</p></div>
+          <div class="search-overlay-text search-not-ready-only"><p class="title" data-i18n="inspector.factSearch">Fact Search</p><p class="text">Please wait - building index...</p></div>
         </div>
       </div>
 

--- a/iXBRLViewerPlugin/viewer/src/i18n/en/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/en/translation.json
@@ -40,6 +40,7 @@
     "hiddenFact": "Hidden Fact",
     "hiddenFacts": "Hidden Facts",
     "highlight": "Highlight",
+    "initializing": "Initializing",
     "loadingViewer": "Loading iXBRL Viewer",
     "narrowerAnchor": "Narrower anchors",
     "nextTag": "Next tag",

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -115,7 +115,7 @@ Inspector.prototype.initialize = function (report, viewer) {
             report.setViewerOptions(inspector._viewerOptions);
             inspector.outline = new DocumentOutline(report);
             inspector.createOutline();
-            inspector._iv.setProgress(i18next.t("search.buildingSearchIndex")).then(() => {
+            inspector._iv.setProgress(i18next.t("inspector.initializing")).then(() => {
                 inspector._search = new ReportSearch(report);
                 inspector.setupSearchControls();
                 inspector.buildDisplayOptionsMenu();

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import $ from 'jquery'
-import { formatNumber, wrapLabel, truncateLabel } from "./util.js";
+import { formatNumber, wrapLabel, truncateLabel, runGenerator } from "./util.js";
 import { ReportSearch } from "./search.js";
 import { Calculation } from "./calculations.js";
 import { IXBRLChart } from './chart.js';
@@ -136,7 +136,10 @@ Inspector.prototype.initializeViewer = function () {
     viewer.onMouseLeave.add(id => this.viewerMouseLeave(id));
     $('.ixbrl-next-tag').click(() => viewer.selectNextTag(this._currentItem));
     $('.ixbrl-prev-tag').click(() => viewer.selectPrevTag(this._currentItem));
-    this.search();
+}
+
+Inspector.prototype.postLoadAsync = function () {
+    runGenerator(this._search.buildSearchIndex(this.searchReady));
 }
 
 
@@ -280,7 +283,6 @@ Inspector.prototype.searchSpec = function () {
 }
 
 Inspector.prototype.setupSearchControls = function (viewer) {
-    var inspector = this;
     $('.search-controls input, .search-controls select').change(() => this.search());
     $(".search-controls div.filter-toggle").click(() => $(".search-controls").toggleClass('show-filters'));
     $(".search-controls .search-filters .reset").click(() => this.resetSearchFilters());
@@ -303,9 +305,17 @@ Inspector.prototype.resetSearchFilters = function () {
     this.search();
 }
 
+Inspector.prototype.searchReady = function() {
+    $('#inspector').addClass('search-ready');
+    $('#ixbrl-search').prop('disabled', false);
+}
+
 Inspector.prototype.search = function() {
     var spec = this.searchSpec();
     var results = this._search.search(spec);
+    if (results === undefined) {
+        return;
+    }
     var viewer = this._viewer;
     var container = $('#inspector .search-results .results');
     $('div', container).remove();

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -117,7 +117,6 @@ Inspector.prototype.initialize = function (report, viewer) {
             inspector.createOutline();
             inspector._iv.setProgress(i18next.t("inspector.initializing")).then(() => {
                 inspector._search = new ReportSearch(report);
-                inspector.setupSearchControls();
                 inspector.buildDisplayOptionsMenu();
                 inspector.buildToolbarHighlightMenu();
                 inspector.buildHighlightKey();
@@ -306,6 +305,7 @@ Inspector.prototype.resetSearchFilters = function () {
 }
 
 Inspector.prototype.searchReady = function() {
+    this.setupSearchControls();
     $('#inspector').addClass('search-ready');
     $('#ixbrl-search').prop('disabled', false);
     this.search();

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -139,7 +139,7 @@ Inspector.prototype.initializeViewer = function () {
 }
 
 Inspector.prototype.postLoadAsync = function () {
-    runGenerator(this._search.buildSearchIndex(this.searchReady));
+    runGenerator(this._search.buildSearchIndex(() => this.searchReady()));
 }
 
 
@@ -308,6 +308,7 @@ Inspector.prototype.resetSearchFilters = function () {
 Inspector.prototype.searchReady = function() {
     $('#inspector').addClass('search-ready');
     $('#ixbrl-search').prop('disabled', false);
+    this.search();
 }
 
 Inspector.prototype.search = function() {

--- a/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
@@ -248,6 +248,8 @@ iXBRLViewer.prototype.load = function () {
                             if (iv.options.showValidationWarningOnStart) {
                                 inspector.showValidationWarning();
                             }
+                            viewer.postLoadAsync();
+                            inspector.postLoadAsync();
                         })
                         .catch(err => {
                             if (err instanceof DocumentTooLargeError) {

--- a/iXBRLViewerPlugin/viewer/src/js/search.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.js
@@ -65,6 +65,16 @@ export class ReportSearch {
             }
         }
         const builder = new lunr.Builder();
+        builder.pipeline.add(
+          lunr.trimmer,
+          lunr.stopWordFilter,
+          lunr.stemmer
+        )
+
+        builder.searchPipeline.add(
+          lunr.stemmer
+        )
+
         builder.ref('id');
         builder.field('label');
         builder.field('concept');

--- a/iXBRLViewerPlugin/viewer/src/js/search.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.js
@@ -60,7 +60,7 @@ export class ReportSearch {
                 this.periods[p.key()] = p.toString();
             }
 
-            if (i % 100 == 0) {
+            if (i % 100 === 0) {
                 yield;
             }
         }
@@ -89,7 +89,7 @@ export class ReportSearch {
 
         for (const [i, doc] of docs.entries()) {
             builder.add(doc);
-            if (i % 100 == 0) {
+            if (i % 100 === 0) {
                 yield;
             }
         }

--- a/iXBRLViewerPlugin/viewer/src/js/util.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.js
@@ -137,3 +137,14 @@ export function setDefault(obj, key, def) {
     }
     return obj[key];
 }
+
+export function runGenerator(generator) {
+    function resume() {
+        const res = generator.next();
+        if (!res.done) {
+            setTimeout(resume, 0);
+        }
+        return;
+    }
+    setTimeout(resume, 0);
+}

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -764,7 +764,7 @@ Viewer.prototype.postProcess = function*(iframe) {
             if (getComputedStyle(e).getPropertyValue("display") !== 'inline') {
                 e.getBoundingClientRect().height
             }
-            if (i % 100 == 0) {
+            if (i % 100 === 0) {
                 yield;
             }
         }
@@ -772,7 +772,7 @@ Viewer.prototype.postProcess = function*(iframe) {
             if (getComputedStyle(e).getPropertyValue("display") !== 'inline' && e.getBoundingClientRect().height == 0) {
                 e.classList.add("ixbrl-no-highlight");
             }
-            if (i % 100 == 0) {
+            if (i % 100 === 0) {
                 yield;
             }
         }

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -755,7 +755,7 @@ Viewer.prototype.selectDocument = function (docIndex) {
     this._setTitle(docIndex);
 }
 
-Viewer.prototype.postProcess = function*(iframe) {
+Viewer.prototype.postProcess = function*() {
     for (const iframe of this._iframes.get()) {
         const elts = $(iframe).contents().get(0).querySelectorAll(".ixbrl-contains-absolute");
         // In some cases, getBoundingClientRect().height returns 0, and

--- a/iXBRLViewerPlugin/viewer/src/less/form-controls.less
+++ b/iXBRLViewerPlugin/viewer/src/less/form-controls.less
@@ -100,3 +100,7 @@ label.checkbox {
     transform: rotate(45deg);
   }
 }
+
+input:disabled {
+  background-color: #eee;
+}

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -976,7 +976,6 @@
         display: none;
       }
 
-      #ixbrl-search,
       .search-results {
         background-color: rgb(0 0 0 / 50%);
       }

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -964,6 +964,23 @@
       width: 100%;
       height: 100%;
     }
+
+    &.search-ready {
+      .search-not-ready-only {
+        display: none;
+      }
+    }
+
+    &:not(.search-ready) {
+      .search-ready-only {
+        display: none;
+      }
+
+      #ixbrl-search,
+      .search-results {
+        background-color: rgb(0 0 0 / 50%);
+      }
+    }
   }
 
   .fact-link {


### PR DESCRIPTION
#### Reason for change

The load process can be slow on large documents, preventing the user from interacting with the viewer.

#### Description of change

This PR moves two slow operations into a asynchronous "post load" phase after the loading mask is removed, and the viewer becomes interactive.  These are:

* Checking for zero-size elements.  This check avoids putting an outline around empty elements.  This is slow, because it relies on the layout-triggering `getClientBoundingRect()`.  In the event that a user selects an affected fact before this operation is completed, the results is purely cosmetic, and will be fixed as soon as the worker gets to that element.
* Building the search index.  Search is now disabled until this operation is complete. 

Working with [this UBS filing](https://www.sec.gov/Archives/edgar/data/1114446/000161052022000028/0001610520-22-000028-index.html), I see the "preprocessing" step reduced from about 12s to 6s, and the build search index phase of about 5s is also deferred.

#### Steps to Test

Open a big filing, such as the UBS one above, and compare time from opening to loading mask disappearing.  Check behaviour of search function immediately after load.

**review**:
@Workiva/xt
@paulwarren-wk
