### PR TITLE
XT-3016 - Update python image to 3.9-slim-bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ ARG BUILD_ARTIFACTS_CDN=/static_release/assets.tar.gz
 RUN npm pack
 ARG BUILD_ARTIFACTS_NPM=/build/*.tgz
 
-FROM python:3.9-slim as python-build
+FROM python:3.9-slim-bullseye as python-build
 
 ARG PIP_INDEX_URL
 ARG GIT_TAG


### PR DESCRIPTION
#### Reason for change
Builds are failing because the underlying skynet image was recently updated to use a bookworm images that causes issues with libc. We need to pin our version of python `3.9-slim` to `3.9-slim-bullseye`.

#### Description of change
Update python image to `3.9-slim-bullseye`

#### Steps to Test
CI

**review**:
@Workiva/xt
@paulwarren-wk
