### PR TITLE
Modernize JavaScript in inspector.js

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/identifiers.js
+++ b/iXBRLViewerPlugin/viewer/src/js/identifiers.js
@@ -20,13 +20,11 @@ const schemes = {
 };
 
 export class Identifiers {
-    static identifierURLForFact(fact) {
-        const data = schemes[fact.identifier().namespace];
+    static identifierURL(identifier) {
+        const data = schemes[identifier.namespace];
         if (data !== undefined && data.url !== undefined) {
-            let url = data.url.replace('%s', fact.identifier().localname);
-            url = url.replace(/%0(\d+)d/, function (match, width) { 
-                return fact.identifier().localname.padStart(width, "0");
-            });
+            let url = data.url.replace('%s', identifier.localname);
+            url = url.replace(/%0(\d+)d/, (match, width) => identifier.localname.padStart(width, "0"));
             return url;
         }
         return undefined;
@@ -46,5 +44,29 @@ export class Identifiers {
             return "[" + data.name + "] " + identifier.localname;
         }
         return identifier.qname
+    }
+
+    static readableNameHTML(identifier) {
+        const data = schemes[identifier.namespace];
+        const span = document.createElement("span");
+        if (data !== undefined) {
+            const schemeSpan = span.appendChild(document.createElement("span"));
+            schemeSpan.textContent = "[" + data.name + "] ";
+            const url = Identifiers.identifierURL(identifier);
+            if (url !== undefined) {
+                const a = span.appendChild(document.createElement("a"));
+                a.textContent = identifier.localname;
+                a.setAttribute("target", "_blank");
+                a.setAttribute("href", url);
+            }
+            else {
+                const el = span.appendChild(document.createElement("span"));
+                el.textContent = identifier.localname;
+            }
+        }
+        else {
+            span.textContent = identifier.qname;
+        }
+        return span;
     }
 }

--- a/iXBRLViewerPlugin/viewer/src/js/identifiers.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/identifiers.test.js
@@ -1,0 +1,51 @@
+import { Identifiers } from './identifiers.js';
+import { QName } from './qname.js';
+
+const prefixMap = {
+    "e": "http://example.com",
+    "cik": "http://www.sec.gov/CIK",
+    "crn": "http://www.companieshouse.gov.uk/",
+    "ua": "https://www.minfin.gov.ua",
+};
+
+function qname(s) {
+    return new QName(prefixMap, s);
+}
+
+describe("readableName", () => {
+    test("Unknown scheme", () => {
+        expect(Identifiers.readableName(qname("e:1234"))).toBe("e:1234");
+    });
+    test("Known scheme", () => {
+        expect(Identifiers.readableName(qname("cik:1234"))).toBe("[CIK] 1234");
+        expect(Identifiers.readableName(qname("ua:01234"))).toBe("[EDRPOU] 01234");
+    });
+});
+
+describe("readableNameHTML", () => {
+    test("Unknown scheme", () => {
+        const html = Identifiers.readableNameHTML(qname("e:1234"));
+        expect(html.textContent).toBe("e:1234");
+    });
+    test("Known scheme with URL", () => {
+        const html = Identifiers.readableNameHTML(qname("cik:1234"));
+        expect(html.childNodes.length).toBe(2);
+        expect(html.childNodes[0].textContent).toBe("[CIK] ");
+        expect(html.childNodes[1].nodeName).toBe("A");
+        expect(html.childNodes[1].getAttribute("href")).toBe("https://www.sec.gov/cgi-bin/browse-edgar?CIK=1234");
+    });
+    test("Known scheme with URL, padded identifier", () => {
+        const html = Identifiers.readableNameHTML(qname("crn:1234"));
+        expect(html.childNodes.length).toBe(2);
+        expect(html.childNodes[0].textContent).toBe("[UK CRN] ");
+        expect(html.childNodes[1].nodeName).toBe("A");
+        expect(html.childNodes[1].getAttribute("href")).toBe("https://beta.companieshouse.gov.uk/company/00001234");
+    });
+    test("Known scheme without URL", () => {
+        const html = Identifiers.readableNameHTML(qname("ua:1234"));
+        expect(html.childNodes.length).toBe(2);
+        expect(html.childNodes[0].textContent).toBe("[EDRPOU] ");
+        expect(html.childNodes[1].nodeName).toBe("SPAN");
+        expect(html.childNodes[1].textContent).toBe("1234");
+    });
+});

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -820,22 +820,9 @@ export class Inspector {
     }
 
     _updateEntityIdentifier(fact, context) {
-        const cell = $('tr.entity-identifier td', context);
-        cell.empty();
-        const url = Identifiers.identifierURLForFact(fact);
-        const name = Identifiers.identifierNameForFact(fact);
-        if (name !== undefined) {
-            $('<span></span>').text('[' + name + "] ").appendTo(cell)
-            if (url !== undefined) {
-                $('<a target="_blank"></a>').attr('href',url).text(fact.identifier().localname).appendTo(cell)
-            }
-            else {
-                $('<span></span>').text(fact.identifier().localname).appendTo(cell);
-            }
-        }
-        else {
-            cell.text(fact.f.a.e);
-        }
+        $('tr.entity-identifier td', context)
+            .empty()
+            .append(Identifiers.readableNameHTML(fact.identifier()));
     }
 
     _footnoteFactsHTML(fact) {

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -573,7 +573,6 @@ export class Inspector {
         }
     }
 
-
     _anchorList(fact, anchors) {
         const html = $("<ul></ul>");
         if (anchors.length > 0) {
@@ -827,7 +826,7 @@ export class Inspector {
 
     _footnoteFactsHTML(fact) {
         const html = $('<div></div>');
-        fact.linkedFacts.forEach((linkedFact) =>  {
+        fact.linkedFacts.forEach((linkedFact) => {
             html.append(this.factListRow(linkedFact));
         });
         return html;
@@ -931,8 +930,7 @@ export class Inspector {
     }
 
     update() {
-        const inspector = this;
-        const cf = inspector._currentItem;
+        const cf = this._currentItem;
         if (!cf) {
             $('#inspector').removeClass('footnote-mode');
             $('#inspector').addClass('no-fact-selected');
@@ -964,8 +962,8 @@ export class Inspector {
                     }
                 }
                 $('.duplicates .text').text(i18next.t('factDetails.duplicatesCount', { current: n + 1, total: ndup}));
-                $('.duplicates .prev').off().click(() => inspector.selectItem(duplicates[(n+ndup-1) % ndup].id));
-                $('.duplicates .next').off().click(() => inspector.selectItem(duplicates[(n+1) % ndup].id));
+                $('.duplicates .prev').off().click(() => this.selectItem(duplicates[(n+ndup-1) % ndup].id));
+                $('.duplicates .next').off().click(() => this.selectItem(duplicates[(n+1) % ndup].id));
 
                 this.getPeriodIncrease(cf);
                 if (cf.isHidden()) {

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -34,1067 +34,1061 @@ import { DIMENSIONS_KEY, DocumentSummary, MEMBERS_KEY, PRIMARY_ITEMS_KEY, TOTAL_
 
 const SEARCH_PAGE_SIZE = 100
 
-export function Inspector(iv) {
-    this._iv = iv;
-    this._viewerOptions = new ViewerOptions()
-    this._currentItem = null;
-}
+export class Inspector {
+    constructor(iv) {
+        this._iv = iv;
+        this._viewerOptions = new ViewerOptions()
+        this._currentItem = null;
+    }
 
-Inspector.prototype.i18nInit = function () {
-    return i18next.init({
-        lng: this.preferredLanguages()[0],
-        // Do not apply translations that are present but with an empty string
-        returnEmptyString: false,
-        fallbackLng: 'en',
-        debug: false,
-        resources: {
-            en: { 
-                translation: require('../i18n/en/translation.json'),
-                referenceParts: require('../i18n/en/referenceparts.json'),
-                currencies: require('../i18n/en/currencies.json')
-            },
-            es: { 
-                translation: require('../i18n/es/translation.json'),
-                referenceParts: require('../i18n/es/referenceparts.json'),
-                currencies: require('../i18n/es/currencies.json')
+    i18nInit() {
+        return i18next.init({
+            lng: this.preferredLanguages()[0],
+            // Do not apply translations that are present but with an empty string
+            returnEmptyString: false,
+            fallbackLng: 'en',
+            debug: false,
+            resources: {
+                en: { 
+                    translation: require('../i18n/en/translation.json'),
+                    referenceParts: require('../i18n/en/referenceparts.json'),
+                    currencies: require('../i18n/en/currencies.json')
+                },
+                es: { 
+                    translation: require('../i18n/es/translation.json'),
+                    referenceParts: require('../i18n/es/referenceparts.json'),
+                    currencies: require('../i18n/es/currencies.json')
+                }
             }
-        }
-    }).then((t) => {
-        jqueryI18next.init(i18next, $, {
-            tName: 't', // --> appends $.t = i18next.t
-            i18nName: 'i18n', // --> appends $.i18n = i18next
-            handleName: 'localize', // --> appends $(selector).localize(opts);
-            selectorAttr: 'data-i18n', // selector for translating elements
-            targetAttr: 'i18n-target', // data-() attribute to grab target element to translate (if different than itself)
-            useOptionsAttr: false, // see optionsAttr
-            parseDefaultValueFromContent: true // parses default values from content ele.val or ele.text
+        }).then((t) => {
+            jqueryI18next.init(i18next, $, {
+                tName: 't', // --> appends $.t = i18next.t
+                i18nName: 'i18n', // --> appends $.i18n = i18next
+                handleName: 'localize', // --> appends $(selector).localize(opts);
+                selectorAttr: 'data-i18n', // selector for translating elements
+                targetAttr: 'i18n-target', // data-() attribute to grab target element to translate (if different than itself)
+                useOptionsAttr: false, // see optionsAttr
+                parseDefaultValueFromContent: true // parses default values from content ele.val or ele.text
+            });
         });
-    });
-}
+    }
 
-Inspector.prototype.initialize = function (report, viewer) {
-    var inspector = this;
-    this._viewer = viewer;
-    return new Promise(function (resolve, reject) {
-        inspector._chart = new IXBRLChart();
-        inspector._report = report;
-        inspector.i18nInit().then((t) => {
-            
-            $(".collapsible-header").on("click", function () { 
-                var d = $(this).closest(".collapsible-section");
-                d.toggleClass("collapsed"); 
-                if (d.hasClass("collapsed")) {
-                    d.find(".collapsible-body").slideUp(250);
-                }
-                else {
-                    d.find(".collapsible-body").slideDown(250);
-                    if (d.hasClass("collapsible-only")) {
-                        d.siblings('.collapsible-section:not(.collapsed)').each(function() {
-                            const section = $(this);
-                            section.addClass("collapsed");
-                            section.find(".collapsible-body").slideUp(250);
-                        });
+    initialize(report, viewer) {
+        const inspector = this;
+        this._viewer = viewer;
+        return new Promise(function (resolve, reject) {
+            inspector._chart = new IXBRLChart();
+            inspector._report = report;
+            inspector.i18nInit().then((t) => {
+                
+                $(".collapsible-header").on("click", function () { 
+                    const d = $(this).closest(".collapsible-section");
+                    d.toggleClass("collapsed"); 
+                    if (d.hasClass("collapsed")) {
+                        d.find(".collapsible-body").slideUp(250);
                     }
-                }
-            });
-            $("#inspector .controls .search-button").on("click", function () {
-                $(this).closest("#inspector").removeClass(["summary-mode", "outline-mode"]).toggleClass("search-mode");
-            });
-            $("#inspector .controls .summary-button").on("click", function () {
-                $(this).closest("#inspector").removeClass(["outline-mode", "search-mode"]).toggleClass("summary-mode");
-            });
-            $("#inspector .controls .outline-button").on("click", function () {
-                $(this).closest("#inspector").removeClass(["summary-mode", "search-mode"]).toggleClass("outline-mode");
-            });
-            $("#inspector-head .back").on("click", function () {
-                $(this).closest("#inspector").removeClass(["summary-mode", "outline-mode", "search-mode"]);
-            });
-            $(".popup-trigger").hover(function () { $(this).find(".popup-content").show() }, function () { $(this).find(".popup-content").hide() });
-            $("#inspector").on("click", ".clipboard-copy", function () {
-                navigator.clipboard.writeText($(this).data("cb-text"));
-            });
-            inspector._toolbarMenu = new Menu($("#toolbar-highlight-menu"));
-            inspector.buildToolbarHighlightMenu();
-
-            inspector._optionsMenu = new Menu($("#display-options-menu"));
-            inspector.buildDisplayOptionsMenu();
-
-            $("#ixv").localize();
-
-            // Listen to messages posted to this window
-            $(window).on("message", (e) => inspector.handleMessage(e));
-            report.setViewerOptions(inspector._viewerOptions);
-            inspector.summary = new DocumentSummary(report);
-            inspector.createSummary()
-            inspector.outline = new DocumentOutline(report);
-            inspector.createOutline();
-            inspector._iv.setProgress(i18next.t("inspector.initializing")).then(() => {
-                inspector._search = new ReportSearch(report);
-                inspector.buildDisplayOptionsMenu();
+                    else {
+                        d.find(".collapsible-body").slideDown(250);
+                        if (d.hasClass("collapsible-only")) {
+                            d.siblings('.collapsible-section:not(.collapsed)').each(function() {
+                                const section = $(this);
+                                section.addClass("collapsed");
+                                section.find(".collapsible-body").slideUp(250);
+                            });
+                        }
+                    }
+                });
+                $("#inspector .controls .search-button").on("click", function () {
+                    $(this).closest("#inspector").removeClass(["summary-mode", "outline-mode"]).toggleClass("search-mode");
+                });
+                $("#inspector .controls .summary-button").on("click", function () {
+                    $(this).closest("#inspector").removeClass(["outline-mode", "search-mode"]).toggleClass("summary-mode");
+                });
+                $("#inspector .controls .outline-button").on("click", function () {
+                    $(this).closest("#inspector").removeClass(["summary-mode", "search-mode"]).toggleClass("outline-mode");
+                });
+                $("#inspector-head .back").on("click", function () {
+                    $(this).closest("#inspector").removeClass(["summary-mode", "outline-mode", "search-mode"]);
+                });
+                $(".popup-trigger").hover(function () { $(this).find(".popup-content").show() }, function () { $(this).find(".popup-content").hide() });
+                $("#inspector").on("click", ".clipboard-copy", function () {
+                    navigator.clipboard.writeText($(this).data("cb-text"));
+                });
+                inspector._toolbarMenu = new Menu($("#toolbar-highlight-menu"));
                 inspector.buildToolbarHighlightMenu();
-                inspector.buildHighlightKey();
-                inspector.setupValidationReportIcon();
-                inspector.initializeViewer();
-                resolve();
+
+                inspector._optionsMenu = new Menu($("#display-options-menu"));
+                inspector.buildDisplayOptionsMenu();
+
+                $("#ixv").localize();
+
+                // Listen to messages posted to this window
+                $(window).on("message", (e) => inspector.handleMessage(e));
+                report.setViewerOptions(inspector._viewerOptions);
+                inspector.summary = new DocumentSummary(report);
+                inspector.createSummary()
+                inspector.outline = new DocumentOutline(report);
+                inspector.createOutline();
+                inspector._iv.setProgress(i18next.t("inspector.initializing")).then(() => {
+                    inspector._search = new ReportSearch(report);
+                    inspector.buildDisplayOptionsMenu();
+                    inspector.buildToolbarHighlightMenu();
+                    inspector.buildHighlightKey();
+                    inspector.setupValidationReportIcon();
+                    inspector.initializeViewer();
+                    resolve();
+                });
             });
         });
-    });
-}
-
-Inspector.prototype.initializeViewer = function () {
-    var viewer = this._viewer;
-    viewer.onSelect.add((id, eltSet, byClick) => this.selectItem(id, eltSet, byClick));
-    viewer.onMouseEnter.add((id) => this.viewerMouseEnter(id));
-    viewer.onMouseLeave.add(id => this.viewerMouseLeave(id));
-    $('.ixbrl-next-tag').click(() => viewer.selectNextTag(this._currentItem));
-    $('.ixbrl-prev-tag').click(() => viewer.selectPrevTag(this._currentItem));
-}
-
-Inspector.prototype.postLoadAsync = function () {
-    runGenerator(this._search.buildSearchIndex(() => this.searchReady()));
-}
-
-
-/*
- * Check for fragment identifier pointing to a specific fact and select it if
- * present.
- */
-Inspector.prototype.handleFactDeepLink = function () {
-    if (location.hash.startsWith("#f-")) {
-        this.selectItem(location.hash.slice(3));
     }
-}
 
-Inspector.prototype.handleMessage = function (event) {
-    var jsonString = event.originalEvent.data;
-    var data = JSON.parse(jsonString);
+    initializeViewer() {
+        this._viewer.onSelect.add((id, eltSet, byClick) => this.selectItem(id, eltSet, byClick));
+        this._viewer.onMouseEnter.add((id) => this.viewerMouseEnter(id));
+        this._viewer.onMouseLeave.add(id => this.viewerMouseLeave(id));
+        $('.ixbrl-next-tag').click(() => this._viewer.selectNextTag(this._currentItem));
+        $('.ixbrl-prev-tag').click(() => this._viewer.selectPrevTag(this._currentItem));
+    }
 
-    if (data.task == 'SHOW_FACT') {
-        this.selectItem(data.factId);
+    postLoadAsync() {
+        runGenerator(this._search.buildSearchIndex(() => this.searchReady()));
     }
-    else {
-        console.log("Not handling unsupported task message: " + jsonString);
-    }
-}
 
-Inspector.prototype.updateURLFragment = function () {
-    if (this._currentItem) {
-        location.hash = "#f-" + this._currentItem.id;
-    }
-    else {
-        location.hash = "";
-    }
-}
 
-Inspector.prototype.buildDisplayOptionsMenu = function () {
-    this._optionsMenu.reset();
-    if (this._report) {
-        var dl = this.selectDefaultLanguage();
-        this._optionsMenu.addCheckboxGroup(this._report.availableLanguages(), this._report.languageNames(), dl, (lang) => { this.setLanguage(lang); this.update() }, "select-language");
-        this.setLanguage(dl);
-        if (this._report.filingDocuments()) {
-            this._optionsMenu.addDownloadButton("Download filing documents", this._report.filingDocuments())
+    /*
+     * Check for fragment identifier pointing to a specific fact and select it if
+     * present.
+     */
+    handleFactDeepLink() {
+        if (location.hash.startsWith("#f-")) {
+            this.selectItem(location.hash.slice(3));
         }
     }
-    this._iv.callPluginMethod("extendDisplayOptionsMenu", this._optionsMenu);
-}
 
-Inspector.prototype.buildToolbarHighlightMenu = function () {
-    this._toolbarMenu.reset();
-    this._toolbarMenu.addCheckboxItem(i18next.t("toolbar.xbrlElements"), (checked) => this.highlightAllTags(checked), "highlight-tags", null, this._iv.options.highlightTagsOnStartup);
-    this._iv.callPluginMethod("extendToolbarHighlightMenu", this._toolbarMenu);
-}
+    handleMessage(event) {
+        const jsonString = event.originalEvent.data;
+        const data = JSON.parse(jsonString);
 
-Inspector.prototype.buildHighlightKey = function () {
-    $(".highlight-key .items").empty();
-    var key = this._report.namespaceGroups();
-    this._iv.callPluginMethod("extendHighlightKey", key);
-
-    for (var i = 0; i < key.length; i++) {
-        $("<div>")
-            .addClass("item")
-            .append($("<span></span>").addClass("sample").addClass("sample-" + i))
-            .append($("<span></span>").text(key[i]))
-            .appendTo($(".highlight-key .items"));
-    }
-}
-
-Inspector.prototype.highlightAllTags = function (checked) {
-    var inspector = this;
-    this._viewer.highlightAllTags(checked, inspector._report.namespaceGroups());
-}
-
-Inspector.prototype.factListRow = function(f) {
-    var row = $('<div class="fact-list-item"></div>')
-        .click(() => this.selectItem(f.id))
-        .dblclick(() => $('#inspector').removeClass("search-mode"))
-        .mousedown((e) => { 
-            /* Prevents text selection via double click without
-             * disabling click+drag text selection (which user-select:
-             * none would )
-             */
-            if (e.detail > 1) { 
-                e.preventDefault() 
-            } 
-        })
-        .mouseenter(() => this._viewer.linkedHighlightFact(f))
-        .mouseleave(() => this._viewer.clearLinkedHighlightFact(f))
-        .data('ivid', f.id);
-    $('<div class="select-icon"></div>')
-        .click(() => {
-            this.selectItem(f.id);
-            $('#inspector').removeClass("search-mode");
-        })
-        .appendTo(row)
-    $('<div class="title"></div>')
-        .text(f.getLabelOrName("std"))
-        .appendTo(row);
-    $('<div class="dimension"></div>')
-        .text(f.period().toString())
-        .appendTo(row);
-
-    for (const aspect of f.aspects()) {
-        if (aspect.isTaxonomyDefined() && !aspect.isNil()) {
-            $('<div class="dimension"></div>')
-                .text(aspect.valueLabel())
-                .appendTo(row);
-        }
-    }
-    if (f.isHidden()) {
-        $('<div class="hidden"></div>')
-            .text(i18next.t("search.hiddenFact"))
-            .appendTo(row);
-    }
-    else if (f.isHTMLHidden()) {
-        $('<div class="hidden"></div>')
-            .text(i18next.t("search.concealedFact"))
-            .appendTo(row);
-    }
-    return row;
-}
-
-Inspector.prototype.addResults = function(container, results, offset) {
-    $('.more-results', container).remove();
-    for (var i = offset; i < results.length; i++ ) {
-        if (i - offset >= SEARCH_PAGE_SIZE) {
-            $('<div class="more-results"></div>')
-                .text(i18next.t("search.showMoreResults"))
-                .on('click', () => this.addResults(container, results, i))
-                .appendTo(container);
-            break;
-        }
-        this.factListRow(results[i].fact).appendTo(container);
-    }
-}
-
-Inspector.prototype.searchSpec = function () {
-    var spec = {};
-    spec.searchString = $('#ixbrl-search').val();
-    spec.showVisibleFacts = $('#search-visible-fact-filter').prop('checked');
-    spec.showHiddenFacts = $('#search-hidden-fact-filter').prop('checked');
-    spec.namespacesFilter = $('#search-filter-namespaces select').val();
-    spec.unitsFilter = $('#search-filter-units select').val();
-    spec.scalesFilter = $('#search-filter-scales select').val();
-    spec.periodFilter = $('#search-filter-period select').val();
-    spec.conceptTypeFilter = $('#search-filter-concept-type').val();
-    spec.factValueFilter = $('#search-filter-fact-value').val();
-    spec.calculationsFilter = $('#search-filter-calculations select').val();
-    spec.dimensionTypeFilter = $('#search-filter-dimension-type select').val();
-    return spec;
-}
-
-Inspector.prototype.setupSearchControls = function (viewer) {
-    const inspector = this;
-    $('.search-controls input, .search-controls select').change(() => this.search());
-    $(".search-controls div.filter-toggle").click(() => $(".search-controls").toggleClass('show-filters'));
-    $(".search-controls .search-filters .reset").click(() => this.resetSearchFilters());
-    $(".search-controls .search-filters .reset-multiselect").on("click", function () {
-        $(this).siblings().children('select option:selected').prop('selected', false);
-        inspector.search();
-    });
-    Object.keys(this._search.periods).forEach(key => {
-        $("<option>")
-            .attr("value", key)
-            .text(this._search.periods[key])
-            .appendTo('#search-filter-period select');
-    });
-    this._report.getUsedPrefixes().forEach(prefix => {
-        $("<option>")
-            .attr("value", prefix)
-            .text(`${prefix} (${this._report.prefixMap()[prefix]})`)
-            .appendTo('#search-filter-namespaces select');
-    });
-    this._report.getUsedUnits().forEach(unit => {
-        $("<option>")
-                .attr("value", unit)
-                .text(`${this._report.getUnit(unit)?.label()} (${unit})`)
-                .appendTo('#search-filter-units select');
-    });
-    const scalesOptions = this._getScalesOptions();
-    Object.keys(scalesOptions).sort().forEach(scale => {
-            $("<option>")
-                    .attr("value", scale)
-                    .text(scalesOptions[scale])
-                    .appendTo('#search-filter-scales select');
-    });
-}
-
-Inspector.prototype._getScalesOptions = function() {
-    const scalesOptions = {}
-    const usedScalesMap = this._report.getUsedScalesMap();
-    Object.keys(usedScalesMap).sort().forEach(scale => {
-        const labels = Array.from(usedScalesMap[scale]).sort();
-        if (labels.length > 0) {
-            scalesOptions[scale] = labels.join(', ');
+        if (data.task == 'SHOW_FACT') {
+            this.selectItem(data.factId);
         }
         else {
-            scalesOptions[scale] = scale.toString();
+            console.log("Not handling unsupported task message: " + jsonString);
         }
-    });
-    return scalesOptions;
-}
-
-Inspector.prototype.resetSearchFilters = function () {
-    $("#search-filter-period select option:selected").prop("selected", false);
-    $("#search-filter-concept-type").val("*");
-    $("#search-filter-fact-value").val("*");
-    $("#search-filter-calculations select option:selected").prop("selected", false);
-    $("#search-filter-dimension-type select option:selected").prop("selected", false);
-    $("#search-hidden-fact-filter").prop("checked", true);
-    $("#search-visible-fact-filter").prop("checked", true);
-    $("#search-filter-namespaces select option:selected").prop("selected", false);
-    $("#search-filter-units select option:selected").prop("selected", false);
-    $("#search-filter-scales select option:selected").prop("selected", false);
-    this.search();
-}
-
-Inspector.prototype.searchReady = function() {
-    this.setupSearchControls();
-    $('#inspector').addClass('search-ready');
-    $('#ixbrl-search').prop('disabled', false);
-    this.search();
-}
-
-Inspector.prototype.search = function() {
-    var spec = this.searchSpec();
-    var results = this._search.search(spec);
-    if (results === undefined) {
-        return;
-    }
-    var viewer = this._viewer;
-    var container = $('#inspector .search-results .results');
-    $('div', container).remove();
-    viewer.clearRelatedHighlighting();
-    var overlay = $('#inspector .search-results .search-overlay');
-    if (results.length > 0) {
-        overlay.hide();
-        this.addResults(container, results, 0);
-    }
-    else {
-        $(".title", overlay).text(i18next.t("search.noMatchFound"));
-        $(".text", overlay).text(i18next.t("search.tryAgainDifferentKeywords"));
-        overlay.show();
-    }
-    $("#matching-concepts-count").text(results.length);
-    /* Don't highlight search results if there's no search string */
-    if (spec.searchString != "") {
-        viewer.highlightRelatedFacts($.map(results, r =>  r.fact ));
-    }
-    this.updateMultiSelectSubheader('search-filter-scales');
-    this.updateMultiSelectSubheader('search-filter-units');
-    this.updateMultiSelectSubheader('search-filter-namespaces');
-    this.updateMultiSelectSubheader('search-filter-dimension-type');
-    this.updateMultiSelectSubheader('search-filter-calculations');
-    this.updateMultiSelectSubheader('search-filter-period');
-}
-
-Inspector.prototype.updateMultiSelectSubheader = function (id) {
-    const subheader = $(`#${id} .collapsible-subheader`);
-    const selectedOptions = $(`#${id} select option:selected`);
-    if (selectedOptions.length === 1) {
-        subheader.text(` ${selectedOptions.text()}`);
-    }
-    else if (selectedOptions.length > 0) {
-        const totalOptions = $(`#${id} select option`).length;
-        subheader.text(` (${selectedOptions.length}/${totalOptions} ${i18next.t("search.selected")})`)
-    } else {
-        subheader.empty();
-    }
-}
-
-Inspector.prototype.updateCalculation = function (fact, elr) {
-    $('.calculations .tree').empty().append(this._calculationHTML(fact, elr));
-}
-
-Inspector.prototype.createSummary = function () {
-    const summaryDom = $("#inspector .summary .body");
-    this._populateFactSummary(summaryDom);
-    this._populateTagSummary(summaryDom);
-    this._populateFileSummary(summaryDom);
-}
-
-Inspector.prototype._populateFactSummary = function(summaryDom) {
-    const totalFacts = this.summary.totalFacts();
-    $("<span></span>")
-            .text(totalFacts)
-            .appendTo(summaryDom.find(".total-facts-value"));
-}
-
-Inspector.prototype._populateTagSummary = function (summaryDom) {
-    const summaryTagsTableBody = summaryDom.find(".tag-summary-table-body");
-
-    const tagCounts = this.summary.tagCounts();
-
-    let totalPrimaryItemTags = 0;
-    let totalDimensionTags = 0;
-    let totalMemberTags = 0;
-    let totalTags = 0;
-    for (const counts of tagCounts.values()) {
-        totalPrimaryItemTags += counts[PRIMARY_ITEMS_KEY];
-        totalDimensionTags += counts[DIMENSIONS_KEY];
-        totalMemberTags += counts[MEMBERS_KEY];
-        totalTags += counts[TOTAL_KEY];
     }
 
-    function insertTagCount(row, count, total) {
-        let percent = 0;
-        if (total > 0) {
-            percent = count / total;
+    updateURLFragment() {
+        if (this._currentItem) {
+            location.hash = "#f-" + this._currentItem.id;
         }
-        let formattedPercent = percent.toLocaleString(undefined, {
-            style: "percent",
-        });
-        formattedPercent = ` (${formattedPercent})`;
+        else {
+            location.hash = "";
+        }
+    }
 
-        $("<td></td>")
-                .text(count)
-                .addClass("figure")
-                .append($("<sup></sup>").text(formattedPercent))
+    buildDisplayOptionsMenu() {
+        this._optionsMenu.reset();
+        if (this._report) {
+            const dl = this.selectDefaultLanguage();
+            this._optionsMenu.addCheckboxGroup(this._report.availableLanguages(), this._report.languageNames(), dl, (lang) => { this.setLanguage(lang); this.update() }, "select-language");
+            this.setLanguage(dl);
+            if (this._report.filingDocuments()) {
+                this._optionsMenu.addDownloadButton("Download filing documents", this._report.filingDocuments())
+            }
+        }
+        this._iv.callPluginMethod("extendDisplayOptionsMenu", this._optionsMenu);
+    }
+
+    buildToolbarHighlightMenu() {
+        this._toolbarMenu.reset();
+        this._toolbarMenu.addCheckboxItem(i18next.t("toolbar.xbrlElements"), (checked) => this.highlightAllTags(checked), "highlight-tags", null, this._iv.options.highlightTagsOnStartup);
+        this._iv.callPluginMethod("extendToolbarHighlightMenu", this._toolbarMenu);
+    }
+
+    buildHighlightKey() {
+        $(".highlight-key .items").empty();
+        const key = this._report.namespaceGroups();
+        this._iv.callPluginMethod("extendHighlightKey", key);
+
+        for (const [i, name] of key.entries()) {
+            $("<div>")
+                .addClass("item")
+                .append($("<span></span>").addClass("sample").addClass("sample-" + i))
+                .append($("<span></span>").text(name))
+                .appendTo($(".highlight-key .items"));
+        }
+    }
+
+    highlightAllTags(checked) {
+        this._viewer.highlightAllTags(checked, this._report.namespaceGroups());
+    }
+
+    factListRow(f) {
+        const row = $('<div class="fact-list-item"></div>')
+            .click(() => this.selectItem(f.id))
+            .dblclick(() => $('#inspector').removeClass("search-mode"))
+            .mousedown((e) => { 
+                /* Prevents text selection via double click without
+                 * disabling click+drag text selection (which user-select:
+                 * none would )
+                 */
+                if (e.detail > 1) { 
+                    e.preventDefault() 
+                } 
+            })
+            .mouseenter(() => this._viewer.linkedHighlightFact(f))
+            .mouseleave(() => this._viewer.clearLinkedHighlightFact(f))
+            .data('ivid', f.id);
+        $('<div class="select-icon"></div>')
+            .click(() => {
+                this.selectItem(f.id);
+                $('#inspector').removeClass("search-mode");
+            })
+            .appendTo(row)
+        $('<div class="title"></div>')
+            .text(f.getLabelOrName("std"))
+            .appendTo(row);
+        $('<div class="dimension"></div>')
+            .text(f.period().toString())
+            .appendTo(row);
+
+        for (const aspect of f.aspects()) {
+            if (aspect.isTaxonomyDefined() && !aspect.isNil()) {
+                $('<div class="dimension"></div>')
+                    .text(aspect.valueLabel())
+                    .appendTo(row);
+            }
+        }
+        if (f.isHidden()) {
+            $('<div class="hidden"></div>')
+                .text(i18next.t("search.hiddenFact"))
                 .appendTo(row);
+        }
+        else if (f.isHTMLHidden()) {
+            $('<div class="hidden"></div>')
+                .text(i18next.t("search.concealedFact"))
+                .appendTo(row);
+        }
+        return row;
     }
 
-    const sortedPrefixCounts = [...tagCounts.entries()].sort((a, b) => a[0].localeCompare(b[0]));
-    for (const [prefix, counts] of sortedPrefixCounts) {
-        const countRow = $("<tr></tr>").appendTo(summaryTagsTableBody);
-        countRow.append($("<th></th>").attr("scope", "row").text(prefix));
-        insertTagCount(countRow, counts[PRIMARY_ITEMS_KEY], totalPrimaryItemTags);
-        insertTagCount(countRow, counts[DIMENSIONS_KEY], totalDimensionTags);
-        insertTagCount(countRow, counts[MEMBERS_KEY], totalMemberTags);
-        insertTagCount(countRow, counts[TOTAL_KEY], totalTags);
+    addResults(container, results, offset) {
+        $('.more-results', container).remove();
+        for (var i = offset; i < results.length; i++ ) {
+            if (i - offset >= SEARCH_PAGE_SIZE) {
+                $('<div class="more-results"></div>')
+                    .text(i18next.t("search.showMoreResults"))
+                    .on('click', () => this.addResults(container, results, i))
+                    .appendTo(container);
+                break;
+            }
+            this.factListRow(results[i].fact).appendTo(container);
+        }
     }
 
-    const summaryTagsTableFooterRow = summaryDom.find(".tag-summary-table-footer-row");
+    searchSpec() {
+        const spec = {};
+        spec.searchString = $('#ixbrl-search').val();
+        spec.showVisibleFacts = $('#search-visible-fact-filter').prop('checked');
+        spec.showHiddenFacts = $('#search-hidden-fact-filter').prop('checked');
+        spec.namespacesFilter = $('#search-filter-namespaces select').val();
+        spec.unitsFilter = $('#search-filter-units select').val();
+        spec.scalesFilter = $('#search-filter-scales select').val();
+        spec.periodFilter = $('#search-filter-period select').val();
+        spec.conceptTypeFilter = $('#search-filter-concept-type').val();
+        spec.factValueFilter = $('#search-filter-fact-value').val();
+        spec.calculationsFilter = $('#search-filter-calculations select').val();
+        spec.dimensionTypeFilter = $('#search-filter-dimension-type select').val();
+        return spec;
+    }
 
-    insertTagCount(summaryTagsTableFooterRow, totalPrimaryItemTags, totalPrimaryItemTags);
-    insertTagCount(summaryTagsTableFooterRow, totalDimensionTags, totalDimensionTags);
-    insertTagCount(summaryTagsTableFooterRow, totalMemberTags, totalMemberTags);
-    insertTagCount(summaryTagsTableFooterRow, totalTags, totalTags);
-}
+    setupSearchControls(viewer) {
+        const inspector = this;
+        $('.search-controls input, .search-controls select').change(() => this.search());
+        $(".search-controls div.filter-toggle").click(() => $(".search-controls").toggleClass('show-filters'));
+        $(".search-controls .search-filters .reset").click(() => this.resetSearchFilters());
+        $(".search-controls .search-filters .reset-multiselect").on("click", function () {
+            $(this).siblings().children('select option:selected').prop('selected', false);
+            inspector.search();
+        });
+        for (const key of Object.keys(this._search.periods)) {
+            $("<option>")
+                .attr("value", key)
+                .text(this._search.periods[key])
+                .appendTo('#search-filter-period select');
+        }
+        for (const prefix of this._report.getUsedPrefixes()) {
+            $("<option>")
+                .attr("value", prefix)
+                .text(`${prefix} (${this._report.prefixMap()[prefix]})`)
+                .appendTo('#search-filter-namespaces select');
+        }
+        for (const unit of this._report.getUsedUnits()) {
+            $("<option>")
+                    .attr("value", unit)
+                    .text(`${this._report.getUnit(unit)?.label()} (${unit})`)
+                    .appendTo('#search-filter-units select');
+        }
+        const scalesOptions = this._getScalesOptions();
+        for (const scale of Object.keys(scalesOptions).sort()) {
+                $("<option>")
+                        .attr("value", scale)
+                        .text(scalesOptions[scale])
+                        .appendTo('#search-filter-scales select');
+        }
+    }
 
-Inspector.prototype._populateFileSummary = function (summaryDom) {
-    const {
-        inline,
-        schema,
-        calcLinkbase,
-        defLinkbase,
-        labelLinkbase,
-        presLinkbase,
-        refLinkbase,
-        unrecognizedLinkbase
-    } = this.summary.getLocalDocuments();
+    _getScalesOptions() {
+        const scalesOptions = {}
+        const usedScalesMap = this._report.getUsedScalesMap();
+        Object.keys(usedScalesMap).sort().forEach(scale => {
+            const labels = Array.from(usedScalesMap[scale]).sort();
+            if (labels.length > 0) {
+                scalesOptions[scale] = labels.join(', ');
+            }
+            else {
+                scalesOptions[scale] = scale.toString();
+            }
+        });
+        return scalesOptions;
+    }
 
-    const summaryFilesContent = summaryDom.find(".files-summary");
+    resetSearchFilters() {
+        $("#search-filter-period select option:selected").prop("selected", false);
+        $("#search-filter-concept-type").val("*");
+        $("#search-filter-fact-value").val("*");
+        $("#search-filter-calculations select option:selected").prop("selected", false);
+        $("#search-filter-dimension-type select option:selected").prop("selected", false);
+        $("#search-hidden-fact-filter").prop("checked", true);
+        $("#search-visible-fact-filter").prop("checked", true);
+        $("#search-filter-namespaces select option:selected").prop("selected", false);
+        $("#search-filter-units select option:selected").prop("selected", false);
+        $("#search-filter-scales select option:selected").prop("selected", false);
+        this.search();
+    }
 
-    function insertFileSummary(docs, classSelector) {
-        if (docs.length === 0) {
-            summaryFilesContent.find(classSelector).hide();
+    searchReady() {
+        this.setupSearchControls();
+        $('#inspector').addClass('search-ready');
+        $('#ixbrl-search').prop('disabled', false);
+        this.search();
+    }
+
+    search () {
+        const spec = this.searchSpec();
+        const results = this._search.search(spec);
+        if (results === undefined) {
+            return;
+        }
+        const container = $('#inspector .search-results .results');
+        $('div', container).remove();
+        this._viewer.clearRelatedHighlighting();
+        const overlay = $('#inspector .search-results .search-overlay');
+        if (results.length > 0) {
+            overlay.hide();
+            this.addResults(container, results, 0);
+        }
+        else {
+            $(".title", overlay).text(i18next.t("search.noMatchFound"));
+            $(".text", overlay).text(i18next.t("search.tryAgainDifferentKeywords"));
+            overlay.show();
+        }
+        $("#matching-concepts-count").text(results.length);
+        /* Don't highlight search results if there's no search string */
+        if (spec.searchString != "") {
+            this._viewer.highlightRelatedFacts(results.map(r => r.fact));
+        }
+        this.updateMultiSelectSubheader('search-filter-scales');
+        this.updateMultiSelectSubheader('search-filter-units');
+        this.updateMultiSelectSubheader('search-filter-namespaces');
+        this.updateMultiSelectSubheader('search-filter-dimension-type');
+        this.updateMultiSelectSubheader('search-filter-calculations');
+        this.updateMultiSelectSubheader('search-filter-period');
+    }
+
+    updateMultiSelectSubheader(id) {
+        const subheader = $(`#${id} .collapsible-subheader`);
+        const selectedOptions = $(`#${id} select option:selected`);
+        if (selectedOptions.length === 1) {
+            subheader.text(` ${selectedOptions.text()}`);
+        }
+        else if (selectedOptions.length > 0) {
+            const totalOptions = $(`#${id} select option`).length;
+            subheader.text(` (${selectedOptions.length}/${totalOptions} ${i18next.t("search.selected")})`)
         } else {
-            const ul = summaryFilesContent.find(classSelector + ' ul')
-            for (const doc of docs) {
-                ul.append($("<li></li>").text(doc));
+            subheader.empty();
+        }
+    }
+
+    updateCalculation(fact, elr) {
+        $('.calculations .tree').empty().append(this._calculationHTML(fact, elr));
+    }
+
+    createSummary() {
+        const summaryDom = $("#inspector .summary .body");
+        this._populateFactSummary(summaryDom);
+        this._populateTagSummary(summaryDom);
+        this._populateFileSummary(summaryDom);
+    }
+
+    _populateFactSummary(summaryDom) {
+        const totalFacts = this.summary.totalFacts();
+        $("<span></span>")
+                .text(totalFacts)
+                .appendTo(summaryDom.find(".total-facts-value"));
+    }
+
+    _populateTagSummary(summaryDom) {
+        const summaryTagsTableBody = summaryDom.find(".tag-summary-table-body");
+
+        const tagCounts = this.summary.tagCounts();
+
+        let totalPrimaryItemTags = 0;
+        let totalDimensionTags = 0;
+        let totalMemberTags = 0;
+        let totalTags = 0;
+        for (const counts of tagCounts.values()) {
+            totalPrimaryItemTags += counts[PRIMARY_ITEMS_KEY];
+            totalDimensionTags += counts[DIMENSIONS_KEY];
+            totalMemberTags += counts[MEMBERS_KEY];
+            totalTags += counts[TOTAL_KEY];
+        }
+
+        function insertTagCount(row, count, total) {
+            let percent = 0;
+            if (total > 0) {
+                percent = count / total;
+            }
+            let formattedPercent = percent.toLocaleString(undefined, {
+                style: "percent",
+            });
+            formattedPercent = ` (${formattedPercent})`;
+
+            $("<td></td>")
+                    .text(count)
+                    .addClass("figure")
+                    .append($("<sup></sup>").text(formattedPercent))
+                    .appendTo(row);
+        }
+
+        const sortedPrefixCounts = [...tagCounts.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+        for (const [prefix, counts] of sortedPrefixCounts) {
+            const countRow = $("<tr></tr>").appendTo(summaryTagsTableBody);
+            countRow.append($("<th></th>").attr("scope", "row").text(prefix));
+            insertTagCount(countRow, counts[PRIMARY_ITEMS_KEY], totalPrimaryItemTags);
+            insertTagCount(countRow, counts[DIMENSIONS_KEY], totalDimensionTags);
+            insertTagCount(countRow, counts[MEMBERS_KEY], totalMemberTags);
+            insertTagCount(countRow, counts[TOTAL_KEY], totalTags);
+        }
+
+        const summaryTagsTableFooterRow = summaryDom.find(".tag-summary-table-footer-row");
+
+        insertTagCount(summaryTagsTableFooterRow, totalPrimaryItemTags, totalPrimaryItemTags);
+        insertTagCount(summaryTagsTableFooterRow, totalDimensionTags, totalDimensionTags);
+        insertTagCount(summaryTagsTableFooterRow, totalMemberTags, totalMemberTags);
+        insertTagCount(summaryTagsTableFooterRow, totalTags, totalTags);
+    }
+
+    _populateFileSummary(summaryDom) {
+        const {
+            inline,
+            schema,
+            calcLinkbase,
+            defLinkbase,
+            labelLinkbase,
+            presLinkbase,
+            refLinkbase,
+            unrecognizedLinkbase
+        } = this.summary.getLocalDocuments();
+
+        const summaryFilesContent = summaryDom.find(".files-summary");
+
+        function insertFileSummary(docs, classSelector) {
+            if (docs.length === 0) {
+                summaryFilesContent.find(classSelector).hide();
+            } else {
+                const ul = summaryFilesContent.find(classSelector + ' ul')
+                for (const doc of docs) {
+                    ul.append($("<li></li>").text(doc));
+                }
+            }
+        }
+
+        insertFileSummary(inline, ".inline-docs");
+        insertFileSummary(schema, ".schemas");
+        insertFileSummary(presLinkbase, ".pres-links");
+        insertFileSummary(calcLinkbase, ".calc-links");
+        insertFileSummary(defLinkbase, ".def-links");
+        insertFileSummary(labelLinkbase, ".label-links");
+        insertFileSummary(refLinkbase, ".ref-links");
+        insertFileSummary(unrecognizedLinkbase, ".other-links");
+    };
+
+    createOutline() {
+        if (this.outline.hasOutline()) {
+            $('.outline .no-outline-overlay').hide();
+            const container = $('<div class="fact-list"></div>').appendTo($('.outline .body'));
+            for (const elr of this.outline.sortedSections()) {
+                $('<div class="fact-list-item"></div>')
+                    .text(this._report.getRoleLabel(elr))
+                    .click(() => this.selectItem(this.outline.sections[elr].id))
+                    .dblclick(() => $('#inspector').removeClass("outline-mode"))
+                    .mousedown((e) => {
+                        // Prevent text selection by double click
+                        if (e.detail > 1) { 
+                            e.preventDefault() 
+                        } 
+                    })
+                    .appendTo(container);
             }
         }
     }
 
-    insertFileSummary(inline, ".inline-docs");
-    insertFileSummary(schema, ".schemas");
-    insertFileSummary(presLinkbase, ".pres-links");
-    insertFileSummary(calcLinkbase, ".calc-links");
-    insertFileSummary(defLinkbase, ".def-links");
-    insertFileSummary(labelLinkbase, ".label-links");
-    insertFileSummary(refLinkbase, ".ref-links");
-    insertFileSummary(unrecognizedLinkbase, ".other-links");
-};
-
-Inspector.prototype.createOutline = function () {
-    if (this.outline.hasOutline()) {
-        $('.outline .no-outline-overlay').hide();
-        var container = $('<div class="fact-list"></div>').appendTo($('.outline .body'));
-        for (const elr of this.outline.sortedSections()) {
+    updateOutline(cf) {
+        $('.fact-groups').empty();
+        for (const elr of this.outline.groupsForFact(cf)) {
             $('<div class="fact-list-item"></div>')
                 .text(this._report.getRoleLabel(elr))
                 .click(() => this.selectItem(this.outline.sections[elr].id))
-                .dblclick(() => $('#inspector').removeClass("outline-mode"))
-                .mousedown((e) => {
-                    // Prevent text selection by double click
-                    if (e.detail > 1) { 
-                        e.preventDefault() 
-                    } 
-                })
-                .appendTo(container);
+                .appendTo($('.fact-groups'));
+        }
+
+    }
+
+    updateFootnotes(fact) {
+        // Outbound fact->footnote and fact->fact links
+        $('.footnotes').empty().append(this._footnotesHTML(fact));
+
+        // Inbound fact->fact footnote links.  Not widely used, so only show the
+        // section if we have some. 
+        if (fact.linkedFacts.length > 0) {
+            $('#inspector .footnote-facts-section')
+                .show()
+                .find('.footnote-facts')
+                .empty()
+                .append(this._footnoteFactsHTML(fact));
+        }
+        else {
+            $('#inspector .footnote-facts-section').hide();
         }
     }
-}
-
-Inspector.prototype.updateOutline = function (cf) {
-    $('.fact-groups').empty();
-    for (const elr of this.outline.groupsForFact(cf)) {
-        $('<div class="fact-list-item"></div>')
-            .text(this._report.getRoleLabel(elr))
-            .click(() => this.selectItem(this.outline.sections[elr].id))
-            .appendTo($('.fact-groups'));
-    }
-
-}
-
-Inspector.prototype.updateFootnotes = function (fact) {
-    // Outbound fact->footnote and fact->fact links
-    $('.footnotes').empty().append(this._footnotesHTML(fact));
-
-    // Inbound fact->fact footnote links.  Not widely used, so only show the
-    // section if we have some. 
-    if (fact.linkedFacts.length > 0) {
-        $('#inspector .footnote-facts-section')
-            .show()
-            .find('.footnote-facts')
-            .empty()
-            .append(this._footnoteFactsHTML(fact));
-    }
-    else {
-        $('#inspector .footnote-facts-section').hide();
-    }
-}
 
 
-Inspector.prototype._anchorList = function (fact, anchors) {
-    var html = $("<ul></ul>");
-    if (anchors.length > 0) {
-        for (const c of anchors) {
-            const otherFacts = this._report.getAlignedFacts(fact, { "c": c });
-            const label = this._report.getLabel(c, "std", true);
+    _anchorList(fact, anchors) {
+        const html = $("<ul></ul>");
+        if (anchors.length > 0) {
+            for (const c of anchors) {
+                const otherFacts = this._report.getAlignedFacts(fact, { "c": c });
+                const label = this._report.getLabel(c, "std", true);
 
-            $("<li></li>")
-                .appendTo(html)
-                .append(this.factLinkHTML(label, otherFacts));
+                $("<li></li>")
+                    .appendTo(html)
+                    .append(this.factLinkHTML(label, otherFacts));
+            }
         }
-    }
-    else {
-        $('<li></li>')
-            .append($('<i></i>').text(i18next.t("common.none")))
-            .appendTo(html);
-    }
-    return html;
-}
-
-Inspector.prototype.updateAnchoring = function (fact) {
-    if (!this._report.usesAnchoring()) {
-        $('.anchoring').hide();
-    }
-    else {
-        $('.anchoring').show();
-
-        $('.anchoring .collapsible-body .anchors-wider')
-            .empty()
-            .append(this._anchorList(fact, fact.widerConcepts()));
-
-        $('.anchoring .collapsible-body .anchors-narrower')
-            .empty()
-            .append(this._anchorList(fact, fact.narrowerConcepts()));
-    }
-
-}
-
-Inspector.prototype._referencesHTML = function (fact) {
-    var c = fact.concept();
-    var a = new Accordian();
-    $.each(fact.concept().references(), function (i,r) {
-        var title = $("<span></span>").text(r[0].value);
-        var body =  $('<table class="fact-properties"><tbody></tbody></table>')
-        var tbody = body.find("tbody");
-        $.each(r, function (j,p) {
-            var row = $("<tr>")
-                .append($("<th></th>").text(i18next.t(`referenceParts:${p.part}`, {defaultValue: p.part})))
-                .append($("<td></td>").text(p.value))
-                .appendTo(tbody);
-            if (p.part == 'URI') {
-                row.addClass("uri");
-                row.find("td").wrapInner($("<a>").attr("href",p.value));
-            }
-        });
-        a.addCard(title, body, i == 0);
-    });
-    return a.contents();
-}
-
-Inspector.prototype._calculationHTML = function (fact, elr) {
-    var calc = new Calculation(fact);
-    if (!calc.hasCalculations()) {
-        return "";
-    }
-    var tableFacts = this._viewer.factsInSameTable(fact);
-    if (!elr) {
-        elr = calc.bestELRForFactSet(tableFacts);
-    }
-    var report = this._report;
-    var viewer = this._viewer;
-    var inspector = this;
-    var a = new Accordian();
-
-    $.each(calc.elrs(), function (e, rolePrefix) {
-        var label = report.getRoleLabel(rolePrefix, inspector._viewerOptions);
-
-        var rCalc = calc.resolvedCalculation(e);
-        var calcBody = $('<div></div>');
-        $.each(rCalc, function (i, r) {
-            var itemHTML = $("<div></div>")
-                .addClass("item")
-                .append($("<span></span>").addClass("weight").text(r.weightSign + " "))
-                .append($("<span></span>").addClass("concept-name").text(report.getLabelOrName(r.concept, "std")))
-                .appendTo(calcBody);
-
-            if (r.facts) {
-                itemHTML.addClass("calc-fact-link");
-                itemHTML.data('ivid', r.facts);
-                itemHTML.click(function () { inspector.selectItem(Object.values(r.facts)[0].id ) });
-                itemHTML.mouseenter(function () { $.each(r.facts, function (k,f) { viewer.linkedHighlightFact(f); })});
-                itemHTML.mouseleave(function () { $.each(r.facts, function (k,f) { viewer.clearLinkedHighlightFact(f); })});
-                $.each(r.facts, function (k,f) { viewer.highlightRelatedFact(f); });
-            }
-        });
-        $("<div></div>").addClass("item").addClass("total")
-            .append($("<span></span>").addClass("weight"))
-            .append($("<span></span>").addClass("concept-name").text(fact.getLabelOrName("std")))
-            .appendTo(calcBody);
-
-        a.addCard($("<span></span>").text(label), calcBody, e == elr);
-
-    });
-    return a.contents();
-}
-
-Inspector.prototype._footnotesHTML = function (fact) {
-    var html = $("<div></div>").addClass("fact-list");
-    $.each(fact.footnotes(), (n, fn) => {
-        if (fn instanceof Footnote) {
-            $("<div></div>")
-                .addClass("block-list-item")
-                .text(truncateLabel(fn.textContent(), 120))
-                .mouseenter(() => this._viewer.linkedHighlightFact(fn))
-                .mouseleave(() => this._viewer.clearLinkedHighlightFact(fn))
-                .click(() => this.selectItem(fn.id))
+        else {
+            $('<li></li>')
+                .append($('<i></i>').text(i18next.t("common.none")))
                 .appendTo(html);
         }
-        else if (fn instanceof Fact) {
-            html.append(this.factListRow(fn));
-        }
-    });
-    return html;
-}
+        return html;
+    }
 
-Inspector.prototype.viewerMouseEnter = function (id) {
-    $('.calculations .item').filter(function () {   
-        return $.inArray(id, $.map($(this).data('ivid'), f => f.id )) > -1 
-    }).addClass('linked-highlight');
-    $('#inspector .search .results tr').filter(function () {   
-        return $(this).data('ivid') == id;
-    }).addClass('linked-highlight');
-}
-
-Inspector.prototype.viewerMouseLeave = function (id) {
-    $('.calculations .item').removeClass('linked-highlight');
-    $('#inspector .search .results tr').removeClass('linked-highlight');
-}
-
-Inspector.prototype.describeChange = function (oldFact, newFact) {
-    if (newFact.value() > 0 == oldFact.value() > 0 && Math.abs(oldFact.value()) + Math.abs(newFact.value()) > 0) {
-        var x = (newFact.value() - oldFact.value()) * 100 / oldFact.value();
-        var t;
-        if (x >= 0) {
-            t = i18next.t('factDetails.changePercentageIncrease', { increase: formatNumber(x,1)});
+    updateAnchoring(fact) {
+        if (!this._report.usesAnchoring()) {
+            $('.anchoring').hide();
         }
         else {
-            t = i18next.t('factDetails.changePercentageDecrease', { decrease: formatNumber(-1 * x,1)});
+            $('.anchoring').show();
+
+            $('.anchoring .collapsible-body .anchors-wider')
+                .empty()
+                .append(this._anchorList(fact, fact.widerConcepts()));
+
+            $('.anchoring .collapsible-body .anchors-narrower')
+                .empty()
+                .append(this._anchorList(fact, fact.narrowerConcepts()));
         }
-        return t;
-    }
-    else {
-        return i18next.t('factDetails.changeFromIn', { from: oldFact.readableValue()}); 
-    }
-}
 
-Inspector.prototype.factLinkHTML = function (label, factList) {
-    var html = $("<span></span>").text(label);
-    if (factList.length > 0) {
-        html
-        .addClass("fact-link")
-        .click(() => this.selectItem(factList[0].id))
-        .mouseenter(() => $.each(factList, (i,f) => this._viewer.linkedHighlightFact(f)))
-        .mouseleave(() => $.each(factList, (i,f) => this._viewer.clearLinkedHighlightFact(f)));
     }
-    return html;
-}
 
-Inspector.prototype.getPeriodIncrease = function (fact) {
-    var viewer = this._viewer;
-    var inspector = this;
-    if (fact.isNumeric()) {
-        var otherFacts = this._report.getAlignedFacts(fact, {"p":null });
-        var mostRecent;
-        if (fact.periodTo()) {
-            $.each(otherFacts, function (i, of) {
-                if (of.periodTo() && of.periodTo() < fact.periodTo() && (!mostRecent || of.periodTo() > mostRecent.periodTo()) && fact.isEquivalentDuration(of)) {
-                    mostRecent = of;
+    _referencesHTML(fact) {
+        const c = fact.concept();
+        const a = new Accordian();
+        for (const [i, r] of fact.concept().references().entries()) {
+            const title = $("<span></span>").text(r[0].value);
+            const body =  $('<table class="fact-properties"><tbody></tbody></table>')
+            const tbody = body.find("tbody");
+            for (const p of r) {
+                const row = $("<tr>")
+                    .append($("<th></th>").text(i18next.t(`referenceParts:${p.part}`, {defaultValue: p.part})))
+                    .append($("<td></td>").text(p.value))
+                    .appendTo(tbody);
+                if (p.part == 'URI') {
+                    row.addClass("uri");
+                    row.find("td").wrapInner($("<a>").attr("href", p.value));
                 }
-            });
+            }
+            a.addCard(title, body, i == 0);
         }
-        var s = "";
-        if (mostRecent) {
-            var allMostRecent = this._report.getAlignedFacts(mostRecent);
-            s = $("<span></span>")
-                    .text(this.describeChange(mostRecent, fact))
-                    .append(this.factLinkHTML(mostRecent.periodString(), allMostRecent));
+        return a.contents();
+    }
 
+    _calculationHTML(fact, elr) {
+        const calc = new Calculation(fact);
+        if (!calc.hasCalculations()) {
+            return "";
+        }
+        const tableFacts = this._viewer.factsInSameTable(fact);
+        if (!elr) {
+            elr = calc.bestELRForFactSet(tableFacts);
+        }
+        const report = this._report;
+        const inspector = this;
+        const a = new Accordian();
+
+        for (const [e, rolePrefix] of Object.entries(calc.elrs())) {
+            const label = report.getRoleLabel(rolePrefix, inspector._viewerOptions);
+
+            const rCalc = calc.resolvedCalculation(e);
+            const calcBody = $('<div></div>');
+            for (const [i, r] of rCalc.entries()) {
+                const itemHTML = $("<div></div>")
+                    .addClass("item")
+                    .append($("<span></span>").addClass("weight").text(r.weightSign + " "))
+                    .append($("<span></span>").addClass("concept-name").text(report.getLabelOrName(r.concept, "std")))
+                    .appendTo(calcBody);
+
+                if (r.facts) {
+                    itemHTML.addClass("calc-fact-link");
+                    itemHTML.data('ivid', r.facts);
+                    itemHTML.click(() => inspector.selectItem(Object.values(r.facts)[0].id));
+                    itemHTML.mouseenter(() => Object.values(r.facts).forEach(f => this._viewer.linkedHighlightFact(f)));
+                    itemHTML.mouseleave(() => Object.values(r.facts).forEach(f => this._viewer.clearLinkedHighlightFact(f)));
+                    Object.values(r.facts).forEach(f => this._viewer.highlightRelatedFact(f));
+                }
+            }
+            $("<div></div>").addClass("item").addClass("total")
+                .append($("<span></span>").addClass("weight"))
+                .append($("<span></span>").addClass("concept-name").text(fact.getLabelOrName("std")))
+                .appendTo(calcBody);
+
+            a.addCard($("<span></span>").text(label), calcBody, e == elr);
+
+        }
+        return a.contents();
+    }
+
+    _footnotesHTML(fact) {
+        const html = $("<div></div>").addClass("fact-list");
+        for (const fn of fact.footnotes()) {
+            if (fn instanceof Footnote) {
+                $("<div></div>")
+                    .addClass("block-list-item")
+                    .text(truncateLabel(fn.textContent(), 120))
+                    .mouseenter(() => this._viewer.linkedHighlightFact(fn))
+                    .mouseleave(() => this._viewer.clearLinkedHighlightFact(fn))
+                    .click(() => this.selectItem(fn.id))
+                    .appendTo(html);
+            }
+            else if (fn instanceof Fact) {
+                html.append(this.factListRow(fn));
+            }
+        }
+        return html;
+    }
+
+    viewerMouseEnter(id) {
+        $('.calculations .item')
+            .filter((i, e) => Object.keys($(e).data('ivid') ?? {}).includes(id))
+            .addClass('linked-highlight');
+        $('#inspector .search .results tr')
+            .filter((i, e) => $(e).data('ivid') == id)
+            .addClass('linked-highlight');
+    }
+
+    viewerMouseLeave(id) {
+        $('.calculations .item').removeClass('linked-highlight');
+        $('#inspector .search .results tr').removeClass('linked-highlight');
+    }
+
+    describeChange(oldFact, newFact) {
+        if (newFact.value() > 0 == oldFact.value() > 0 && Math.abs(oldFact.value()) + Math.abs(newFact.value()) > 0) {
+            const x = (newFact.value() - oldFact.value()) * 100 / oldFact.value();
+            let t = 0;
+            if (x >= 0) {
+                t = i18next.t('factDetails.changePercentageIncrease', { increase: formatNumber(x,1)});
+            }
+            else {
+                t = i18next.t('factDetails.changePercentageDecrease', { decrease: formatNumber(-1 * x,1)});
+            }
+            return t;
         }
         else {
-            s = $("<i>").text(i18next.t('factDetails.noPriorFactInThisReport'));
+            return i18next.t('factDetails.changeFromIn', { from: oldFact.readableValue()}); 
         }
     }
-    else {
-        s = $("<i>").text("n/a").attr("title", "non-numeric fact");
+
+    factLinkHTML(label, factList) {
+        const html = $("<span></span>").text(label);
+        if (factList.length > 0) {
+            html
+            .addClass("fact-link")
+            .click(() => this.selectItem(factList[0].id))
+            .mouseenter(() => factList.forEach(f => this._viewer.linkedHighlightFact(f)))
+            .mouseleave(() => factList.forEach(f => this._viewer.clearLinkedHighlightFact(f)));
+        }
+        return html;
     }
-    $(".fact-properties tr.change td").html(s);
 
-}
+    getPeriodIncrease(fact) {
+        let s = "";
+        if (fact.isNumeric()) {
+            const otherFacts = this._report.getAlignedFacts(fact, {"p":null });
+            var mostRecent;
+            if (fact.periodTo()) {
+                for (const other of otherFacts) {
+                    if (other.periodTo() && other.periodTo() < fact.periodTo() && (!mostRecent || other.periodTo() > mostRecent.periodTo()) && fact.isEquivalentDuration(other)) {
+                        mostRecent = other;
+                    }
+                }
+            }
+            if (mostRecent) {
+                const allMostRecent = this._report.getAlignedFacts(mostRecent);
+                s = $("<span></span>")
+                        .text(this.describeChange(mostRecent, fact))
+                        .append(this.factLinkHTML(mostRecent.periodString(), allMostRecent));
 
-Inspector.prototype._updateValue = function (item, showAll, context) {
-    const text = item.readableValue();
-    const tr = $('tr.value', context);
-    var v = text;
-    if (!showAll) {
-        var fullLabel = text;
-        var vv = wrapLabel(text, 120);
-        if (vv.length > 1) {
-            tr.addClass("truncated");
-            tr.find('.show-all')
-                .off('click')
-                .on('click', () => this._updateValue(item, true, context));
+            }
+            else {
+                s = $("<i>").text(i18next.t('factDetails.noPriorFactInThisReport'));
+            }
+        }
+        else {
+            s = $("<i>").text("n/a").attr("title", "non-numeric fact");
+        }
+        $(".fact-properties tr.change td").html(s);
+
+    }
+
+    _updateValue(item, showAll, context) {
+        const text = item.readableValue();
+        const tr = $('tr.value', context);
+        let v = text;
+        if (!showAll) {
+            const vv = wrapLabel(text, 120);
+            if (vv.length > 1) {
+                tr.addClass("truncated");
+                tr.find('.show-all')
+                    .off('click')
+                    .on('click', () => this._updateValue(item, true, context));
+            }
+            else {
+                tr.removeClass('truncated');
+            }
+            v = vv[0];
         }
         else {
             tr.removeClass('truncated');
         }
-        v = vv[0];
-    }
-    else {
-        tr.removeClass('truncated');
-    }
 
-    // Only enable text block viewer for escaped, text block facts.  This
-    // ensure that we're only rendering fragments of the main documents, rather
-    // than potentially arbitrary strings.
-    if (TextBlockViewerDialog.canRender(item)) {
-        tr
-            .addClass('text-block')
-            .find('.expand-text-block')
-                .off().click(() => this.showTextBlock(item));
-    }
-    else {
-        tr.removeClass('text-block');
-    }
-
-    var valueSpan = tr.find('td .value').empty().text(v);
-    if (item instanceof Fact && (item.isNil() || item.isInvalidIXValue())) {
-        valueSpan.wrapInner("<i></i>");
-    }
-
-}
-
-Inspector.prototype.showTextBlock = function(item) {
-    const tbd = new TextBlockViewerDialog(item);
-    tbd.displayTextBlock();
-    tbd.show();
-}
-
-Inspector.prototype._updateEntityIdentifier = function (fact, context) {
-    const cell = $('tr.entity-identifier td', context);
-    cell.empty();
-    const url = Identifiers.identifierURLForFact(fact);
-    const name = Identifiers.identifierNameForFact(fact);
-    if (fact !== undefined) {
-        $('<span></span>').text('['+Identifiers.identifierNameForFact(fact) + "] ").appendTo(cell)
-        if (url !== undefined) {
-            $('<a target="_blank"></a>').attr('href',url).text(fact.identifier().localname).appendTo(cell)
+        // Only enable text block viewer for escaped, text block facts.  This
+        // ensure that we're only rendering fragments of the main documents, rather
+        // than potentially arbitrary strings.
+        if (TextBlockViewerDialog.canRender(item)) {
+            tr
+                .addClass('text-block')
+                .find('.expand-text-block')
+                    .off().click(() => this.showTextBlock(item));
         }
         else {
-            $('<span></span>').text(fact.identifier().localname).appendTo(cell);
+            tr.removeClass('text-block');
+        }
+
+        const valueSpan = tr.find('td .value').empty().text(v);
+        if (item instanceof Fact && (item.isNil() || item.isInvalidIXValue())) {
+            valueSpan.wrapInner("<i></i>");
+        }
+
+    }
+
+    showTextBlock(item) {
+        const tbd = new TextBlockViewerDialog(item);
+        tbd.displayTextBlock();
+        tbd.show();
+    }
+
+    _updateEntityIdentifier(fact, context) {
+        const cell = $('tr.entity-identifier td', context);
+        cell.empty();
+        const url = Identifiers.identifierURLForFact(fact);
+        const name = Identifiers.identifierNameForFact(fact);
+        if (name !== undefined) {
+            $('<span></span>').text('[' + name + "] ").appendTo(cell)
+            if (url !== undefined) {
+                $('<a target="_blank"></a>').attr('href',url).text(fact.identifier().localname).appendTo(cell)
+            }
+            else {
+                $('<span></span>').text(fact.identifier().localname).appendTo(cell);
+            }
+        }
+        else {
+            cell.text(fact.f.a.e);
         }
     }
-    else {
-        cell.text(fact.f.a.e);
+
+    _footnoteFactsHTML(fact) {
+        const html = $('<div></div>');
+        fact.linkedFacts.forEach((linkedFact) =>  {
+            html.append(this.factListRow(linkedFact));
+        });
+        return html;
     }
-}
 
-Inspector.prototype._footnoteFactsHTML = function(fact) {
-    var html = $('<div></div>');
-    fact.linkedFacts.forEach((linkedFact) =>  {
-        html.append(this.factListRow(linkedFact));
-    });
-    return html;
-}
+    /* 
+     * Build an accordian containing a summary of all nested facts/footnotes
+     * corresponding to the current viewer selection.
+     */
+    _selectionSummaryAccordian() {
+        const cf = this._currentItem;
 
-/* 
- * Build an accordian containing a summary of all nested facts/footnotes
- * corresponding to the current viewer selection.
- */
-Inspector.prototype._selectionSummaryAccordian = function() {
-    var cf = this._currentItem;
+        // dissolveSingle => title not shown if only one item in accordian
+        const a = new Accordian({
+            onSelect: (id) => this.switchItem(id),
+            alwaysOpen: true,
+            dissolveSingle: true,
+        });
 
-    // dissolveSingle => title not shown if only one item in accordian
-    var a = new Accordian({
-        onSelect: (id) => this.switchItem(id),
-        alwaysOpen: true,
-        dissolveSingle: true,
-    });
-
-    var fs = new FactSet(this._currentItemList);
-    $.each(this._currentItemList, (i, fact) => {
-        var factHTML;
-        var title = fs.minimallyUniqueLabel(fact);
-        if (fact instanceof Fact) {
-            factHTML = $(require('../html/fact-details.html')); 
-            $('.std-label', factHTML).text(fact.getLabelOrName("std", true));
-            $('.documentation', factHTML).text(fact.getLabel("doc") || "");
-            $('tr.concept td', factHTML)
-                .find('.text')
-                    .text(fact.conceptName())
-                    .attr("title", fact.conceptName())
-                .end()
-                .find('.clipboard-copy')
-                    .data('cb-text', fact.conceptName())
-                .end();
-            $('tr.period td', factHTML)
-                .text(fact.periodString());
-            if (fact.isNumeric()) {
-                $('tr.period td', factHTML).append(
-                    $("<span></span>") 
-                        .addClass("analyse")
-                        .text("")
-                        .click(() => this.analyseDimension(fact, ["p"]))
-                );
-            }
-            this._updateEntityIdentifier(fact, factHTML);
-            this._updateValue(fact, false, factHTML);
-
-            var accuracyTD = $('tr.accuracy td', factHTML).empty().append(fact.readableAccuracy());
-            if (!fact.isNumeric() || fact.isNil()) {
-                accuracyTD.wrapInner("<i></i>");
-            }
-
-            var scaleTD = $('tr.scale td', factHTML).empty().append(fact.readableScale());
-            if (!fact.isNumeric() || fact.isNil()) {
-                scaleTD.wrapInner("<i></i>");
-            }
-
-            $('#dimensions', factHTML).empty();
-            const taxonomyDefinedAspects = fact.aspects().filter(a => a.isTaxonomyDefined());
-            if (taxonomyDefinedAspects.length === 0) {
-                $('#dimensions-label', factHTML).hide();
-            }
-            for (const aspect of taxonomyDefinedAspects) {
-                var h = $('<div class="dimension"></div>')
-                    .text(aspect.label() || aspect.name())
-                    .appendTo($('#dimensions', factHTML));
+        const fs = new FactSet(this._currentItemList);
+        for (const fact of this._currentItemList) {
+            let factHTML;
+            const title = fs.minimallyUniqueLabel(fact);
+            if (fact instanceof Fact) {
+                factHTML = $(require('../html/fact-details.html')); 
+                $('.std-label', factHTML).text(fact.getLabelOrName("std", true));
+                $('.documentation', factHTML).text(fact.getLabel("doc") || "");
+                $('tr.concept td', factHTML)
+                    .find('.text')
+                        .text(fact.conceptName())
+                        .attr("title", fact.conceptName())
+                    .end()
+                    .find('.clipboard-copy')
+                        .data('cb-text', fact.conceptName())
+                    .end();
+                $('tr.period td', factHTML)
+                    .text(fact.periodString());
                 if (fact.isNumeric()) {
-                    h.append(
+                    $('tr.period td', factHTML).append(
                         $("<span></span>") 
                             .addClass("analyse")
                             .text("")
-                            .on("click", () => this.analyseDimension(fact, [aspect.name()]))
-                    )
+                            .click(() => this.analyseDimension(fact, ["p"]))
+                    );
                 }
-                var s = $('<div class="dimension-value"></div>')
-                    .text(aspect.valueLabel())
-                    .appendTo(h);
-                if (aspect.isNil()) {
-                    s.wrapInner("<i></i>");
+                this._updateEntityIdentifier(fact, factHTML);
+                this._updateValue(fact, false, factHTML);
+
+                const accuracyTD = $('tr.accuracy td', factHTML).empty().append(fact.readableAccuracy());
+                if (!fact.isNumeric() || fact.isNil()) {
+                    accuracyTD.wrapInner("<i></i>");
+                }
+
+                const scaleTD = $('tr.scale td', factHTML).empty().append(fact.readableScale());
+                if (!fact.isNumeric() || fact.isNil()) {
+                    scaleTD.wrapInner("<i></i>");
+                }
+
+                $('#dimensions', factHTML).empty();
+                const taxonomyDefinedAspects = fact.aspects().filter(a => a.isTaxonomyDefined());
+                if (taxonomyDefinedAspects.length === 0) {
+                    $('#dimensions-label', factHTML).hide();
+                }
+                for (const aspect of taxonomyDefinedAspects) {
+                    const h = $('<div class="dimension"></div>')
+                        .text(aspect.label() || aspect.name())
+                        .appendTo($('#dimensions', factHTML));
+                    if (fact.isNumeric()) {
+                        h.append(
+                            $("<span></span>") 
+                                .addClass("analyse")
+                                .text("")
+                                .on("click", () => this.analyseDimension(fact, [aspect.name()]))
+                        )
+                    }
+                    const s = $('<div class="dimension-value"></div>')
+                        .text(aspect.valueLabel())
+                        .appendTo(h);
+                    if (aspect.isNil()) {
+                        s.wrapInner("<i></i>");
+                    }
                 }
             }
+            else if (fact instanceof Footnote) {
+                factHTML = $(require('../html/footnote-details.html')); 
+                this._updateValue(fact, false, factHTML);
+            }
+            a.addCard(
+                title,
+                factHTML, 
+                fact.id == cf.id,
+                fact.id
+            );
         }
-        else if (fact instanceof Footnote) {
-            factHTML = $(require('../html/footnote-details.html')); 
-            this._updateValue(fact, false, factHTML);
-        }
-        a.addCard(
-            title,
-            factHTML, 
-            fact.id == cf.id,
-            fact.id
-        );
-    });
-    return a;
-}
+        return a;
+    }
 
-Inspector.prototype.analyseDimension = function(fact, dimensions) {
-    var chart = new IXBRLChart();
-    chart.analyseDimension(fact, dimensions);
-}
+    analyseDimension(fact, dimensions) {
+        const chart = new IXBRLChart();
+        chart.analyseDimension(fact, dimensions);
+    }
 
-Inspector.prototype.update = function () {
-    var inspector = this;
-    var cf = inspector._currentItem;
-    if (!cf) {
-        $('#inspector').removeClass('footnote-mode');
-        $('#inspector').addClass('no-fact-selected');
-    } 
-    else { 
-        $('#inspector').removeClass('no-fact-selected').removeClass("hidden-fact").removeClass("html-hidden-fact");
-
-        $('#inspector .fact-inspector')
-            .empty()
-            .append(this._selectionSummaryAccordian().contents());
-
-        if (cf instanceof Fact) {
+    update() {
+        const inspector = this;
+        const cf = inspector._currentItem;
+        if (!cf) {
             $('#inspector').removeClass('footnote-mode');
+            $('#inspector').addClass('no-fact-selected');
+        } 
+        else { 
+            $('#inspector').removeClass('no-fact-selected').removeClass("hidden-fact").removeClass("html-hidden-fact");
 
-            this.updateCalculation(cf);
-            this.updateOutline(cf);
-            this.updateFootnotes(cf);
-            this.updateAnchoring(cf);
-            $('div.references').empty().append(this._referencesHTML(cf));
-            $('#inspector .search-results .fact-list-item').removeClass('selected');
-            $('#inspector .search-results .fact-list-item').filter(function () { return $(this).data('ivid') == cf.id }).addClass('selected');
+            $('#inspector .fact-inspector')
+                .empty()
+                .append(this._selectionSummaryAccordian().contents());
 
-            var duplicates = cf.duplicates();
-            var n = 0;
-            var ndup = duplicates.length;
-            for (var i = 0; i < ndup; i++) {
-                if (cf.id == duplicates[i].id) {
-                    n = i;
+            if (cf instanceof Fact) {
+                $('#inspector').removeClass('footnote-mode');
+
+                this.updateCalculation(cf);
+                this.updateOutline(cf);
+                this.updateFootnotes(cf);
+                this.updateAnchoring(cf);
+                $('div.references').empty().append(this._referencesHTML(cf));
+                $('#inspector .search-results .fact-list-item').removeClass('selected');
+                $('#inspector .search-results .fact-list-item').filter((i, e) => $(e).data('ivid') == cf.id).addClass('selected');
+
+                const duplicates = cf.duplicates();
+                let n = 0;
+                const ndup = duplicates.length;
+                for (var i = 0; i < ndup; i++) {
+                    if (cf.id == duplicates[i].id) {
+                        n = i;
+                    }
+                }
+                $('.duplicates .text').text(i18next.t('factDetails.duplicatesCount', { current: n + 1, total: ndup}));
+                $('.duplicates .prev').off().click(() => inspector.selectItem(duplicates[(n+ndup-1) % ndup].id));
+                $('.duplicates .next').off().click(() => inspector.selectItem(duplicates[(n+1) % ndup].id));
+
+                this.getPeriodIncrease(cf);
+                if (cf.isHidden()) {
+                    $('#inspector').addClass('hidden-fact');
+                }
+                else if (cf.isHTMLHidden()) {
+                    $('#inspector').addClass('html-hidden-fact');
+                }
+
+            }
+            else if (cf instanceof Footnote) {
+                $('#inspector').addClass('footnote-mode');
+                $('#inspector .footnote-details .footnote-facts').empty().append(this._footnoteFactsHTML(cf));
+            }
+            $('.fact-details').localize();
+        }
+        this.updateURLFragment();
+    }
+
+    /*
+     * Select a fact or footnote from the report.
+     *
+     * Takes an ID of the item to select.  An optional list of "alternate"
+     * fact/footnotes may be specified, which will be presented in an accordian.
+     * This is used when the user clicks on a nested fact/footnote in the viewer,
+     * so that all items corresponding to the area clicked are shown.
+     *
+     * If itemIdList is omitted, the currently selected item list is reset to just
+     * the primary item.
+     */
+    selectItem(id, itemIdList, noScroll) {
+        if (itemIdList === undefined) {
+            this._currentItemList = [ this._report.getItemById(id) ];
+        }
+        else {
+            this._currentItemList = [];
+            for (const itemId of itemIdList) {
+                this._currentItemList.push(this._report.getItemById(itemId));
+            }
+        }
+        this.switchItem(id, noScroll);
+    }
+
+    /*
+     * Switches the currently selected item.  Unlike selectItem, this does not
+     * change the current list of "alternate" items.  
+     *
+     * For facts, the "id" must be in the current alternate fact list.
+     *
+     * For footnotes, we currently only support a single footnote being selected.
+     */
+    switchItem(id, noScroll) {
+        if (id !== null) {
+            this._currentItem = this._report.getItemById(id);
+            if (!noScroll) {
+                this._viewer.showItemById(id);
+            }
+            this._viewer.highlightItem(id);
+        }
+        else {
+            this._currentItem = null;
+            this._viewer.clearHighlighting();
+        }
+        this.update();
+    }
+
+    preferredLanguages() {
+        const urlParams = new URLSearchParams(window.location.search);
+        if (urlParams.has("lang")) {
+            return [ urlParams.get("lang") ];
+        }
+        const langs = window.navigator.languages || [ window.navigator.language || window.navigator.userLanguage ] ;
+        if (langs.length == 0 || !langs[0]) {
+            return ["en"];
+        }
+        return langs;
+    }
+
+    selectDefaultLanguage() {
+        const al = this._report.availableLanguages();
+        for (const pl of this.preferredLanguages()) {
+            for (const l of al) {
+                if (l.toLowerCase() == pl.toLowerCase()) {
+                    return l;
                 }
             }
-            $('.duplicates .text').text(i18next.t('factDetails.duplicatesCount', { current: n + 1, total: ndup}));
-            var viewer = this._viewer;
-            $('.duplicates .prev').off().click(() => inspector.selectItem(duplicates[(n+ndup-1) % ndup].id));
-            $('.duplicates .next').off().click(() => inspector.selectItem(duplicates[(n+1) % ndup].id));
-
-            this.getPeriodIncrease(cf);
-            if (cf.isHidden()) {
-                $('#inspector').addClass('hidden-fact');
-            }
-            else if (cf.isHTMLHidden()) {
-                $('#inspector').addClass('html-hidden-fact');
-            }
-
         }
-        else if (cf instanceof Footnote) {
-            $('#inspector').addClass('footnote-mode');
-            $('#inspector .footnote-details .footnote-facts').empty().append(this._footnoteFactsHTML(cf));
-        }
-        $('.fact-details').localize();
+        return this._report.availableLanguages()[0];
     }
-    this.updateURLFragment();
-}
 
-/*
- * Select a fact or footnote from the report.
- *
- * Takes an ID of the item to select.  An optional list of "alternate"
- * fact/footnotes may be specified, which will be presented in an accordian.
- * This is used when the user clicks on a nested fact/footnote in the viewer,
- * so that all items corresponding to the area clicked are shown.
- *
- * If itemIdList is omitted, the currently selected item list is reset to just
- * the primary item.
- */
-Inspector.prototype.selectItem = function (id, itemIdList, noScroll) {
-    if (itemIdList === undefined) {
-        this._currentItemList = [ this._report.getItemById(id) ];
+    setLanguage(lang) {
+        this._viewerOptions.language = lang;
     }
-    else {
-        this._currentItemList = [];
-        for (var i = 0; i < itemIdList.length; i++) {
-            this._currentItemList.push(this._report.getItemById(itemIdList[i]));
+
+    showValidationReport() {
+        const vr = new ValidationReportDialog();
+        vr.displayErrors(this._report.data.validation);
+        vr.show();
+    }
+
+    setupValidationReportIcon() {
+        if (this._report.hasValidationErrors()) {
+            $("#ixv .validation-warning").show().on("click", () => this.showValidationReport());
         }
     }
-    this.switchItem(id, noScroll);
-}
 
-/*
- * Switches the currently selected item.  Unlike selectItem, this does not
- * change the current list of "alternate" items.  
- *
- * For facts, the "id" must be in the current alternate fact list.
- *
- * For footnotes, we currently only support a single footnote being selected.
- */
-Inspector.prototype.switchItem = function (id, noScroll) {
-    if (id !== null) {
-        this._currentItem = this._report.getItemById(id);
-        if (!noScroll) {
-            this._viewer.showItemById(id);
+    showValidationWarning() {
+        if (this._report.hasValidationErrors()) {
+            const message = $("<div></div>").append("<p>This report contains <b>XBRL validation errors</b>.  These errors may prevent this document from opening correctly in other XBRL software.</p>");
+            const mb = new MessageBox("Validation errors", message, "View Details", "Dismiss");
+            mb.show(() => this.showValidationReport());
         }
-        this._viewer.highlightItem(id);
-    }
-    else {
-        this._currentItem = null;
-        this._viewer.clearHighlighting();
-    }
-    this.update();
-}
-
-Inspector.prototype.preferredLanguages = function () {
-    var urlParams = new URLSearchParams(window.location.search);
-    if (urlParams.has("lang")) {
-        return [ urlParams.get("lang") ];
-    }
-    var langs = window.navigator.languages || [ window.navigator.language || window.navigator.userLanguage ] ;
-    if (langs.length == 0 || !langs[0]) {
-        return ["en"];
-    }
-    return langs;
-}
-
-Inspector.prototype.selectDefaultLanguage = function () {
-    var al = this._report.availableLanguages();
-    $.each(this.preferredLanguages(), function (i, pl) {
-        $.each(al, function (j, l) {
-            if (l.toLowerCase() == pl.toLowerCase()) {
-                return l;
-            }
-        });
-    });
-    return this._report.availableLanguages()[0];
-}
-
-Inspector.prototype.setLanguage = function (lang) {
-    this._viewerOptions.language = lang;
-}
-
-Inspector.prototype.showValidationReport = function () {
-    const vr = new ValidationReportDialog();
-    vr.displayErrors(this._report.data.validation);
-    vr.show();
-}
-
-Inspector.prototype.setupValidationReportIcon = function () {
-    if (this._report.hasValidationErrors()) {
-        $("#ixv .validation-warning").show().on("click", () => this.showValidationReport());
-    }
-}
-
-Inspector.prototype.showValidationWarning = function () {
-    if (this._report.hasValidationErrors()) {
-        var message = $("<div></div>").append("<p>This report contains <b>XBRL validation errors</b>.  These errors may prevent this document from opening correctly in other XBRL software.</p>");
-        var mb = new MessageBox("Validation errors", message, "View Details", "Dismiss");
-        mb.show(() => this.showValidationReport());
     }
 }

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -659,9 +659,10 @@ export class Inspector {
                     .append($("<span></span>").addClass("concept-name").text(report.getLabelOrName(r.concept, "std")))
                     .appendTo(calcBody);
 
+                // r.facts is a map of fact IDs to Fact objects
                 if (r.facts) {
                     itemHTML.addClass("calc-fact-link");
-                    itemHTML.data('ivid', r.facts);
+                    itemHTML.data('ivids', Object.keys(r.facts));
                     itemHTML.click(() => inspector.selectItem(Object.values(r.facts)[0].id));
                     itemHTML.mouseenter(() => Object.values(r.facts).forEach(f => this._viewer.linkedHighlightFact(f)));
                     itemHTML.mouseleave(() => Object.values(r.facts).forEach(f => this._viewer.clearLinkedHighlightFact(f)));
@@ -700,7 +701,7 @@ export class Inspector {
 
     viewerMouseEnter(id) {
         $('.calculations .item')
-            .filter((i, e) => Object.keys($(e).data('ivid') ?? {}).includes(id))
+            .filter((i, e) => ($(e).data('ivids') ?? []).includes(id))
             .addClass('linked-highlight');
         $('#inspector .search .results tr')
             .filter((i, e) => $(e).data('ivid') == id)

--- a/iXBRLViewerPlugin/viewer/src/js/tableExport.js
+++ b/iXBRLViewerPlugin/viewer/src/js/tableExport.js
@@ -54,7 +54,7 @@ export class TableExport {
                 const facts = $(this).find(".ixbrl-element").addBack(".ixbrl-element");
                 let fact = null;
                 if (facts.length > 0) {
-                    const id = facts.first().data('ivid');
+                    const id = facts.first().data('ivids');
                     fact = report.getItemById(id);
                 }
                 if (fact instanceof Fact) {

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -47,7 +47,7 @@ export class Viewer {
         this._currentDocumentIndex = 0;
     }
 
-    _checkContinuationCount = function() {
+    _checkContinuationCount() {
         const continuationCount = Object.keys(this.continuationOfMap).length
         if (continuationCount > this._iv.options.continuationElementLimit) {
             const contents = $('<div></div>')
@@ -65,7 +65,7 @@ export class Viewer {
         return Promise.resolve();
     }
 
-    initialize = function() {
+    initialize() {
         return new Promise(async (resolve, reject) => {
             const viewer = this;
             viewer._buildContinuationMaps();
@@ -100,7 +100,7 @@ export class Viewer {
         });
     }
 
-    _addDocumentSetTabs = function() {
+    _addDocumentSetTabs() {
         if (this._report.isDocumentSet()) {
             $('#ixv .ixds-tabs').show();
             for (const [i, doc] of this._report.documentSetFiles().entries()) {
@@ -118,7 +118,7 @@ export class Viewer {
     // Wrap a DOM node in a div or span.  If the node or any descendent has
     // display: block, a div is used, otherwise a span.  Returns the wrapper node
     // as a jQuery node
-    _wrapNode = function(n) {
+    _wrapNode(n) {
         var wrapper = "<span>";
         const nn = n.getElementsByTagName("*");
         for (var i = 0; i < nn.length; i++) {
@@ -161,7 +161,7 @@ export class Viewer {
      * All other links are forced to open in a new tab
      *
      */
-    _updateLink = function(n) {
+    _updateLink(n) {
         const url = $(n).attr("href");
         if (url !== undefined) {
             const [file, fragment] = url.split('#', 2);
@@ -181,7 +181,7 @@ export class Viewer {
         }
     }
 
-    _findOrCreateWrapperNode = function(domNode) {
+    _findOrCreateWrapperNode(domNode) {
         const v = this;
         /* Is the element the only significant content within a <td> or <th> ? If
          * so, use that as the wrapper element. */
@@ -223,13 +223,13 @@ export class Viewer {
 
 
     // Adds the specified ID to the "ivid" data list on the given node
-    _addIdToNode = function(node, id) {
+    _addIdToNode(node, id) {
         const ivids = node.data('ivid') || [];
         ivids.push(id);
         node.data('ivid', ivids);
     }
 
-    _buildContinuationMaps = function() {
+    _buildContinuationMaps() {
         // map of element id to next element id in continuation chain
         const nextContinuationMap = {};
         // map of items in default target document to all their continuations
@@ -294,7 +294,7 @@ export class Viewer {
     // Viewer._docOrderItemIndex is a DocOrderIndex object that maintains a list of
     // fact and footnotes in document order.
     //
-    _preProcessiXBRL = function(n, docIndex, inHidden) {
+    _preProcessiXBRL(n, docIndex, inHidden) {
         const name = localName(n.nodeName).toUpperCase();
         const isFootnote = name === 'FOOTNOTE';
         const isContinuation = name === 'CONTINUATION';
@@ -387,7 +387,7 @@ export class Viewer {
         this._preProcessChildNodes(n, docIndex, inHidden);
     }
 
-    _getIXHiddenLinkStyle = function(domNode) {
+    _getIXHiddenLinkStyle(domNode) {
         if (domNode.hasAttribute('style')) {
             const re = /(?:^|\s|;)-(?:sec|esef)-ix-hidden:\s*([^\s;]+)/;
             const m = domNode.getAttribute('style').match(re);
@@ -412,7 +412,7 @@ export class Viewer {
         this._iv.callPluginMethod("updateViewerStyleElements", stlyeElts);
     }
 
-    contents = function() {
+    contents() {
         return this._iframes.contents();
     }
 
@@ -474,7 +474,7 @@ export class Viewer {
     /*
      * Calculate the intersection of two rectangles
      */
-    intersect = function(r1, r2) {
+    intersect(r1, r2) {
         const r3 = {
             left: Math.max(r1.left, r2.left),
             top: Math.max(r1.top, r2.top),
@@ -527,7 +527,7 @@ export class Viewer {
 
     /* If the specified element is not fully visible, scroll it into the center of
      * the viewport */
-    showElement = function(e) {
+    showElement(e) {
         const ee = e.get(0);
         if (!this.isFullyVisible(ee)) {
             ee.scrollIntoView({ block: "center", inline: "center" });
@@ -636,7 +636,7 @@ export class Viewer {
     /*
      * Add or remove a class to an item (fact or footnote) and any continuation elements
      */
-    changeItemClass = function(itemId, highlightClass, removeClass) {
+    changeItemClass(itemId, highlightClass, removeClass) {
         const elements = this.elementsForItemIds([itemId].concat(this.itemContinuationMap[itemId]))
         if (removeClass) {
             elements.removeClass(highlightClass);
@@ -649,7 +649,7 @@ export class Viewer {
     /*
      * Change the currently highlighted item
      */
-    highlightItem = function(factId) {
+    highlightItem(factId) {
         this.clearHighlighting();
         this.changeItemClass(factId, "ixbrl-selected");
     }
@@ -738,7 +738,7 @@ export class Viewer {
         $('#top-bar .document-title').text($('head title', this._iframes.eq(docIndex).contents()).text());
     }
 
-    showDocumentForItemId = function(itemId) {
+    showDocumentForItemId(itemId) {
         this.selectDocument(this._ixNodeMap[itemId].docIndex);
     }
 

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -222,11 +222,11 @@ export class Viewer {
     }
 
 
-    // Adds the specified ID to the "ivid" data list on the given node
+    // Adds the specified ID to the "ivids" data list on the given node
     _addIdToNode(node, id) {
-        const ivids = node.data('ivid') || [];
+        const ivids = node.data('ivids') || [];
         ivids.push(id);
-        node.data('ivid', ivids);
+        node.data('ivids', ivids);
     }
 
     _buildContinuationMaps() {
@@ -284,10 +284,10 @@ export class Viewer {
     //   .ixbrl-element-footnote       
     //                         Indicates type of element being wrapped
     //
-    // All ixbrl-elements have "ivid" data added, which is a list of the ID
+    // All ixbrl-elements have "ivids" data added, which is a list of the ID
     // attribute(s) of corresponding IX item(s).  Continuations have the IDs of
     // their head items (fact or footnotes).
-    // "ivid" can be a mix of different types.
+    // "ivids" can be a mix of different types.
     //
     // Viewer._ixNodeMap is a map of these IDs to IXNode objects.
     //
@@ -365,7 +365,7 @@ export class Viewer {
                 const id = this._getIXHiddenLinkStyle(n);
                 if (id !== null) {
                     nodes = $(n);
-                    nodes.addClass("ixbrl-element").data('ivid', [id]);
+                    nodes.addClass("ixbrl-element").data('ivids', [id]);
                     this._docOrderItemIndex.addItem(id, docIndex);
                     /* We may have already seen the corresponding ix element in the hidden
                      * section */
@@ -539,7 +539,7 @@ export class Viewer {
     }
 
     _ixIdsForElement(e) {
-        return e.data('ivid');
+        return e.data('ivids');
     }
 
     /*
@@ -599,12 +599,12 @@ export class Viewer {
     }
 
     _mouseEnter(e) {
-        const id = e.data('ivid')[0];
+        const id = e.data('ivids')[0];
         this.onMouseEnter.fire(id);
     }
 
     _mouseLeave(e) {
-        const id = e.data('ivid')[0];
+        const id = e.data('ivids')[0];
         this.onMouseLeave.fire(id);
     }
 
@@ -680,7 +680,7 @@ export class Viewer {
                     // Choosing the first means that we're arbitrarily choosing a
                     // highlight color for an element that is double tagged in a
                     // table cell.
-                    const ixn = $(this).data('ivid').map(id => viewer._ixNodeMap[id]).filter(ixn => !ixn.footnote)[0];
+                    const ixn = $(this).data('ivids').map(id => viewer._ixNodeMap[id]).filter(ixn => !ixn.footnote)[0];
                     if (ixn != undefined) {
                         const elements = viewer.elementsForItemIds(ixn.chainIXIds());
                         const i = groups[report.getItemById(ixn.id).conceptQName().prefix];
@@ -721,7 +721,7 @@ export class Viewer {
         var facts = [];
         const e = this.elementsForItemId(fact.id);
         e.closest("table").find(".ixbrl-element").each(function () {
-            facts = facts.concat($(this).data('ivid'));
+            facts = facts.concat($(this).data('ivids'));
         });
         return facts;
     }


### PR DESCRIPTION
#### Reason for change

Fixes #377.

#### Description of change

Updates `inspector.js` to use ES `class` syntax, and other more modern JS constructs.  Reduces use of jQuery.

Also fixes some minor issues in the updates to `viewer.js`.

#### Steps to Test

Viewer functionality should be unchanged.  Check that inspector operations work correctly as before.

**review**:
@Workiva/xt
@paulwarren-wk
