### PR TITLE
Improve layout of tag summary table with narrow width / long prefixes

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -286,11 +286,11 @@ limitations under the License.
                 <table>
                   <thead>
                     <tr>
-                      <th scope="col" data-i18n="inspector.summary.tag.colNamespace">Namespace</th>
-                      <th scope="col" data-i18n="inspector.summary.tag.colPrimaryItems">Primary Items</th>
-                      <th scope="col" data-i18n="inspector.summary.tag.colDimensions">Dimensions</th>
-                      <th scope="col" data-i18n="inspector.summary.tag.colMembers">Members</th>
-                      <th scope="col" data-i18n="inspector.summary.tag.colTotal">Total</th>
+                      <th scope="col" class="namespace"><div data-i18n="inspector.summary.tag.colNamespace">Namespace</div></th>
+                      <th scope="col" class="figure"><div data-i18n="inspector.summary.tag.colPrimaryItems">Primary Items</div></th>
+                      <th scope="col" class="figure"><div data-i18n="inspector.summary.tag.colDimensions">Dimensions</div></th>
+                      <th scope="col" class="figure"><div data-i18n="inspector.summary.tag.colMembers">Members</div></th>
+                      <th scope="col" class="figure"><div data-i18n="inspector.summary.tag.colTotal">Total</div></th>
                     </tr>
                   </thead>
                   <tbody class="tag-summary-table-body">

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -468,6 +468,7 @@ Inspector.prototype._populateTagSummary = function (summaryDom) {
 
         $("<td></td>")
                 .text(count)
+                .addClass("figure")
                 .append($("<sup></sup>").text(formattedPercent))
                 .appendTo(row);
     }

--- a/iXBRLViewerPlugin/viewer/src/less/summary.less
+++ b/iXBRLViewerPlugin/viewer/src/less/summary.less
@@ -33,6 +33,7 @@
 
       sup {
         font-size: 0.9rem;
+        display: block;
       }
 
       table {
@@ -47,8 +48,32 @@
 
         thead {
           th {
-            white-space: break-spaces;
+            white-space: nowrap;
+            position: relative;
+            height: 10rem;
+
+            &.namespace {
+              text-align: left;
+              vertical-align: bottom;
+            }
+
+            &.figure {
+              width: 5rem;
+
+              & > div {
+                position: absolute;
+                transform: translate(100px, -50%) rotate(45deg) translate(-50%, 50%);
+                text-align: right;
+                width: 200px;
+                right: 0;
+                bottom: 0;
+              }
+            }
           }
+        }
+
+        tbody th {
+          font-weight: normal;
         }
 
         tbody,
@@ -62,6 +87,10 @@
 
             &:hover {
               background-color: rgb(230 230 230);
+            }
+
+            td.figure {
+              text-align: right;
             }
           }
         }


### PR DESCRIPTION
#### Reason for change

The new fact summary table does not work well on narrow screen widths or on documents with long prefixes.

For example, this example is from [this Japanese EDINET filing](https://disclosure2.edinet-fsa.go.jp/WEEE0040.aspx?bXVsPWNhbm94JmN0Zj1vZmYmZmxzPW9uJmxwcj1vZmYmcnByPW9mZiZvdGg9b2ZmJnBmcz02Jnllcj0mbW9uPQ==)

![image](https://github.com/Workiva/ixbrl-viewer/assets/45077928/cde7295a-f1d5-4881-bcea-c277c2fc6365)

The long prefix names causes inconsistent column widths for the remaining width, and inconsistent wrapping of the percentage figures.

Problem is also visible with shorter prefixes on a narrow window:

![image](https://github.com/Workiva/ixbrl-viewer/assets/45077928/fce10d07-e91b-472e-bf9d-db729506ded3)

#### Description of change

This change fixes the width of the columns containing numbers, and uses diagonal column headers:

![image](https://github.com/Workiva/ixbrl-viewer/assets/45077928/9f262d22-adde-4bc2-a4ef-884afddd0e92)

The percentage figures are forced onto a separate line, and numbers are now right-aligned.

Diagonal column headers aren't perfect, as we have to guess how much vertical space to leave (or use JS to adjust it - I can't see a way to do it in CSS), bearing in mind that i18n might change the length of these labels.

The only other solution I can see is moving this into a popup dialog where we would have more horizontal space.

#### Steps to Test

Take any iXBRL document and reduce the window width (or inspector pane width) and check the behaviour of the Tag Summary table.

**review**:
@Workiva/xt
@paulwarren-wk
