### PR TITLE
Never scroll when selecting a fact by clicking on it

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -143,7 +143,7 @@ Inspector.prototype.initialize = function (report, viewer) {
 
 Inspector.prototype.initializeViewer = function () {
     var viewer = this._viewer;
-    viewer.onSelect.add((id, eltSet) => this.selectItem(id, eltSet));
+    viewer.onSelect.add((id, eltSet, byClick) => this.selectItem(id, eltSet, byClick));
     viewer.onMouseEnter.add((id) => this.viewerMouseEnter(id));
     viewer.onMouseLeave.add(id => this.viewerMouseLeave(id));
     $('.ixbrl-next-tag').click(() => viewer.selectNextTag(this._currentItem));
@@ -1014,7 +1014,7 @@ Inspector.prototype.update = function () {
  * If itemIdList is omitted, the currently selected item list is reset to just
  * the primary item.
  */
-Inspector.prototype.selectItem = function (id, itemIdList) {
+Inspector.prototype.selectItem = function (id, itemIdList, noScroll) {
     if (itemIdList === undefined) {
         this._currentItemList = [ this._report.getItemById(id) ];
     }
@@ -1024,7 +1024,7 @@ Inspector.prototype.selectItem = function (id, itemIdList) {
             this._currentItemList.push(this._report.getItemById(itemIdList[i]));
         }
     }
-    this.switchItem(id);
+    this.switchItem(id, noScroll);
 }
 
 /*
@@ -1035,10 +1035,12 @@ Inspector.prototype.selectItem = function (id, itemIdList) {
  *
  * For footnotes, we currently only support a single footnote being selected.
  */
-Inspector.prototype.switchItem = function (id) {
+Inspector.prototype.switchItem = function (id, noScroll) {
     if (id !== null) {
         this._currentItem = this._report.getItemById(id);
-        this._viewer.showItemById(id);
+        if (!noScroll) {
+            this._viewer.showItemById(id);
+        }
         this._viewer.highlightItem(id);
     }
     else {

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -555,7 +555,9 @@ export class Viewer {
         if (itemId !== null) {
             this.onSelect.fire(itemId, itemIdList, byClick);
         }
-        this.onSelect.fire(null);
+        else {
+            this.onSelect.fire(null);
+        }
     }
 
     // Handle a mouse click to select.  This finds all tagged elements that the

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -547,14 +547,15 @@ export class Viewer {
      *
      * Takes an optional list of factIds corresponding to all facts that a click
      * falls within.  If omitted, it's treated as a click on a non-nested fact.
+     *
+     * byClick indicates that the element was clicked directly, and in this
+     * case we never scroll to make it more visible.
      */
-    selectElement(itemId, itemIdList) {
+    selectElement(itemId, itemIdList, byClick) {
         if (itemId !== null) {
-            this.onSelect.fire(itemId, itemIdList);
+            this.onSelect.fire(itemId, itemIdList, byClick);
         }
-        else {
-            this.onSelect.fire(null);
-        }
+        this.onSelect.fire(null);
     }
 
     // Handle a mouse click to select.  This finds all tagged elements that the
@@ -592,7 +593,7 @@ export class Viewer {
                 sameContentAncestorId = ids[0];
             }
         });
-        this.selectElement(sameContentAncestorId, itemIDList);
+        this.selectElement(sameContentAncestorId, itemIDList, true);
     }
 
     _mouseEnter(e) {


### PR DESCRIPTION
#### Reason for change

Currently, when selecting a fact, we check to see if the fact is fully visible, and if not, scroll so that is is centered in the view.

The code doesn't take into account continuations, so if you click on a continuation, and the "head" fact isn't fully in view, we scroll away from what you clicked on.  This is also a problem even without continuations if you have a large text block that is larger than the viewport.

On reflection, when you select a fact by clicking on it in the document view, I don't think it's ever desirable to scroll that view.

#### Description of change

We now never scroll the view

#### Steps to Test

See steps described on #437 (note this isn't a fix for the main part of #437, just the fact that it scrolls away from what you click on).

Alternatively, scroll so that any fact is only partially visible.  Click on it, and notice that the view no longer scrolls to center it.

**review**:
@Workiva/xt
@paulwarren-wk
