### PR TITLE
XT-2871: Filter facts by concept namespace

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -91,6 +91,12 @@ limitations under the License.
               <option value="positive" data-i18n="inspector.positive">Positive</option>
           </select>
 
+          <div class="control-label" data-i18n="inspector.namespaces">
+            Namespaces
+          </div>
+          <select id="search-filter-namespaces" multiple>
+          </select>
+
           <div class="control-label" data-i18n="inspector.period">
               Period
           </div>

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -111,6 +111,10 @@ limitations under the License.
               </label>
             </div>
           </div>
+          <div class="filter-info">
+            <span id="matching-concepts-count">?</span>
+            <span data-i18n="inspector.matchingConcepts"> matching concept(s)</span>
+          </div>
         </div>
       </div>
     </div> <!-- inspector-head -->

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -131,7 +131,7 @@ export class Fact {
         }
     }
 
-    getPrefix() {
+    getConceptPrefix() {
         return this.conceptName().split(':')[0];
     }
 

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -131,6 +131,10 @@ export class Fact {
         }
     }
 
+    getPrefix() {
+        return this.conceptName().split(':')[0];
+    }
+
     isCalculationContributor() {
         if (this._isCalculationContributor === undefined) {
             this._isCalculationContributor = this._report.isCalculationContributor(this.f.a.c);

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -279,6 +279,7 @@ Inspector.prototype.searchSpec = function () {
     spec.searchString = $('#ixbrl-search').val();
     spec.showVisibleFacts = $('#search-visible-fact-filter').prop('checked');
     spec.showHiddenFacts = $('#search-hidden-fact-filter').prop('checked');
+    spec.namespacesFilter = $('#search-filter-namespaces').val();
     spec.periodFilter = $('#search-filter-period').val();
     spec.conceptTypeFilter = $('#search-filter-concept-type').val();
     spec.factValueFilter = $('#search-filter-fact-value').val();
@@ -299,6 +300,12 @@ Inspector.prototype.setupSearchControls = function (viewer) {
             .text(this._search.periods[key])
             .appendTo('#search-filter-period');
     }
+    this._report.getUsedPrefixes().forEach(prefix => {
+        $("<option>")
+            .attr("value", prefix)
+            .text(`${prefix} (${this._report.prefixMap()[prefix]})`)
+            .appendTo('#search-filter-namespaces');
+    });
 }
 
 Inspector.prototype.resetSearchFilters = function () {
@@ -308,6 +315,7 @@ Inspector.prototype.resetSearchFilters = function () {
     $("#search-filter-calculations").val("*");
     $("#search-hidden-fact-filter").prop("checked", true);
     $("#search-visible-fact-filter").prop("checked", true);
+    $("#search-filter-namespaces option:selected").prop("selected", false);
     this.search();
 }
 

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -338,6 +338,7 @@ Inspector.prototype.search = function() {
         $(".text", overlay).text(i18next.t("search.tryAgainDifferentKeywords"));
         overlay.show();
     }
+    $("#matching-concepts-count").text(results.length);
     /* Don't highlight search results if there's no search string */
     if (spec.searchString != "") {
         viewer.highlightRelatedFacts($.map(results, r =>  r.fact ));

--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -185,7 +185,7 @@ iXBRLReport.prototype.prefixMap = function() {
 iXBRLReport.prototype.getUsedPrefixes = function() {
     if (this._usedPrefixes === undefined) {
         this._usedPrefixes = new Set(Object.values(this._items)
-                .map(f => f.getPrefix()));
+                .map(f => f.getConceptPrefix()));
     }
     return this._usedPrefixes;
 }

--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -182,6 +182,14 @@ iXBRLReport.prototype.prefixMap = function() {
     return this.data.prefixes;
 }
 
+iXBRLReport.prototype.getUsedPrefixes = function() {
+    if (this._usedPrefixes === undefined) {
+        this._usedPrefixes = new Set(Object.values(this._items)
+                .map(f => f.getPrefix()));
+    }
+    return this._usedPrefixes;
+}
+
 iXBRLReport.prototype.roleMap = function() {
     return this.data.roles;
 }

--- a/iXBRLViewerPlugin/viewer/src/js/search.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.js
@@ -137,7 +137,7 @@ export class ReportSearch {
     namespacesFilter(s, item) {
         return (
             s.namespacesFilter.length === 0 ||
-            s.namespacesFilter.some(p => item.getPrefix() === p)
+            s.namespacesFilter.some(p => item.getConceptPrefix() === p)
         );
     }
 

--- a/iXBRLViewerPlugin/viewer/src/js/search.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.js
@@ -134,7 +134,12 @@ export class ReportSearch {
         );
     }
 
-
+    namespacesFilter(s, item) {
+        return (
+            s.namespacesFilter.length === 0 ||
+            s.namespacesFilter.some(p => item.getPrefix() === p)
+        );
+    }
 
     search(s) {
         if (!this.ready) {
@@ -149,7 +154,8 @@ export class ReportSearch {
             this.periodFilter,
             this.conceptTypeFilter,
             this.factValueFilter,
-            this.calculationsFilter
+            this.calculationsFilter,
+            this.namespacesFilter,
         ];
 
         rr.forEach((r,i) => {

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -461,6 +461,12 @@
               }
             }
           }
+
+          .filter-info {
+            text-align:center;
+            font-style: italic;
+            font-size: 1.1rem;
+          }
         }
       }
     }

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -463,7 +463,7 @@
           }
 
           .filter-info {
-            text-align:center;
+            text-align: center;
             font-style: italic;
             font-size: 1.1rem;
           }


### PR DESCRIPTION
#### Reason for change
- Add ability to filter by extension concepts
- More generally, ability to filter by namespace is useful

#### Description of change
- Add multi-select filter to filter facts by concept namespace.
- Only shows prefix/namespaces that are actually used by a fact in the report
- Additionally, added a filter results count to provide user with more information about their filters


#### Steps to Test
- Tests have been added
- Load up a report and confirm that selecting *no* namespaces has the same number of results as selecting *all* namespaces. Confirm selecting individual namespaces works as expected.


**review**:
@Workiva/xt
@paulwarren-wk
![Screenshot 2023-05-08 at 10 13 05 AM](https://user-images.githubusercontent.com/105066394/236875234-54ab70c4-c33d-453d-9c37-af1185d9d447.png)
