### PR TITLE
XT-2997: Handle null unit in scale filter

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -275,13 +275,17 @@ export class Fact {
     }
 
     getScaleLabel(value, isAccuracy=false) {
+        let measure = this.measure() ?? '';
+        if (measure) {
+            measure = this.report().qname(measure).localname;
+        }
         return this._report.getScaleLabel(
                 // We use the same table of labels for scale and accuracy,
                 // but decimals means "accurate to 10^-N" whereas scale means 10^N,
                 // so invert N for accuracy.
                 isAccuracy ? -value : value,
                 this.isMonetaryValue(),
-                this.report().qname(this.measure()).localname
+                measure
         );
     }
 

--- a/iXBRLViewerPlugin/viewer/src/js/fact.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.test.js
@@ -389,6 +389,12 @@ describe("Readable accuracy", () => {
             "a": { "u": "eg:unit" }
         }).readableAccuracy()).toBe("4");
 
+        expect(testFact({
+            "v": "1234",
+            "d": 4,
+            "a": { "u": null }
+        }).readableAccuracy()).toBe("4");
+
     });
     test("Numeric, monetary", () => {    
         expect(testFact({


### PR DESCRIPTION
#### Reason for change
The scale filter currently throws if a fact unit is null.

<img width="850" alt="Screenshot 2023-06-14 at 11 45 17 AM" src="https://github.com/Workiva/ixbrl-viewer/assets/46454775/2853f15b-7766-4c6d-a19d-8faa96f106ee">

#### Description of change
Don't pass an undefined measure to `this.report().qname(...)`.


#### Steps to Test
1. `npm run prod`
2. Use [filing_documents.zip](https://github.com/Workiva/ixbrl-viewer/files/11748087/filing_documents.zip)
3. `python arelleCmdLine.py --plugins=/path/to/ixbrl-viewer/iXBRLViewerPlugin -f /path/to/filing_documents.zip --save-viewer ixbrl-report-viewer.html --viewer-url=/path/to/ixbrl-viewer/iXBRLViewerPlugin/viewer/dist/ixbrlviewer.js`
4. Open `ixbrl-report-viewer.html` and click into the fact and confirm that an exception isn't thrown.



**review**:
@Workiva/xt
@paulwarren-wk
