### PR TITLE
XT-3054 Workiva build fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,3 @@
 .idea
-.github
 .vscode
-aviary.yaml
-CODEOWNERS
-Dockerfile
 node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ ARG BUILD_ARTIFACTS_CDN=/static_release/assets.tar.gz
 RUN npm pack
 ARG BUILD_ARTIFACTS_NPM=/build/*.tgz
 
-FROM python:3.9-slim-bullseye as python-build
+FROM python:3.11.4-slim-bullseye as python-build
 
 ARG PIP_INDEX_URL
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ARG NPM_CONFIG_USERCONFIG=/.npmrc
 
 WORKDIR /build/
 
-COPY package.json /build/
+COPY package.json package-lock.json /build/
 RUN npm install --include=dev
 
 COPY . /build/

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ contains all of the javascript that runs the viewer functionality.
 
 ## Installation
 
-The python portion of this repo is developed using Python 3.9.
+The python portion of this repo is developed using Python 3.11.
 
 1. Clone the [iXBRL Viewer git repository][ixbrlviewer-github].
 2. Download and install [Arelle][arelle-download]


### PR DESCRIPTION
#### Description of change
Python package version detection inspects the working directory for uncommitted changes.
If there are uncommitted changes the build is determined to be a dev build. For the workiva
docker build this causes it to always be dirty because tracked files are excluded from the
build environment.

Additionally updates the Python version and includes the package lock file for the docker build.

#### Reason for change

#### Steps to Test
* CI

**review**:
@Workiva/xt
@paulwarren-wk
