### PR TITLE
XT-2867: Filter facts by calculations

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -77,9 +77,9 @@ limitations under the License.
           </div>
           <select id="search-filter-calculations">
             <option value="*" data-i18n="inspector.allOption">ALL</option>
-            <option value="contributing" data-i18n="inspector.contributing">Contributing Item</option>
-            <option value="summation" data-i18n="inspector.summation">Summation Item</option>
-            <option value="either" data-i18n="inspector.either">Either</option>
+            <option value="summation" data-i18n="inspector.summation">Summation</option>
+            <option value="contributor" data-i18n="inspector.contributor">Contributor</option>
+            <option value="summationOrContributor" data-i18n="inspector.summationOrContributor">Summation or Contributor</option>
           </select>
 
           <div class="control-label" data-i18n="inspector.factValue">

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -72,6 +72,16 @@ limitations under the License.
               <option value="text" data-i18n="inspector.textOption">Text</option>
           </select>
 
+          <div class="control-label" data-i18n="inspector.calculations">
+            Calculations
+          </div>
+          <select id="search-filter-calculations">
+            <option value="*" data-i18n="inspector.allOption">ALL</option>
+            <option value="contributing" data-i18n="inspector.contributing">Contributing Item</option>
+            <option value="summation" data-i18n="inspector.summation">Summation Item</option>
+            <option value="either" data-i18n="inspector.either">Either</option>
+          </select>
+
           <div class="control-label" data-i18n="inspector.factValue">
               Fact Value
           </div>

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -67,7 +67,7 @@ limitations under the License.
               Concept Type
           </div>
           <select id="search-filter-concept-type">
-              <option value="*" data-i18n="inspector.allOption">ALL</option>
+              <option value="*" data-i18n="inspector.noFilter">-</option>
               <option value="numeric" data-i18n="inspector.numericOption">Numeric</option>
               <option value="text" data-i18n="inspector.textOption">Text</option>
           </select>
@@ -76,7 +76,7 @@ limitations under the License.
             Calculations
           </div>
           <select id="search-filter-calculations">
-            <option value="*" data-i18n="inspector.allOption">ALL</option>
+            <option value="*" data-i18n="inspector.noFilter">-</option>
             <option value="summation" data-i18n="inspector.summation">Summation</option>
             <option value="contributor" data-i18n="inspector.contributor">Contributor</option>
             <option value="summationOrContributor" data-i18n="inspector.summationOrContributor">Summation or Contributor</option>
@@ -86,7 +86,7 @@ limitations under the License.
               Fact Value
           </div>
           <select id="search-filter-fact-value">
-              <option value="*" data-i18n="inspector.allOption">ALL</option>
+              <option value="*" data-i18n="inspector.noFilter">-</option>
               <option value="negative" data-i18n="inspector.negative">Negative</option>
               <option value="positive" data-i18n="inspector.positive">Positive</option>
           </select>

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -30,8 +30,6 @@ export class Fact {
         this._report = report;
         this.id = factId;
         this.linkedFacts = [];
-        this.isCalcItem = this._report.isCalculationContributingConcept(this.f.a.c);
-        this.isCalcSum = this._report.isCalculationSummationConcept(this.f.a.c);
     }
 
     report() {
@@ -131,6 +129,20 @@ export class Fact {
         else {
             return undefined;
         }
+    }
+
+    isCalculationContributor() {
+        if (this._isCalculationContributor === undefined) {
+            this._isCalculationContributor = this._report.isCalculationContributor(this.f.a.c);
+        }
+        return this._isCalculationContributor;
+    }
+
+    isCalculationSummation() {
+        if (this._isCalculationSummation === undefined) {
+            this._isCalculationSummation = this._report.isCalculationSummation(this.f.a.c);
+        }
+        return this._isCalculationSummation;
     }
 
     isNumeric() {

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -30,6 +30,8 @@ export class Fact {
         this._report = report;
         this.id = factId;
         this.linkedFacts = [];
+        this.isCalcItem = this._report.isCalculationContributingConcept(this.f.a.c);
+        this.isCalcSum = this._report.isCalculationSummationConcept(this.f.a.c);
     }
 
     report() {

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -289,7 +289,7 @@ Inspector.prototype.setupSearchControls = function (viewer) {
     $(".search-controls .search-filters .reset").click(() => this.resetSearchFilters());
     $("#search-filter-period")
         .empty()
-        .append($('<option value="*">ALL</option>'));
+        .append($('<option value="*">-</option>'));
     for (const key in this._search.periods) {
         $("<option>")
             .attr("value", key)

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -279,6 +279,7 @@ Inspector.prototype.searchSpec = function () {
     spec.periodFilter = $('#search-filter-period').val();
     spec.conceptTypeFilter = $('#search-filter-concept-type').val();
     spec.factValueFilter = $('#search-filter-fact-value').val();
+    spec.calculationsFilter = $('#search-filter-calculations').val();
     return spec;
 }
 
@@ -301,6 +302,7 @@ Inspector.prototype.resetSearchFilters = function () {
     $("#search-filter-period").val("*");
     $("#search-filter-concept-type").val("*");
     $("#search-filter-fact-value").val("*");
+    $("#search-filter-calculations").val("*");
     $("#search-hidden-fact-filter").prop("checked", true);
     $("#search-visible-fact-filter").prop("checked", true);
     this.search();

--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -72,29 +72,29 @@ iXBRLReport.prototype._initialize = function () {
 iXBRLReport.prototype.isCalculationContributor = function(c) {
     if (this._calculationContributors === undefined) {
         if (this.data.rels?.calc) {
-            this._calculationContributors = Object.values(this.data.rels.calc).flatMap(calculations => {
+            this._calculationContributors = new Set(Object.values(this.data.rels.calc).flatMap(calculations => {
                 return Object.values(calculations).flatMap(contributors => {
                     return contributors.map(c => c.t);
                 });
-            });
+            }));
         } else {
             this._calculationContributors = [];
         }
     }
-    return this._calculationContributors.includes(c);
+    return this._calculationContributors.has(c);
 }
 
 iXBRLReport.prototype.isCalculationSummation = function(c) {
     if (this._calculationSummations === undefined) {
         if (this.data.rels?.calc) {
-            this._calculationSummations = Object.values(this.data.rels.calc).flatMap(calculations => {
+            this._calculationSummations = new Set(Object.values(this.data.rels.calc).flatMap(calculations => {
                 return Object.keys(calculations);
-            });
+            }));
         } else {
             this._calculationSummations = [];
         }
     }
-    return this._calculationSummations.includes(c);
+    return this._calculationSummations.has(c);
 }
 
 iXBRLReport.prototype.getLabel = function(c, rolePrefix, showPrefix) {

--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -69,6 +69,22 @@ iXBRLReport.prototype._initialize = function () {
     }
 }
 
+iXBRLReport.prototype.isCalculationContributingConcept = function(c) {
+    if (this.data.rels.calc === undefined) return false;
+    return Boolean(Object.values(this.data.rels.calc).some(calculations => {
+        return Object.values(calculations).some(contributingItems => {
+            return contributingItems.some(i => i.t === c);
+        })
+    }));
+}
+
+iXBRLReport.prototype.isCalculationSummationConcept = function(c) {
+    if (this.data.rels.calc === undefined) return false;
+    return Boolean(Object.values(this.data.rels.calc).some(calculations => {
+        return Object.keys(calculations).includes(c);
+    }));
+}
+
 iXBRLReport.prototype.getLabel = function(c, rolePrefix, showPrefix) {
     rolePrefix = rolePrefix || 'std';
     var lang = this._viewerOptions.language;

--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -69,20 +69,32 @@ iXBRLReport.prototype._initialize = function () {
     }
 }
 
-iXBRLReport.prototype.isCalculationContributingConcept = function(c) {
-    if (!this.data.rels?.calc) return false;
-    return Boolean(Object.values(this.data.rels.calc).some(calculations => {
-        return Object.values(calculations).some(contributingItems => {
-            return contributingItems.some(i => i.t === c);
-        })
-    }));
+iXBRLReport.prototype.isCalculationContributor = function(c) {
+    if (this._calculationContributors === undefined) {
+        if (this.data.rels?.calc) {
+            this._calculationContributors = Object.values(this.data.rels.calc).flatMap(calculations => {
+                return Object.values(calculations).flatMap(contributors => {
+                    return contributors.map(c => c.t);
+                });
+            });
+        } else {
+            this._calculationContributors = [];
+        }
+    }
+    return this._calculationContributors.includes(c);
 }
 
-iXBRLReport.prototype.isCalculationSummationConcept = function(c) {
-    if (!this.data.rels?.calc) return false;
-    return Boolean(Object.values(this.data.rels.calc).some(calculations => {
-        return Object.keys(calculations).includes(c);
-    }));
+iXBRLReport.prototype.isCalculationSummation = function(c) {
+    if (this._calculationSummations === undefined) {
+        if (this.data.rels?.calc) {
+            this._calculationSummations = Object.values(this.data.rels.calc).flatMap(calculations => {
+                return Object.keys(calculations);
+            });
+        } else {
+            this._calculationSummations = [];
+        }
+    }
+    return this._calculationSummations.includes(c);
 }
 
 iXBRLReport.prototype.getLabel = function(c, rolePrefix, showPrefix) {

--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -70,7 +70,7 @@ iXBRLReport.prototype._initialize = function () {
 }
 
 iXBRLReport.prototype.isCalculationContributingConcept = function(c) {
-    if (this.data.rels.calc === undefined) return false;
+    if (!this.data.rels?.calc) return false;
     return Boolean(Object.values(this.data.rels.calc).some(calculations => {
         return Object.values(calculations).some(contributingItems => {
             return contributingItems.some(i => i.t === c);
@@ -79,7 +79,7 @@ iXBRLReport.prototype.isCalculationContributingConcept = function(c) {
 }
 
 iXBRLReport.prototype.isCalculationSummationConcept = function(c) {
-    if (this.data.rels.calc === undefined) return false;
+    if (!this.data.rels?.calc) return false;
     return Boolean(Object.values(this.data.rels.calc).some(calculations => {
         return Object.keys(calculations).includes(c);
     }));

--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -78,7 +78,7 @@ iXBRLReport.prototype.isCalculationContributor = function(c) {
                 });
             }));
         } else {
-            this._calculationContributors = [];
+            this._calculationContributors = new Set();
         }
     }
     return this._calculationContributors.has(c);
@@ -91,7 +91,7 @@ iXBRLReport.prototype.isCalculationSummation = function(c) {
                 return Object.keys(calculations);
             }));
         } else {
-            this._calculationSummations = [];
+            this._calculationSummations = new Set();
         }
     }
     return this._calculationSummations.has(c);

--- a/iXBRLViewerPlugin/viewer/src/js/search.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.js
@@ -128,9 +128,9 @@ export class ReportSearch {
     calculationsFilter(s, item) {
         return (
             s.calculationsFilter === '*' ||
-            (s.calculationsFilter === 'contributing' && item.isCalcItem) ||
-            (s.calculationsFilter === 'summation' && item.isCalcSum) ||
-            (s.calculationsFilter === 'either' && (item.isCalcItem || item.isCalcSum))
+            (s.calculationsFilter === 'summation' && item.isCalculationSummation()) ||
+            (s.calculationsFilter === 'contributor' && item.isCalculationContributor()) ||
+            (s.calculationsFilter === 'summationOrContributor' && (item.isCalculationSummation() || item.isCalculationContributor()))
         );
     }
 

--- a/iXBRLViewerPlugin/viewer/src/js/search.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.js
@@ -99,6 +99,43 @@ export class ReportSearch {
         doneCallback();
     }
 
+    visibilityFilter(s, item) {
+        return item.isHidden() ? s.showHiddenFacts : s.showVisibleFacts;
+    }
+
+    periodFilter(s, item) {
+        return (
+            s.periodFilter === '*' ||
+            s.periodFilter === item.period().key()
+        );
+    }
+
+    conceptTypeFilter(s, item) {
+        return (
+            s.conceptTypeFilter === '*' ||
+            s.conceptTypeFilter === (item.isNumeric() ? 'numeric' : 'text')
+        );
+    }
+
+    factValueFilter(s, item) {
+        return (
+            s.factValueFilter === '*' ||
+            (s.factValueFilter === 'positive' && item.isPositive()) ||
+            (s.factValueFilter === 'negative' && item.isNegative())
+        );
+    }
+
+    calculationsFilter(s, item) {
+        return (
+            s.calculationsFilter === '*' ||
+            (s.calculationsFilter === 'contributing' && item.isCalcItem) ||
+            (s.calculationsFilter === 'summation' && item.isCalcSum) ||
+            (s.calculationsFilter === 'either' && (item.isCalcItem || item.isCalcSum))
+        );
+    }
+
+
+
     search(s) {
         if (!this.ready) {
             return;
@@ -107,12 +144,17 @@ export class ReportSearch {
         var results = []
         var searchIndex = this;
 
+        const filters = [
+            this.visibilityFilter,
+            this.periodFilter,
+            this.conceptTypeFilter,
+            this.factValueFilter,
+            this.calculationsFilter
+        ];
+
         rr.forEach((r,i) => {
                 var item = searchIndex._report.getItemById(r.ref);
-                if ((item.isHidden() ? s.showHiddenFacts : s.showVisibleFacts) &&
-                    (s.periodFilter === '*' || item.period().key() === s.periodFilter) &&
-                    (s.conceptTypeFilter === '*' || s.conceptTypeFilter === (item.isNumeric() ? 'numeric' : 'text')) &&
-                    (s.factValueFilter === '*' || (s.factValueFilter === 'positive' && item.isPositive()) || (s.factValueFilter === 'negative' && item.isNegative())))
+                if (filters.every(f => f(s, item)))
                 {
                     results.push({
                         "fact": item,

--- a/iXBRLViewerPlugin/viewer/src/js/search.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.js
@@ -140,9 +140,9 @@ export class ReportSearch {
         if (!this.ready) {
             return;
         }
-        var rr = this._searchIndex.search(s.searchString);
-        var results = []
-        var searchIndex = this;
+        const rr = this._searchIndex.search(s.searchString);
+        const results = []
+        const searchIndex = this;
 
         const filters = [
             this.visibilityFilter,
@@ -153,9 +153,8 @@ export class ReportSearch {
         ];
 
         rr.forEach((r,i) => {
-                var item = searchIndex._report.getItemById(r.ref);
-                if (filters.every(f => f(s, item)))
-                {
+                const item = searchIndex._report.getItemById(r.ref);
+                if (filters.every(f => f(s, item))) {
                     results.push({
                         "fact": item,
                         "score": r.score

--- a/iXBRLViewerPlugin/viewer/src/js/search.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.test.js
@@ -182,9 +182,9 @@ describe("Search calculation filter", () => {
         expect(results).toEqual(['item1', 'item2', 'other', 'summation']);
     });
 
-    test("Calculations 'contributing' filter works", () => {
+    test("Calculations 'contributor' filter works", () => {
         const spec = testSearchSpec();
-        spec.calculationsFilter = 'contributing';
+        spec.calculationsFilter = 'contributor';
         const results = reportSearch.search(spec).map(r => r.fact.id).sort();
         expect(results).toEqual(['item1', 'item2']);
     });
@@ -196,9 +196,9 @@ describe("Search calculation filter", () => {
         expect(results).toEqual(['summation']);
     });
 
-    test("Calculations 'either' filter works", () => {
+    test("Calculations 'summationOrContributor' filter works", () => {
         const spec = testSearchSpec();
-        spec.calculationsFilter = 'either';
+        spec.calculationsFilter = 'summationOrContributor';
         const results = reportSearch.search(spec).map(r => r.fact.id).sort();
         expect(results).toEqual(['item1', 'item2', 'summation']);
     });

--- a/iXBRLViewerPlugin/viewer/src/js/search.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.test.js
@@ -16,18 +16,15 @@ import { ReportSearch } from "./search.js"
 import {iXBRLReport} from "./report";
 
 const testReportData = {
-    "concepts": {
-        "us-gaap:Cash": {
-            "labels": {
-                "ns0": {
-                    "en-us": "Cash"
-                }
-            }
-        }
-    },
-    "languages": {
-        "en-us": "En (US)"
-    },
+    "concepts": {},
+    "languages": {},
+    "facts": {},
+    "prefixes": {},
+    "roles": {},
+    "roleDefs": {},
+    "rels": {}
+};
+
 function getReportSearch(report) {
     const reportSearch = new ReportSearch(report);
     const searchIndex = reportSearch.buildSearchIndex(() => {});
@@ -69,15 +66,6 @@ function createNumericFact(id, concept, unit, period, value) {
         "value": value
     });
 }
-
-    "facts": {},
-    "prefixes": {
-        "us-gaap": "http://fasb.org/us-gaap/2023",
-    },
-    "roles": {},
-    "roleDefs": {},
-    "rels": {}
-};
 
 function testReport(ixData, testData) {
     // Deep copy of standing data

--- a/iXBRLViewerPlugin/viewer/src/js/search.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.test.js
@@ -28,6 +28,13 @@ const testReportData = {
     "languages": {
         "en-us": "En (US)"
     },
+function getReportSearch(report) {
+    const reportSearch = new ReportSearch(report);
+    const searchIndex = reportSearch.buildSearchIndex(() => {});
+    for (const _ of searchIndex) {}
+    return reportSearch;
+}
+
     "facts": {},
     "prefixes": {
         "us-gaap": "http://fasb.org/us-gaap/2023",
@@ -102,9 +109,7 @@ describe("search negative filter", () => {
             {'positive': positive, 'negative': negative, 'zero': zero, 'text': text, 'undefined': undef},
             {'positive': {}, 'negative': {}, 'zero': {}, 'text': {}, 'undefined': {}}
     )
-    const reportSearch = new ReportSearch(report);
-    const searchIndex = reportSearch.buildSearchIndex(() => {});
-    for (const _ of searchIndex) {}
+    const reportSearch = getReportSearch(report);
 
     test("Fact Value Negative filter works", () => {
         const spec = testSearchSpec('Cash');

--- a/iXBRLViewerPlugin/viewer/src/js/search.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.test.js
@@ -202,4 +202,23 @@ describe("Search calculation filter", () => {
         const results = reportSearch.search(spec).map(r => r.fact.id).sort();
         expect(results).toEqual(['item1', 'item2', 'summation']);
     });
+    const emptyReport = testReport(
+            {'fact': {}},
+            {
+                "concepts": {
+                    ...createSimpleConcept("test:Concept", "Concept"),
+                },
+                "facts": {
+                    ...createSimpleFact("fact", "test:Fact"),
+                },
+            },
+    )
+    const emptyReportSearch = getReportSearch(emptyReport);
+
+    test("Calculations filter works on empty report", () => {
+        const spec = testSearchSpec();
+        spec.calculationsFilter = 'summationOrContributor';
+        const results = emptyReportSearch.search(spec).map(r => r.fact.id).sort();
+        expect(results).toEqual([]);
+    });
 });

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -450,6 +450,7 @@
 
           .checkboxes {
             display: flex;
+            flex-wrap: wrap;
 
             & > div {
               margin: 1.2rem 0;


### PR DESCRIPTION
#### Description of change
Filter facts based on their concept's status as:
- Calculation summation item
- Calculation contributing item
- Either of the above

Reworked the code that applies the filter into individual functions rather than a single if statement that will grow in complexity.
Added some helper functions to the search test code.
<img width="422" alt="Screenshot 2023-05-04 at 2 36 01 PM" src="https://user-images.githubusercontent.com/105066394/236323441-1ff30b7a-ff62-4bb2-8dbc-4eaaa974a248.png">
<img width="431" alt="Screenshot 2023-05-04 at 2 36 11 PM" src="https://user-images.githubusercontent.com/105066394/236323453-1084747a-019a-49aa-882b-160dd1ade30c.png">


#### Steps to Test
- CI
- Load a filing of your choosing and ensure each calculation filter works as you would expect

**review**:
@Workiva/xt
@paulwarren-wk
