### PR TITLE
XT-3043 Create empty shell setup.py to pass Workiva Deploy validation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()


### PR DESCRIPTION
#### Reason for change
Workiva Deploy expects a setup.py file in pypi packages. We can delete this once we move under the Arelle org.

#### Description of change
* Shell setup.py

#### Steps to Test
* CI

**review**:
@Workiva/xt
@paulwarren-wk
