### PR TITLE
XT-2866 Add ability to filter positive/negative fact values

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -71,6 +71,16 @@ limitations under the License.
               <option value="numeric" data-i18n="inspector.numericOption">Numeric</option>
               <option value="text" data-i18n="inspector.textOption">Text</option>
           </select>
+
+          <div class="control-label" data-i18n="inspector.factValue">
+              Fact Value
+          </div>
+          <select id="search-filter-fact-value">
+              <option value="*" data-i18n="inspector.allOption">ALL</option>
+              <option value="negative" data-i18n="inspector.negative">Negative</option>
+              <option value="positive" data-i18n="inspector.positive">Positive</option>
+          </select>
+
           <div class="control-label" data-i18n="inspector.period">
               Period
           </div>

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -20,6 +20,7 @@ import { Aspect } from "./aspect.js";
 import { Period } from './period.js';
 import { formatNumber } from "./util.js";
 import { Footnote } from "./footnote.js";
+import Decimal from "decimal.js";
 
 export class Fact {
     
@@ -210,7 +211,16 @@ export class Fact {
     isNil() {
         return this.f.v === null;
     }
+    isNegative() {
+        return this.isNumeric() && !this.isNil() && this.value() !== undefined && new Decimal(this.value()).isNegative() && !this.isZero();
+    }
+    isPositive() {
+        return this.isNumeric() && !this.isNil() && this.value() !== undefined && new Decimal(this.value()).isPositive() && !this.isZero();
+    }
 
+    isZero() {
+        return this.isNumeric() && !this.isNil() && this.value() !== undefined && new Decimal(this.value()).isZero();
+    }
     isInvalidIXValue() {
         return this.f.err == 'INVALID_IX_VALUE';
     }

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -278,6 +278,7 @@ Inspector.prototype.searchSpec = function () {
     spec.showHiddenFacts = $('#search-hidden-fact-filter').prop('checked');
     spec.periodFilter = $('#search-filter-period').val();
     spec.conceptTypeFilter = $('#search-filter-concept-type').val();
+    spec.factValueFilter = $('#search-filter-fact-value').val();
     return spec;
 }
 
@@ -299,6 +300,7 @@ Inspector.prototype.setupSearchControls = function (viewer) {
 Inspector.prototype.resetSearchFilters = function () {
     $("#search-filter-period").val("*");
     $("#search-filter-concept-type").val("*");
+    $("#search-filter-fact-value").val("*");
     $("#search-hidden-fact-filter").prop("checked", true);
     $("#search-visible-fact-filter").prop("checked", true);
     this.search();

--- a/iXBRLViewerPlugin/viewer/src/js/search.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.js
@@ -14,6 +14,7 @@
 
 import lunr from 'lunr'
 import $ from 'jquery'
+import Decimal from "decimal.js";
 
 export class ReportSearch {
     constructor(report) {
@@ -108,10 +109,11 @@ export class ReportSearch {
 
         rr.forEach((r,i) => {
                 var item = searchIndex._report.getItemById(r.ref);
-                if (
-                    (item.isHidden() ? s.showHiddenFacts : s.showVisibleFacts) &&
-                    (s.periodFilter == '*' || item.period().key() == s.periodFilter) &&
-                    (s.conceptTypeFilter == '*' || s.conceptTypeFilter == (item.isNumeric() ? 'numeric' : 'text'))) {
+                if ((item.isHidden() ? s.showHiddenFacts : s.showVisibleFacts) &&
+                    (s.periodFilter === '*' || item.period().key() === s.periodFilter) &&
+                    (s.conceptTypeFilter === '*' || s.conceptTypeFilter === (item.isNumeric() ? 'numeric' : 'text')) &&
+                    (s.factValueFilter === '*' || (s.factValueFilter === 'positive' && item.isPositive()) || (s.factValueFilter === 'negative' && item.isNegative())))
+                {
                     results.push({
                         "fact": item,
                         "score": r.score

--- a/iXBRLViewerPlugin/viewer/src/js/search.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.test.js
@@ -1,0 +1,142 @@
+// Copyright 2023 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { ReportSearch } from "./search.js"
+import {iXBRLReport} from "./report";
+
+const testReportData = {
+    "concepts": {
+        "us-gaap:Cash": {
+            "labels": {
+                "ns0": {
+                    "en-us": "Cash"
+                }
+            }
+        }
+    },
+    "languages": {
+        "en-us": "En (US)"
+    },
+    "facts": {},
+    "prefixes": {
+        "us-gaap": "http://fasb.org/us-gaap/2023",
+    },
+    "roles": {},
+    "roleDefs": {},
+    "rels": {}
+};
+
+function testReport(facts, ixData) {
+    // Deep copy of standing data
+    const data = JSON.parse(JSON.stringify(testReportData));
+    data.facts = facts;
+    const report = new iXBRLReport(data);
+    report.setIXNodeMap(ixData);
+    return report;
+}
+
+function testSearchSpec(searchString) {
+    const spec = {};
+    spec.searchString = searchString;
+    spec.showVisibleFacts = true;
+    spec.showHiddenFacts = true;
+    spec.periodFilter = '*';
+    spec.conceptTypeFilter = '*';
+    spec.factValueFilter = '*';
+    return spec;
+}
+
+describe("search negative filter", () => {
+    const positive = {
+        "d": -3,
+        "v": 1000,
+        "a": {
+            "c": "us-gaap:Cash",
+            "u": "iso4217:USD",
+            "p": "2018-01-01/2019-01-01",
+        }};
+    const negative = {
+        "d": -3,
+        "v": -1000,
+        "a": {
+            "c": "us-gaap:Cash",
+            "u": "iso4217:USD",
+            "p": "2018-01-01/2019-01-01",
+        }};
+    const zero = {
+        "d": 0,
+        "v": 0,
+        "a": {
+            "c": "us-gaap:Cash",
+            "u": "iso4217:USD",
+            "p": "2018-01-01/2019-01-03",
+        }};
+    const text = {
+        "d": -3,
+        "v": "someText",
+        "a": {
+            "c": "us-gaap:Cash",
+            "u": undefined,
+            "p": "2018-01-01/2019-01-03",
+        }};
+    const undef = {
+        "d": -3,
+        "v": undefined,
+        "a": {
+            "c": "us-gaap:Cash",
+            "u": "iso4217:USD",
+            "p": "2018-01-01/2019-01-03",
+        }};
+    const report = testReport(
+            {'positive': positive, 'negative': negative, 'zero': zero, 'text': text, 'undefined': undef},
+            {'positive': {}, 'negative': {}, 'zero': {}, 'text': {}, 'undefined': {}}
+    )
+    const reportSearch = new ReportSearch(report);
+    const searchIndex = reportSearch.buildSearchIndex(() => {});
+    for (const _ of searchIndex) {}
+
+    test("Fact Value Negative filter works", () => {
+        const spec = testSearchSpec('Cash');
+        spec.factValueFilter = 'negative'
+        const results = reportSearch.search(spec);
+        expect(results.length).toEqual(1)
+        expect(results[0]["fact"]["id"]).toEqual("negative")
+    });
+
+    test("Fact Value Negative filter works with other filter", () => {
+        const spec = testSearchSpec('Cash');
+        spec.factValueFilter = 'negative'
+        spec.periodFilter = '2018-01-01/2019-01-01'
+        const results = reportSearch.search(spec);
+        expect(results.length).toEqual(1)
+        expect(results[0]["fact"]["id"]).toEqual("negative")
+    });
+
+    test("Fact Value Positive filter works", () => {
+        const spec = testSearchSpec('Cash');
+        spec.factValueFilter = 'positive'
+        const results = reportSearch.search(spec);
+        expect(results.length).toEqual(1)
+        expect(results[0]["fact"]["id"]).toEqual("positive")
+    });
+
+    test("Fact Value Positive filter works with other filter", () => {
+        const spec = testSearchSpec('Cash');
+        spec.factValueFilter = 'positive'
+        spec.periodFilter = '2018-01-01/2019-01-01'
+        const results = reportSearch.search(spec);
+        expect(results.length).toEqual(1)
+        expect(results[0]["fact"]["id"]).toEqual("positive")
+    });
+});


### PR DESCRIPTION
#### Reason for change
General improvements

#### Description of change
Adds a fact value positive/negative filter

<img width="436" alt="Screenshot 2023-04-24 at 2 13 18 PM" src="https://user-images.githubusercontent.com/17255946/234105808-81a5f6ad-52c4-411a-9b03-ba6752ea5f3e.png">

#### Steps to Test
- Pull this branch
- Build the javascript
  - `npm install && npm run prod`
- Create a filing with some positive an negative facts associated
- From arelle run: `python arelleCmdLine.py --plugins=/PATH_TO/ixbrl-viewer/iXBRLViewerPlugin -f /PATH_TO/filing_documents/ixbrldoc.htm  --save-viewer ixbrl-report-viewer.html --viewer-url /PATH_TO/ixbrl-viewer/iXBRLViewerPlugin/viewer/dist/ixbrlviewer.js`
- `open ixbrldoc.htm`

### NOTE:
`--save-viewer` arg doesn't seem to be taken into account when generating a file

**review**:
@Workiva/xt
@paulwarren-wk
