### PR TITLE
XT-2959: Collapsible filter elements

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/html/fact-details.html
+++ b/iXBRLViewerPlugin/viewer/src/html/fact-details.html
@@ -18,7 +18,7 @@ limitations under the License.
   <h4 data-i18n="factDetails.concept">Concept</h4>
   <div class="std-label"></div>
   <div class="documentation"></div>
-  <h4 data-i18n="factDetails.dimensions">Dimensions</h4>
+  <h4 id="dimensions-label" data-i18n="factDetails.dimensions">Dimensions</h4>
   <div id="dimensions"></div>
   <table class="fact-properties">
     <tr class="period">

--- a/iXBRLViewerPlugin/viewer/src/html/fact-details.html
+++ b/iXBRLViewerPlugin/viewer/src/html/fact-details.html
@@ -20,6 +20,7 @@ limitations under the License.
   <div class="documentation"></div>
   <h4 id="dimensions-label" data-i18n="factDetails.dimensions">Dimensions</h4>
   <div id="dimensions"></div>
+  <h4 data-i18n="factDetails.properties">Properties</h4>
   <table class="fact-properties">
     <tr class="period">
       <th data-i18n="factDetails.date">Date</th>

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -86,15 +86,6 @@ limitations under the License.
             <option value="summationOrContributor" data-i18n="inspector.summationOrContributor">Summation or Contributor</option>
           </select>
 
-          <div class="control-label" data-i18n="inspector.dimensions">
-              Dimension Type
-          </div>
-          <select id="search-filter-dimension-type">
-              <option value="*" data-i18n="inspector.noFilter">-</option>
-              <option value="explicit" data-i18n="inspector.explicitDimension">Explicit Dimensions</option>
-              <option value="typed" data-i18n="inspector.typedDimensions">Typed Dimensions</option>
-          </select>
-
           <div class="control-label" data-i18n="inspector.factValue">
               Fact Value
           </div>
@@ -103,6 +94,20 @@ limitations under the License.
               <option value="negative" data-i18n="inspector.negative">Negative</option>
               <option value="positive" data-i18n="inspector.positive">Positive</option>
           </select>
+
+          <div id="search-filter-dimension-type" class="collapsible-section collapsed">
+            <h3 class="collapsible-header">
+              <span data-i18n="inspector.dimensions">Dimension Type</span>
+              <span class="collapsible-subheader"></span>
+            </h3>
+            <div class="collapsible-body dimensions" style="display: none;">
+              <select>
+                <option value="*" data-i18n="inspector.noFilter">-</option>
+                <option value="explicit" data-i18n="inspector.explicitDimension">Explicit Dimensions</option>
+                <option value="typed" data-i18n="inspector.typedDimensions">Typed Dimensions</option>
+              </select>
+            </div>
+          </div>
 
           <div id="search-filter-scales" class="collapsible-section collapsed">
             <h3 class="collapsible-header">

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -105,6 +105,7 @@ limitations under the License.
               <span class="collapsible-subheader"></span>
             </h3>
             <div class="collapsible-body dimensions" style="display: none;">
+              <span class="reset-multiselect"></span>
               <select multiple size="2">
                 <option value="explicit" data-i18n="inspector.explicitDimension">Explicit Dimensions</option>
                 <option value="typed" data-i18n="inspector.typedDimensions">Typed Dimensions</option>
@@ -118,6 +119,7 @@ limitations under the License.
               <span class="collapsible-subheader"></span>
             </h3>
             <div class="collapsible-body scales" style="display: none;">
+              <span class="reset-multiselect"></span>
               <select multiple>
               </select>
             </div>
@@ -129,6 +131,7 @@ limitations under the License.
               <span class="collapsible-subheader"></span>
             </h3>
             <div class="collapsible-body units" style="display: none;">
+              <span class="reset-multiselect"></span>
               <select multiple>
               </select>
             </div>
@@ -140,6 +143,7 @@ limitations under the License.
               <span class="collapsible-subheader"></span>
             </h3>
             <div class="collapsible-body namespaces" style="display: none;">
+              <span class="reset-multiselect"></span>
               <select multiple>
               </select>
             </div>

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -104,23 +104,38 @@ limitations under the License.
               <option value="positive" data-i18n="inspector.positive">Positive</option>
           </select>
 
-          <div class="control-label" data-i18n="inspector.scales">
-            Scales
+          <div id="search-filter-scales" class="collapsible-section collapsed">
+            <h3 class="collapsible-header">
+              <span data-i18n="inspector.scales">Scales</span>
+              <span class="collapsible-subheader"></span>
+            </h3>
+            <div class="collapsible-body scales" style="display: none;">
+              <select multiple>
+              </select>
+            </div>
           </div>
-          <select id="search-filter-scales" multiple>
-          </select>
 
-          <div class="control-label" data-i18n="inspector.units">
-            Units
+          <div id="search-filter-units" class="collapsible-section collapsed">
+            <h3 class="collapsible-header">
+              <span data-i18n="inspector.units">Units</span>
+              <span class="collapsible-subheader"></span>
+            </h3>
+            <div class="collapsible-body units" style="display: none;">
+              <select multiple>
+              </select>
+            </div>
           </div>
-          <select id="search-filter-units" multiple>
-          </select>
 
-          <div class="control-label" data-i18n="inspector.namespaces">
-            Namespaces
+          <div id="search-filter-namespaces" class="collapsible-section collapsed">
+            <h3 class="collapsible-header">
+              <span data-i18n="inspector.namespaces">Namespaces</span>
+              <span class="collapsible-subheader"></span>
+            </h3>
+            <div class="collapsible-body namespaces" style="display: none;">
+              <select multiple>
+              </select>
+            </div>
           </div>
-          <select id="search-filter-namespaces" multiple>
-          </select>
 
           <div class="control-label" data-i18n="inspector.period">
               Period

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -67,23 +67,27 @@ limitations under the License.
         <div class="search-filters">
           <div class="reset" data-i18n="inspector.reset">Reset</div>
           <h3 data-i18n="inspector.filter">Filter</h3>
-          <div class="control-label" data-i18n="inspector.conceptType">
+          <div class="filter-group">
+            <div class="control-label" data-i18n="inspector.conceptType">
               Concept Type
-          </div>
-          <select id="search-filter-concept-type">
+            </div>
+            <select id="search-filter-concept-type">
               <option value="*">-</option>
               <option value="numeric" data-i18n="inspector.numericOption">Numeric</option>
               <option value="text" data-i18n="inspector.textOption">Text</option>
-          </select>
-
-          <div class="control-label" data-i18n="inspector.factValue">
-              Fact Value
+            </select>
           </div>
-          <select id="search-filter-fact-value">
-              <option value="*">-</option>
-              <option value="negative" data-i18n="inspector.negative">Negative</option>
-              <option value="positive" data-i18n="inspector.positive">Positive</option>
-          </select>
+
+          <div class="filter-group">
+            <div class="control-label" data-i18n="inspector.factValue">
+                Fact Value
+            </div>
+            <select id="search-filter-fact-value">
+                <option value="*">-</option>
+                <option value="negative" data-i18n="inspector.negative">Negative</option>
+                <option value="positive" data-i18n="inspector.positive">Positive</option>
+            </select>
+          </div>
 
           <div id="search-filter-calculations" class="collapsible-section collapsible-only collapsed">
             <h3 class="collapsible-header">

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -89,52 +89,27 @@ limitations under the License.
             </select>
           </div>
 
-          <div id="search-filter-calculations" class="collapsible-section collapsible-only collapsed">
-            <h3 class="collapsible-header">
-              <span data-i18n="inspector.calculations">Calculations</span>
-              <span class="collapsible-subheader"></span>
-            </h3>
-            <div class="collapsible-body calculations" style="display: none;">
-              <span class="reset-multiselect"></span>
-              <select multiple size="2">
-                <option value="summation" data-i18n="inspector.summation">Summation</option>
-                <option value="contributor" data-i18n="inspector.contributor">Contributor</option>
-              </select>
+          <div class="checkboxes">
+            <div>
+              <label class="checkbox">
+                <input id="search-hidden-fact-filter" type="checkbox" checked="checked"/> <span data-i18n="inspector.hiddenFacts">Hidden Facts</span>
+                <span class="checkmark"></span>
+              </label>
+            </div>
+            <div>
+              <label class="checkbox">
+                <input id="search-visible-fact-filter" type="checkbox" checked="checked"/> <span data-i18n="inspector.visibleFacts">Visible Facts</span>
+                <span class="checkmark"></span>
+              </label>
             </div>
           </div>
 
-          <div id="search-filter-dimension-type" class="collapsible-section collapsible-only collapsed">
+          <div id="search-filter-period" class="collapsible-section collapsible-only collapsed">
             <h3 class="collapsible-header">
-              <span data-i18n="inspector.dimensions">Dimension Type</span>
+              <span data-i18n="inspector.period">Period</span>
               <span class="collapsible-subheader"></span>
             </h3>
-            <div class="collapsible-body dimensions" style="display: none;">
-              <span class="reset-multiselect"></span>
-              <select multiple size="2">
-                <option value="explicit" data-i18n="inspector.explicitDimension">Explicit Dimensions</option>
-                <option value="typed" data-i18n="inspector.typedDimensions">Typed Dimensions</option>
-              </select>
-            </div>
-          </div>
-
-          <div id="search-filter-scales" class="collapsible-section collapsible-only collapsed">
-            <h3 class="collapsible-header">
-              <span data-i18n="inspector.scales">Scales</span>
-              <span class="collapsible-subheader"></span>
-            </h3>
-            <div class="collapsible-body scales" style="display: none;">
-              <span class="reset-multiselect"></span>
-              <select multiple>
-              </select>
-            </div>
-          </div>
-
-          <div id="search-filter-units" class="collapsible-section collapsible-only collapsed">
-            <h3 class="collapsible-header">
-              <span data-i18n="inspector.units">Units</span>
-              <span class="collapsible-subheader"></span>
-            </h3>
-            <div class="collapsible-body units" style="display: none;">
+            <div class="collapsible-body" style="display: none;">
               <span class="reset-multiselect"></span>
               <select multiple>
               </select>
@@ -153,32 +128,58 @@ limitations under the License.
             </div>
           </div>
 
-          <div id="search-filter-period" class="collapsible-section collapsible-only collapsed">
+          <div id="search-filter-units" class="collapsible-section collapsible-only collapsed">
             <h3 class="collapsible-header">
-              <span data-i18n="inspector.period">Period</span>
+              <span data-i18n="inspector.units">Units</span>
               <span class="collapsible-subheader"></span>
             </h3>
-            <div class="collapsible-body" style="display: none;">
+            <div class="collapsible-body units" style="display: none;">
               <span class="reset-multiselect"></span>
               <select multiple>
               </select>
             </div>
           </div>
-          
-          <div class="checkboxes">
-            <div>
-              <label class="checkbox">
-                <input id="search-hidden-fact-filter" type="checkbox" checked="checked"/> <span data-i18n="inspector.hiddenFacts">Hidden Facts</span>
-                <span class="checkmark"></span>
-              </label>
-            </div>
-            <div>
-              <label class="checkbox">
-                <input id="search-visible-fact-filter" type="checkbox" checked="checked"/> <span data-i18n="inspector.visibleFacts">Visible Facts</span>
-                <span class="checkmark"></span>
-              </label>
+
+          <div id="search-filter-scales" class="collapsible-section collapsible-only collapsed">
+            <h3 class="collapsible-header">
+              <span data-i18n="inspector.scales">Scales</span>
+              <span class="collapsible-subheader"></span>
+            </h3>
+            <div class="collapsible-body scales" style="display: none;">
+              <span class="reset-multiselect"></span>
+              <select multiple>
+              </select>
             </div>
           </div>
+
+          <div id="search-filter-dimension-type" class="collapsible-section collapsible-only collapsed">
+            <h3 class="collapsible-header">
+              <span data-i18n="inspector.dimensions">Dimension Type</span>
+              <span class="collapsible-subheader"></span>
+            </h3>
+            <div class="collapsible-body dimensions" style="display: none;">
+              <span class="reset-multiselect"></span>
+              <select multiple size="2">
+                <option value="explicit" data-i18n="inspector.explicitDimension">Explicit Dimensions</option>
+                <option value="typed" data-i18n="inspector.typedDimensions">Typed Dimensions</option>
+              </select>
+            </div>
+          </div>
+
+          <div id="search-filter-calculations" class="collapsible-section collapsible-only collapsed">
+            <h3 class="collapsible-header">
+              <span data-i18n="inspector.calculations">Calculations</span>
+              <span class="collapsible-subheader"></span>
+            </h3>
+            <div class="collapsible-body calculations" style="display: none;">
+              <span class="reset-multiselect"></span>
+              <select multiple size="2">
+                <option value="summation" data-i18n="inspector.summation">Summation</option>
+                <option value="contributor" data-i18n="inspector.contributor">Contributor</option>
+              </select>
+            </div>
+          </div>
+
           <div class="filter-info">
             <span id="matching-concepts-count">?</span>
             <span data-i18n="inspector.matchingConcepts"> matching concept(s)</span>

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -85,7 +85,7 @@ limitations under the License.
               <option value="positive" data-i18n="inspector.positive">Positive</option>
           </select>
 
-          <div id="search-filter-calculations" class="collapsible-section collapsed">
+          <div id="search-filter-calculations" class="collapsible-section collapsible-only collapsed">
             <h3 class="collapsible-header">
               <span data-i18n="inspector.calculations">Calculations</span>
               <span class="collapsible-subheader"></span>
@@ -99,7 +99,7 @@ limitations under the License.
             </div>
           </div>
 
-          <div id="search-filter-dimension-type" class="collapsible-section collapsed">
+          <div id="search-filter-dimension-type" class="collapsible-section collapsible-only collapsed">
             <h3 class="collapsible-header">
               <span data-i18n="inspector.dimensions">Dimension Type</span>
               <span class="collapsible-subheader"></span>
@@ -113,7 +113,7 @@ limitations under the License.
             </div>
           </div>
 
-          <div id="search-filter-scales" class="collapsible-section collapsed">
+          <div id="search-filter-scales" class="collapsible-section collapsible-only collapsed">
             <h3 class="collapsible-header">
               <span data-i18n="inspector.scales">Scales</span>
               <span class="collapsible-subheader"></span>
@@ -125,7 +125,7 @@ limitations under the License.
             </div>
           </div>
 
-          <div id="search-filter-units" class="collapsible-section collapsed">
+          <div id="search-filter-units" class="collapsible-section collapsible-only collapsed">
             <h3 class="collapsible-header">
               <span data-i18n="inspector.units">Units</span>
               <span class="collapsible-subheader"></span>
@@ -137,7 +137,7 @@ limitations under the License.
             </div>
           </div>
 
-          <div id="search-filter-namespaces" class="collapsible-section collapsed">
+          <div id="search-filter-namespaces" class="collapsible-section collapsible-only collapsed">
             <h3 class="collapsible-header">
               <span data-i18n="inspector.namespaces">Namespaces</span>
               <span class="collapsible-subheader"></span>

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -76,16 +76,6 @@ limitations under the License.
               <option value="text" data-i18n="inspector.textOption">Text</option>
           </select>
 
-          <div class="control-label" data-i18n="inspector.calculations">
-            Calculations
-          </div>
-          <select id="search-filter-calculations">
-            <option value="*">-</option>
-            <option value="summation" data-i18n="inspector.summation">Summation</option>
-            <option value="contributor" data-i18n="inspector.contributor">Contributor</option>
-            <option value="summationOrContributor" data-i18n="inspector.summationOrContributor">Summation or Contributor</option>
-          </select>
-
           <div class="control-label" data-i18n="inspector.factValue">
               Fact Value
           </div>
@@ -94,6 +84,20 @@ limitations under the License.
               <option value="negative" data-i18n="inspector.negative">Negative</option>
               <option value="positive" data-i18n="inspector.positive">Positive</option>
           </select>
+
+          <div id="search-filter-calculations" class="collapsible-section collapsed">
+            <h3 class="collapsible-header">
+              <span data-i18n="inspector.calculations">Calculations</span>
+              <span class="collapsible-subheader"></span>
+            </h3>
+            <div class="collapsible-body calculations" style="display: none;">
+              <span class="reset-multiselect"></span>
+              <select multiple size="2">
+                <option value="summation" data-i18n="inspector.summation">Summation</option>
+                <option value="contributor" data-i18n="inspector.contributor">Contributor</option>
+              </select>
+            </div>
+          </div>
 
           <div id="search-filter-dimension-type" class="collapsible-section collapsed">
             <h3 class="collapsible-header">

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -149,11 +149,17 @@ limitations under the License.
             </div>
           </div>
 
-          <div class="control-label" data-i18n="inspector.period">
-              Period
+          <div id="search-filter-period" class="collapsible-section collapsible-only collapsed">
+            <h3 class="collapsible-header">
+              <span data-i18n="inspector.period">Period</span>
+              <span class="collapsible-subheader"></span>
+            </h3>
+            <div class="collapsible-body" style="display: none;">
+              <span class="reset-multiselect"></span>
+              <select multiple>
+              </select>
+            </div>
           </div>
-          <select id="search-filter-period">
-          </select>
           
           <div class="checkboxes">
             <div>

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -101,8 +101,7 @@ limitations under the License.
               <span class="collapsible-subheader"></span>
             </h3>
             <div class="collapsible-body dimensions" style="display: none;">
-              <select>
-                <option value="*" data-i18n="inspector.noFilter">-</option>
+              <select multiple size="2">
                 <option value="explicit" data-i18n="inspector.explicitDimension">Explicit Dimensions</option>
                 <option value="typed" data-i18n="inspector.typedDimensions">Typed Dimensions</option>
               </select>

--- a/iXBRLViewerPlugin/viewer/src/i18n/en/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/en/translation.json
@@ -91,7 +91,6 @@
       }
     },
     "summation": "Summation",
-    "summationOrContributor": "Summation or Contributor",
     "textOption": "Text",
     "units": "Units",
     "validationCode": "Code",

--- a/iXBRLViewerPlugin/viewer/src/i18n/en/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/en/translation.json
@@ -120,6 +120,7 @@
     "concealedFact": "Concealed fact",
     "hiddenFact": "Hidden fact",
     "noMatchFound": "No match found",
+    "selected": "selected",
     "showMoreResults": "Show more results",
     "tryAgainDifferentKeywords": "Try again with different keywords"
   },

--- a/iXBRLViewerPlugin/viewer/src/i18n/en/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/en/translation.json
@@ -20,6 +20,7 @@
     "factValue": "Fact Value",
     "noPriorFactInThisReport": "No prior fact in this report",
     "noUnit": "<NOUNIT>",
+    "properties": "Properties",
     "scale": "Scale"
   },
   "footnotes": {

--- a/iXBRLViewerPlugin/viewer/src/i18n/es/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/es/translation.json
@@ -20,6 +20,7 @@
     "factValue": "Valor del hecho",
     "noPriorFactInThisReport": "No hay un hecho previo",
     "noUnit": "Sin unidad",
+    "properties": "Características",
     "scale": "Escala"
   },
   "footnotes": {

--- a/iXBRLViewerPlugin/viewer/src/i18n/es/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/es/translation.json
@@ -120,6 +120,7 @@
     "concealedFact": "",
     "hiddenFact": "Hecho oculto",
     "noMatchFound": "No se encontró ninguna coincidencia",
+    "selected": "seleccionados",
     "showMoreResults": "Mostrar más resultados",
     "tryAgainDifferentKeywords": "Intente nuevamente con palabras clave diferentes"
   },

--- a/iXBRLViewerPlugin/viewer/src/i18n/es/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/es/translation.json
@@ -91,7 +91,6 @@
       }
     },
     "summation": "",
-    "summationOrContributor": "",
     "textOption": "Texto",
     "units": "Unidads",
     "validationCode": "",

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -88,6 +88,13 @@ Inspector.prototype.initialize = function (report, viewer) {
                 }
                 else {
                     d.find(".collapsible-body").slideDown(250);
+                    if (d.hasClass("collapsible-only")) {
+                        d.siblings('.collapsible-section:not(.collapsed)').each(function() {
+                            const section = $(this);
+                            section.addClass("collapsed");
+                            section.find(".collapsible-body").slideUp(250);
+                        });
+                    }
                 }
             });
             $("#inspector .controls .search-button").on("click", function () {

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -285,9 +285,9 @@ Inspector.prototype.searchSpec = function () {
     spec.searchString = $('#ixbrl-search').val();
     spec.showVisibleFacts = $('#search-visible-fact-filter').prop('checked');
     spec.showHiddenFacts = $('#search-hidden-fact-filter').prop('checked');
-    spec.namespacesFilter = $('#search-filter-namespaces').val();
-    spec.unitsFilter = $('#search-filter-units').val();
-    spec.scalesFilter = $('#search-filter-scales').val();
+    spec.namespacesFilter = $('#search-filter-namespaces select').val();
+    spec.unitsFilter = $('#search-filter-units select').val();
+    spec.scalesFilter = $('#search-filter-scales select').val();
     spec.periodFilter = $('#search-filter-period').val();
     spec.conceptTypeFilter = $('#search-filter-concept-type').val();
     spec.factValueFilter = $('#search-filter-fact-value').val();
@@ -313,20 +313,20 @@ Inspector.prototype.setupSearchControls = function (viewer) {
         $("<option>")
             .attr("value", prefix)
             .text(`${prefix} (${this._report.prefixMap()[prefix]})`)
-            .appendTo('#search-filter-namespaces');
+            .appendTo('#search-filter-namespaces select');
     });
     this._report.getUsedUnits().forEach(unit => {
         $("<option>")
                 .attr("value", unit)
                 .text(`${this._report.getUnit(unit)?.label()} (${unit})`)
-                .appendTo('#search-filter-units');
+                .appendTo('#search-filter-units select');
     });
     const scalesOptions = this._getScalesOptions();
     Object.keys(scalesOptions).sort().forEach(scale => {
             $("<option>")
                     .attr("value", scale)
                     .text(scalesOptions[scale])
-                    .appendTo('#search-filter-scales');
+                    .appendTo('#search-filter-scales select');
     });
 }
 
@@ -353,9 +353,9 @@ Inspector.prototype.resetSearchFilters = function () {
     $("#search-filter-dimension-type").val("*")
     $("#search-hidden-fact-filter").prop("checked", true);
     $("#search-visible-fact-filter").prop("checked", true);
-    $("#search-filter-namespaces option:selected").prop("selected", false);
-    $("#search-filter-units option:selected").prop("selected", false);
-    $("#search-filter-scales option:selected").prop("selected", false);
+    $("#search-filter-namespaces select option:selected").prop("selected", false);
+    $("#search-filter-units select option:selected").prop("selected", false);
+    $("#search-filter-scales select option:selected").prop("selected", false);
     this.search();
 }
 
@@ -390,6 +390,19 @@ Inspector.prototype.search = function() {
     /* Don't highlight search results if there's no search string */
     if (spec.searchString != "") {
         viewer.highlightRelatedFacts($.map(results, r =>  r.fact ));
+    }
+    this.updateMultiSelectSubheader('search-filter-scales');
+    this.updateMultiSelectSubheader('search-filter-units');
+    this.updateMultiSelectSubheader('search-filter-namespaces');
+}
+
+Inspector.prototype.updateMultiSelectSubheader = function (id) {
+    const selectedOptions = $(`#${id} select option:selected`).length;
+    if (selectedOptions > 0) {
+        const totalOptions = $(`#${id} select option`).length;
+        $(`#${id} .collapsible-subheader`).text(` (${selectedOptions}/${totalOptions} ${i18next.t("search.selected")})`)
+    } else {
+        $(`#${id} .collapsible-subheader`).empty();
     }
 }
 

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -295,7 +295,7 @@ Inspector.prototype.searchSpec = function () {
     spec.namespacesFilter = $('#search-filter-namespaces select').val();
     spec.unitsFilter = $('#search-filter-units select').val();
     spec.scalesFilter = $('#search-filter-scales select').val();
-    spec.periodFilter = $('#search-filter-period').val();
+    spec.periodFilter = $('#search-filter-period select').val();
     spec.conceptTypeFilter = $('#search-filter-concept-type').val();
     spec.factValueFilter = $('#search-filter-fact-value').val();
     spec.calculationsFilter = $('#search-filter-calculations select').val();
@@ -312,15 +312,12 @@ Inspector.prototype.setupSearchControls = function (viewer) {
         $(this).siblings().children('select option:selected').prop('selected', false);
         inspector.search();
     });
-    $("#search-filter-period")
-        .empty()
-        .append($('<option value="*">-</option>'));
-    for (const key in this._search.periods) {
+    Object.keys(this._search.periods).forEach(key => {
         $("<option>")
             .attr("value", key)
             .text(this._search.periods[key])
-            .appendTo('#search-filter-period');
-    }
+            .appendTo('#search-filter-period select');
+    });
     this._report.getUsedPrefixes().forEach(prefix => {
         $("<option>")
             .attr("value", prefix)
@@ -358,7 +355,7 @@ Inspector.prototype._getScalesOptions = function() {
 }
 
 Inspector.prototype.resetSearchFilters = function () {
-    $("#search-filter-period").val("*");
+    $("#search-filter-period select option:selected").prop("selected", false);
     $("#search-filter-concept-type").val("*");
     $("#search-filter-fact-value").val("*");
     $("#search-filter-calculations select option:selected").prop("selected", false);
@@ -408,6 +405,7 @@ Inspector.prototype.search = function() {
     this.updateMultiSelectSubheader('search-filter-namespaces');
     this.updateMultiSelectSubheader('search-filter-dimension-type');
     this.updateMultiSelectSubheader('search-filter-calculations');
+    this.updateMultiSelectSubheader('search-filter-period');
 }
 
 Inspector.prototype.updateMultiSelectSubheader = function (id) {

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -875,10 +875,11 @@ Inspector.prototype._selectionSummaryAccordian = function() {
             }
 
             $('#dimensions', factHTML).empty();
-            for (const aspect of fact.aspects()) {
-                if (!aspect.isTaxonomyDefined()) {
-                    continue;
-                }
+            const taxonomyDefinedAspects = fact.aspects().filter(a => a.isTaxonomyDefined());
+            if (taxonomyDefinedAspects.length === 0) {
+                $('#dimensions-label', factHTML).hide();
+            }
+            for (const aspect of taxonomyDefinedAspects) {
                 var h = $('<div class="dimension"></div>')
                     .text(aspect.label() || aspect.name())
                     .appendTo($('#dimensions', factHTML));

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -291,7 +291,7 @@ Inspector.prototype.searchSpec = function () {
     spec.periodFilter = $('#search-filter-period').val();
     spec.conceptTypeFilter = $('#search-filter-concept-type').val();
     spec.factValueFilter = $('#search-filter-fact-value').val();
-    spec.calculationsFilter = $('#search-filter-calculations').val();
+    spec.calculationsFilter = $('#search-filter-calculations select').val();
     spec.dimensionTypeFilter = $('#search-filter-dimension-type select').val();
     return spec;
 }
@@ -349,7 +349,7 @@ Inspector.prototype.resetSearchFilters = function () {
     $("#search-filter-period").val("*");
     $("#search-filter-concept-type").val("*");
     $("#search-filter-fact-value").val("*");
-    $("#search-filter-calculations").val("*");
+    $("#search-filter-calculations select option:selected").prop("selected", false);
     $("#search-filter-dimension-type select option:selected").prop("selected", false);
     $("#search-hidden-fact-filter").prop("checked", true);
     $("#search-visible-fact-filter").prop("checked", true);
@@ -395,6 +395,7 @@ Inspector.prototype.search = function() {
     this.updateMultiSelectSubheader('search-filter-units');
     this.updateMultiSelectSubheader('search-filter-namespaces');
     this.updateMultiSelectSubheader('search-filter-dimension-type');
+    this.updateMultiSelectSubheader('search-filter-calculations');
 }
 
 Inspector.prototype.updateMultiSelectSubheader = function (id) {

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -297,9 +297,14 @@ Inspector.prototype.searchSpec = function () {
 }
 
 Inspector.prototype.setupSearchControls = function (viewer) {
+    const inspector = this;
     $('.search-controls input, .search-controls select').change(() => this.search());
     $(".search-controls div.filter-toggle").click(() => $(".search-controls").toggleClass('show-filters'));
     $(".search-controls .search-filters .reset").click(() => this.resetSearchFilters());
+    $(".search-controls .search-filters .reset-multiselect").on("click", function () {
+        $(this).siblings().children('select option:selected').prop('selected', false);
+        inspector.search();
+    });
     $("#search-filter-period")
         .empty()
         .append($('<option value="*">-</option>'));

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -409,12 +409,16 @@ Inspector.prototype.search = function() {
 }
 
 Inspector.prototype.updateMultiSelectSubheader = function (id) {
-    const selectedOptions = $(`#${id} select option:selected`).length;
-    if (selectedOptions > 0) {
+    const subheader = $(`#${id} .collapsible-subheader`);
+    const selectedOptions = $(`#${id} select option:selected`);
+    if (selectedOptions.length === 1) {
+        subheader.text(` ${selectedOptions.text()}`);
+    }
+    else if (selectedOptions.length > 0) {
         const totalOptions = $(`#${id} select option`).length;
-        $(`#${id} .collapsible-subheader`).text(` (${selectedOptions}/${totalOptions} ${i18next.t("search.selected")})`)
+        subheader.text(` (${selectedOptions.length}/${totalOptions} ${i18next.t("search.selected")})`)
     } else {
-        $(`#${id} .collapsible-subheader`).empty();
+        subheader.empty();
     }
 }
 

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -394,6 +394,7 @@ Inspector.prototype.search = function() {
     this.updateMultiSelectSubheader('search-filter-scales');
     this.updateMultiSelectSubheader('search-filter-units');
     this.updateMultiSelectSubheader('search-filter-namespaces');
+    this.updateMultiSelectSubheader('search-filter-dimension-type');
 }
 
 Inspector.prototype.updateMultiSelectSubheader = function (id) {

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -292,7 +292,7 @@ Inspector.prototype.searchSpec = function () {
     spec.conceptTypeFilter = $('#search-filter-concept-type').val();
     spec.factValueFilter = $('#search-filter-fact-value').val();
     spec.calculationsFilter = $('#search-filter-calculations').val();
-    spec.dimensionTypeFilter = $('#search-filter-dimension-type').val();
+    spec.dimensionTypeFilter = $('#search-filter-dimension-type select').val();
     return spec;
 }
 
@@ -350,7 +350,7 @@ Inspector.prototype.resetSearchFilters = function () {
     $("#search-filter-concept-type").val("*");
     $("#search-filter-fact-value").val("*");
     $("#search-filter-calculations").val("*");
-    $("#search-filter-dimension-type").val("*")
+    $("#search-filter-dimension-type select option:selected").prop("selected", false);
     $("#search-hidden-fact-filter").prop("checked", true);
     $("#search-visible-fact-filter").prop("checked", true);
     $("#search-filter-namespaces select option:selected").prop("selected", false);

--- a/iXBRLViewerPlugin/viewer/src/js/search.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.js
@@ -105,8 +105,8 @@ export class ReportSearch {
 
     periodFilter(s, item) {
         return (
-            s.periodFilter === '*' ||
-            s.periodFilter === item.period().key()
+            s.periodFilter.length === 0 ||
+            s.periodFilter.some(p => item.period().key() === p)
         );
     }
 

--- a/iXBRLViewerPlugin/viewer/src/js/search.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.js
@@ -118,10 +118,12 @@ export class ReportSearch {
     }
 
     dimensionTypeFilter(s, item) {
+        const typed = s.dimensionTypeFilter.includes('typed');
+        const explicit = s.dimensionTypeFilter.includes('explicit');
         return (
-            s.dimensionTypeFilter === '*' ||
-            (s.dimensionTypeFilter === 'typed' && item.hasTypedDimension()) ||
-            (s.dimensionTypeFilter === 'explicit' && item.hasExplicitDimension())
+            s.dimensionTypeFilter.length === 0 ||
+            (typed && item.hasTypedDimension()) ||
+            (explicit && item.hasExplicitDimension())
         )
     }
 

--- a/iXBRLViewerPlugin/viewer/src/js/search.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.js
@@ -136,11 +136,12 @@ export class ReportSearch {
     }
 
     calculationsFilter(s, item) {
+        const summation = s.calculationsFilter.includes('summation');
+        const contributor = s.calculationsFilter.includes('contributor');
         return (
-            s.calculationsFilter === '*' ||
-            (s.calculationsFilter === 'summation' && item.isCalculationSummation()) ||
-            (s.calculationsFilter === 'contributor' && item.isCalculationContributor()) ||
-            (s.calculationsFilter === 'summationOrContributor' && (item.isCalculationSummation() || item.isCalculationContributor()))
+            s.calculationsFilter.length === 0 ||
+            (summation && item.isCalculationSummation()) ||
+            (contributor && item.isCalculationContributor())
         );
     }
 

--- a/iXBRLViewerPlugin/viewer/src/js/search.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.test.js
@@ -108,7 +108,7 @@ function testSearchSpec(searchString='') {
     spec.namespacesFilter = [];
     spec.unitsFilter = [];
     spec.scalesFilter = [];
-    spec.periodFilter = '*';
+    spec.periodFilter = [];
     spec.conceptTypeFilter = '*';
     spec.dimensionTypeFilter = [];
     spec.factValueFilter = '*';
@@ -147,7 +147,7 @@ describe("Search fact value filter", () => {
     test("Fact Value Negative filter works with other filter", () => {
         const spec = testSearchSpec('Cash');
         spec.factValueFilter = 'negative'
-        spec.periodFilter = '2018-01-01/2019-01-01'
+        spec.periodFilter = ['2018-01-01/2019-01-01']
         const results = reportSearch.search(spec);
         expect(results.length).toEqual(1)
         expect(results[0]["fact"]["id"]).toEqual("negative")
@@ -164,7 +164,7 @@ describe("Search fact value filter", () => {
     test("Fact Value Positive filter works with other filter", () => {
         const spec = testSearchSpec('Cash');
         spec.factValueFilter = 'positive'
-        spec.periodFilter = '2018-01-01/2019-01-01'
+        spec.periodFilter = ['2018-01-01/2019-01-01']
         const results = reportSearch.search(spec);
         expect(results.length).toEqual(1)
         expect(results[0]["fact"]["id"]).toEqual("positive")

--- a/iXBRLViewerPlugin/viewer/src/js/search.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.test.js
@@ -112,7 +112,7 @@ function testSearchSpec(searchString='') {
     spec.conceptTypeFilter = '*';
     spec.dimensionTypeFilter = [];
     spec.factValueFilter = '*';
-    spec.calculationsFilter = "*";
+    spec.calculationsFilter = [];
     return spec;
 }
 
@@ -203,28 +203,28 @@ describe("Search calculation filter", () => {
 
     test("Calculations 'all' filter works", () => {
         const spec = testSearchSpec();
-        spec.calculationsFilter = '*';
+        spec.calculationsFilter = [];
         const results = reportSearch.search(spec).map(r => r.fact.id).sort();
         expect(results).toEqual(['item1', 'item2', 'other', 'summation']);
     });
 
     test("Calculations 'contributor' filter works", () => {
         const spec = testSearchSpec();
-        spec.calculationsFilter = 'contributor';
+        spec.calculationsFilter = ['contributor'];
         const results = reportSearch.search(spec).map(r => r.fact.id).sort();
         expect(results).toEqual(['item1', 'item2']);
     });
 
     test("Calculations 'summation' filter works", () => {
         const spec = testSearchSpec();
-        spec.calculationsFilter = 'summation';
+        spec.calculationsFilter = ['summation'];
         const results = reportSearch.search(spec).map(r => r.fact.id).sort();
         expect(results).toEqual(['summation']);
     });
 
-    test("Calculations 'summationOrContributor' filter works", () => {
+    test("Calculations 'summation' and 'contributor' filter works", () => {
         const spec = testSearchSpec();
-        spec.calculationsFilter = 'summationOrContributor';
+        spec.calculationsFilter = ['summation', 'contributor'];
         const results = reportSearch.search(spec).map(r => r.fact.id).sort();
         expect(results).toEqual(['item1', 'item2', 'summation']);
     });
@@ -243,7 +243,7 @@ describe("Search calculation filter", () => {
 
     test("Calculations filter works on empty report", () => {
         const spec = testSearchSpec();
-        spec.calculationsFilter = 'summationOrContributor';
+        spec.calculationsFilter = ['summation', 'contributor'];
         const results = emptyReportSearch.search(spec).map(r => r.fact.id).sort();
         expect(results).toEqual([]);
     });

--- a/iXBRLViewerPlugin/viewer/src/js/search.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.test.js
@@ -110,7 +110,7 @@ function testSearchSpec(searchString='') {
     spec.scalesFilter = [];
     spec.periodFilter = '*';
     spec.conceptTypeFilter = '*';
-    spec.dimensionTypeFilter = '*';
+    spec.dimensionTypeFilter = [];
     spec.factValueFilter = '*';
     spec.calculationsFilter = "*";
     return spec;
@@ -414,23 +414,30 @@ describe("Search dimension type filter", () => {
 
     test("Dimension 'all' filter works", () => {
         const spec = testSearchSpec();
-        spec.dimensionTypeFilter = '*';
+        spec.dimensionTypeFilter = [];
         const results = reportSearch.search(spec).map(r => r.fact.id).sort();
         expect(results).toEqual(['explicit', 'explicit2', 'explicitAndTyped', 'explicitAndTyped2', 'simple', 'simple2', 'typed', 'typed2']);
     });
 
     test("Dimension 'explicit' filter works", () => {
         const spec = testSearchSpec();
-        spec.dimensionTypeFilter = 'explicit';
+        spec.dimensionTypeFilter = ['explicit'];
         const results = reportSearch.search(spec).map(r => r.fact.id).sort();
         expect(results).toEqual(['explicit', 'explicit2', 'explicitAndTyped', 'explicitAndTyped2']);
     });
 
     test("Dimension 'typed' filter works", () => {
         const spec = testSearchSpec();
-        spec.dimensionTypeFilter = 'typed';
+        spec.dimensionTypeFilter = ['typed'];
         const results = reportSearch.search(spec).map(r => r.fact.id).sort();
         expect(results).toEqual(['explicitAndTyped', 'explicitAndTyped2', 'typed', 'typed2']);
+    });
+
+    test("Dimension 'explicit' and 'typed' filter works", () => {
+        const spec = testSearchSpec();
+        spec.dimensionTypeFilter = ['explicit', 'typed'];
+        const results = reportSearch.search(spec).map(r => r.fact.id).sort();
+        expect(results).toEqual(['explicit', 'explicit2', 'explicitAndTyped', 'explicitAndTyped2', 'typed', 'typed2']);
     });
 
     const emptyReport = testReport(
@@ -448,7 +455,7 @@ describe("Search dimension type filter", () => {
 
     test("Dimension filter works on empty report", () => {
         const spec = testSearchSpec();
-        spec.dimensionTypeFilter = 'explicit';
+        spec.dimensionTypeFilter = ['explicit'];
         const results = emptyReportSearch.search(spec).map(r => r.fact.id).sort();
         expect(results).toEqual([]);
     });

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -842,6 +842,7 @@
         padding-left: 12px;
         cursor: pointer;
         user-select: none;
+        white-space: nowrap;
 
         &::before {
           .icon-chevron-right();

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -831,6 +831,15 @@
           transition: all 0.25s ease;
           display: inline-block;
         }
+
+        .collapsible-subheader {
+          pointer-events: none;
+          user-select: none;
+          font-weight: normal;
+          font-style: italic;
+          font-size: 1.3rem;
+          color: @text-form-value;
+        }
       }
 
       &.collapsed {
@@ -838,6 +847,10 @@
           transform: rotate(0);
           top: 0.3rem;
           left: -0.2rem;
+        }
+
+        .collapsible-subheader {
+          color: @primary;
         }
       }
 

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -438,6 +438,9 @@
 
         .search-filters {
           position: relative;
+          // Ensure the filter pane never grows too large to hide the results pane
+          max-height: 60vh;
+          overflow-y: auto;
 
           .reset {
             .clickable();

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -453,6 +453,26 @@
             padding-bottom: 0;
           }
 
+          .filter-group {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: space-between;
+            margin-bottom: 0.4em;
+
+            .control-label {
+              white-space: nowrap;
+              margin-right: 2em;
+              width: 6em;
+            }
+
+            input,
+            select,
+            textarea {
+              flex-basis: 12em;
+              flex-grow: 2;
+            }
+          }
+
           .control-label {
             font-weight: bold;
             margin-bottom: 0.6em;

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -683,7 +683,7 @@
       width: 100%;
 
       th {
-        width: 100px;
+        width: 75px;
         text-align: right;
         padding-right: 20px;
         color: @text-title;
@@ -691,8 +691,8 @@
 
       th,
       td {
-        padding-top: 7px;
-        padding-bottom: 7px;
+        padding-top: 2px;
+        padding-bottom: 2px;
       }
 
       tr.value {

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -833,7 +833,6 @@
         }
 
         .collapsible-subheader {
-          pointer-events: none;
           user-select: none;
           font-weight: normal;
           font-style: italic;
@@ -896,6 +895,18 @@
             padding-bottom: 1.2rem;
           }
         }
+      }
+    }
+
+    .reset-multiselect {
+      float: right;
+      line-height: 0;
+      position: relative;
+      bottom: 1rem;
+      cursor: pointer;
+
+      &::after {
+        .icon-close();
       }
     }
 

--- a/tests/puppeteer/framework/page_objects/search_panel.js
+++ b/tests/puppeteer/framework/page_objects/search_panel.js
@@ -51,7 +51,7 @@ export class Search {
 
     async filterPeriod(option) {
         const dropdown = await this.#viewerPage.page
-            .waitForSelector('#search-filter-period');
+            .waitForSelector('#search-filter-period select');
         await dropdown.select(option);
     }
 


### PR DESCRIPTION
#### Reason for change
Several filters being added recently has caused the filter window to extend over the filter results through the bottom of the screen. 

#### Description of change

- Wrap multi-select filters in collapsible sections
  - Only one section can be open at a time 
  - Summary of selected item(s) shown by section header when collapsed
  - "x" button allows for quick clearing of an individual multi-select element
  - Converted dimensions, calculations, and periods filters into collapsible multi-select filters
- Adjust dropdown filters to be inline rather than labels and dropdowns being stacked vertically
- Add `max-height` to filters window to ensure it does not hide results window if it does somehow reach 60%+ view height.

Other UI improvements in this PR that aren't necessarily related to saving UI space in filter window:

- Fact details window
  - Only show "Dimension" label if concept has dimensions to show
  - Add "Properties" label to differentiate fact details table from "Dimensions" section 
- Rearranged filter order to include always-relevant filters first (period, namespace) and more niche filters last (calculations, dimensions)

#### Steps to Test
CI, filter testing

**review**:
@Workiva/xt
@paulwarren-wk
# DEMO GIF
![demo (1)](https://github.com/Workiva/ixbrl-viewer/assets/105066394/c3ac00e0-ee83-40bf-a32b-f5f61a248bb1)

