### PR TITLE
XT-3035 Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     time: "02:00"
     timezone: America/Chicago
   open-pull-requests-limit: 99
+  allow:
+    - dependency-type: all
   reviewers:
   - Workiva/xt
   ignore:
@@ -26,21 +28,12 @@ updates:
   - dependency-name: i18next
     versions:
     - ">=21"
-  - dependency-name: jest
-    versions:
-    - ">=27"
   - dependency-name: less
     versions:
     - ">=4"
   - dependency-name: less-loader
     versions:
     - ">=7"
-  - dependency-name: webpack-cli
-    versions:
-    - ">=4"
-  - dependency-name: webpack-merge
-    versions:
-    - ">=5"
 - package-ecosystem: pip
   directory: "/"
   schedule:
@@ -49,7 +42,7 @@ updates:
     timezone: America/Chicago
   open-pull-requests-limit: 99
   allow:
-    - dependency-type: indirect
+    - dependency-type: all
   reviewers:
   - Workiva/xt
 - package-ecosystem: docker


### PR DESCRIPTION
#### Reason for change
Outdated ignore list and not managing explicit Python dependencies 

#### Description of change
Remove outdated ignore list entries and configure dependabot to manage explicit and potential future lock file dependencies.

#### Steps to Test
* CI

**review**:
@Workiva/xt
@paulwarren-wk
