### PR TITLE
XT-3064: Use npm ci

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,7 +55,10 @@ updates:
   reviewers:
     - Workiva/xt
   allow:
+    - dependency-name: "node"
     - dependency-name: "python"
   ignore:
+    - dependency-name: "node"
+      update-types: ["version-update:semver-major"]
     - dependency-name: "python"
       update-types: ["version-update:semver-major", "version-update:semver-minor"]

--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -14,7 +14,6 @@ jobs:
           - ubuntu-22.04
           - windows-2022
         node-version:
-          - '14'
           - '16'
           - '18'
           - '20'

--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -17,7 +17,7 @@ jobs:
           - '14'
           - '16'
           - '18'
-          - '19'
+          - '20'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3.3.0

--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -26,6 +26,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
         run: |
-          npm install
+          npm ci
       - name: Test with npm
         run: npm run test

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       node_version:
-        default: '19'
+        default: '20'
         description: 'Node version to use'
         required: true
         type: string

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: ${{ inputs.node_version }}
           registry-url: 'https://registry.npmjs.org' # Must explicitly set this for NODE_AUTH_TOKEN to work below
       - name: Install dependencies
-        run: npm install --include=dev
+        run: npm ci
       - name: Test with npm
         run: npm run test
       - name: Build with npm

--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -17,7 +17,7 @@ jobs:
         node-version:
           - '16'
           - '18'
-          - '19'
+          - '20'
         python-version:
           - '3.11'
     runs-on: ${{ matrix.os }}
@@ -36,7 +36,7 @@ jobs:
           check-latest: true
           python-version: ${{ matrix.python-version }}
       - name: Install Dependencies
-        run: npm install --include dev
+        run: npm ci
       - name: Install Arelle
         run: pip install arelle-release .
       - name: Build viewer js

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,8 +50,10 @@ ARG PIP_INDEX_URL
 
 WORKDIR /build/
 
-RUN apt update -y
-RUN apt-get install git -y
+RUN apt update -y && \
+    apt install -y \
+        git && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY . /build/
 RUN pip install -U pip setuptools && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,14 @@
-FROM node:19-slim as node-build
+FROM node:20.2.0-slim as node-build
 
 ARG NPM_CONFIG__AUTH
 ARG NPM_CONFIG_REGISTRY=https://workivaeast.jfrog.io/workivaeast/api/npm/npm-prod/
 ARG NPM_CONFIG_ALWAYS_AUTH=true
 ARG GIT_TAG
+
+RUN apt update -y && \
+    apt install -y \
+        git && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN reg=$(echo "$NPM_CONFIG_REGISTRY" | cut -d ":" -f 2) && \
     echo "$reg:_auth = $NPM_CONFIG__AUTH" > /.npmrc && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ ARG NPM_CONFIG_USERCONFIG=/.npmrc
 WORKDIR /build/
 
 COPY package.json package-lock.json /build/
-RUN npm install --include=dev
+RUN npm update -g npm && \
+    npm ci
 
 COPY . /build/
 


### PR DESCRIPTION
#### Reason for change
We have a package-lock.json file now. We can and should use npm ci to install dependencies in CI.

We were also building and testing against [EOL Node.js versions](https://endoflife.date/nodejs).

#### Description of change
* Use npm ci from Workiva and GitHub pipelines
* Don't use EOL Node.js versions

#### Steps to Test
* ci

**review**:
@Workiva/xt
@paulwarren-wk
