### PR TITLE
Additional test for calling getScaleLabel on facts with no units.

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/fact.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.test.js
@@ -441,6 +441,34 @@ describe("Readable accuracy", () => {
     });
 });
 
+describe("Readable accuracy", () => {
+    test("With units", () => {
+        expect(testFact({
+            "v": "1234",
+            "d": 4,
+            "a": { "u": "iso4217:GBP" }
+        }).getScaleLabel(-2)).toBe("pence");
+        expect(testFact({
+            "v": "1234",
+            "d": 4,
+            "a": { "u": "iso4217:GBP" }
+        }).getScaleLabel(-4)).toBe(null);
+    });
+    test("Without units", () => {
+        expect(testFact({
+            "v": "1234",
+            "d": 4,
+            "a": {}
+        }).getScaleLabel(-2)).toBe("hundredths");
+        expect(testFact({
+            "v": "1234",
+            "d": 4,
+            "a": {}
+        }).getScaleLabel(-4)).toBe(null);
+    });
+});
+
+
 describe("Readable scale", () => {
     test("Non-numeric", () => {
         expect(testFact({


### PR DESCRIPTION
#### Reason for change

Additional tests for the fix on #446 that more closely reflect what caused #435.  The underlying issue on #435 was calling `getScaleLabel` on a fact with absent units, rather than `null` units. 

`getScaleLabel` was previously tested via `readableAccuracy` which has its own guard for non-numeric facts, but it's also called directly from `getUsedScaleMap` on anything with a `scale` attribute.

#### Description of change

Additional tests that call `getScaleLabel` with missing units.

Closes #435 .

#### Steps to Test

**review**:
@Workiva/xt
@paulwarren-wk
