### PR TITLE
Add support for Inline XBRL Document Sets in GUI (use Stub Viewer mode)

### DIFF
--- a/iXBRLViewerPlugin/__init__.py
+++ b/iXBRLViewerPlugin/__init__.py
@@ -193,9 +193,8 @@ def guiRun(cntlr, modelXbrl, attach, *args, **kwargs):
         import webbrowser
         global tempViewer
         tempViewer = tempfile.TemporaryDirectory()
-        viewer_file_name = 'ixbrlviewer.htm'
-        temp_file_path = os.path.join(tempViewer.name, viewer_file_name)
-        generateViewer(cntlr, temp_file_path)
+        viewer_file_name = 'ixbrlviewer.html'
+        generateViewer(cntlr, tempViewer.name, useStubViewer = True)
         localViewer = iXBRLViewerLocalViewer("iXBRL Viewer",  os.path.dirname(__file__))
         localhost = localViewer.init(cntlr, tempViewer.name)
         webbrowser.open(f'{localhost}/{viewer_file_name}')


### PR DESCRIPTION
#### Reason for change

Inline XBRL Document Sets do not open in the viewer in Arelle using the View->iXBRL Viewer->Launch Viewer on load option.

Instead, there is a message in the log stating that the viewer could not be created because the target was not a directory, and the launched browser window displays a 404 error because the viewer was not generated.

#### Description of change

This PR fixes the problem by switching to using stub viewer mode in the GUI, and passing the name of the temporary directory to the viewer builder. 

Using stub viewer mode means that the name of the viewer entry point file is trivial to predict (`ixbrlviewer.html`) but also brings the usual stub viewer advantage of reducing the delay before the loading mask is shown.

#### Steps to Test

* Open Arelle GUI
* Ensure viewer plugin is loaded, and "Launch Viewer on Load" is enabled
* Open any Inline XBRL Document Set
* Check that IXDS opens correctly in the browser.

I was testing this with a Japanese filing:

https://disclosure2.edinet-fsa.go.jp/WEEE0040.aspx?bXVsPWNhbm94JmN0Zj1vZmYmZmxzPW9uJmxwcj1vZmYmcnByPW9mZiZvdGg9b2ZmJnBmcz02Jnllcj0mbW9uPQ==

(Use the submitted document link for the annual filing, unzip, and open all the `.htm` files in the `PublicDoc` folder as an IXDS.

**review**:
@Workiva/xt
@paulwarren-wk
