### PR TITLE
Fix error trying to get a prefix for a footnote

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -184,6 +184,7 @@ iXBRLReport.prototype.prefixMap = function() {
 iXBRLReport.prototype.getUsedPrefixes = function() {
     if (this._usedPrefixes === undefined) {
         this._usedPrefixes = new Set(Object.values(this._items)
+                .filter(f => f instanceof Fact)
                 .map(f => f.getConceptPrefix()));
     }
     return this._usedPrefixes;
@@ -196,6 +197,7 @@ iXBRLReport.prototype.getUsedPrefixes = function() {
 iXBRLReport.prototype.getUsedUnits = function() {
     if (this._usedUnits === undefined) {
         this._usedUnits = new Set(Object.values(this._items)
+                .filter(f => f instanceof Fact)
                 .map(f => f.unit()?.value())
                 .filter(f => f)
                 .sort());

--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -168,9 +168,9 @@ iXBRLReport.prototype.getIXNodeForItemId = function(id) {
 }
 
 iXBRLReport.prototype.facts = function() {
-    var allItems = [];
-    $.each(this.data.facts, (id, f) => allItems.push(this.getItemById(id)));
-    return allItems;
+    var allFacts = [];
+    $.each(this.data.facts, (id, f) => allFacts.push(this.getItemById(id)));
+    return allFacts;
 }
 
 iXBRLReport.prototype.filingDocuments = function() {


### PR DESCRIPTION
#### Reason for change

Fixes #427

#### Description of change

Adds a guard in two places to check that item (which can be a footnote or a fact) is actually a fact before attempting to get the namespace prefix.

#### Steps to Test

* Open sample doc from #427 
* Confirm that there are no errors in the log.

**review**:
@Workiva/xt
@paulwarren-wk
