### PR TITLE
XT-2854: Create release workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -11,11 +11,11 @@ template: |
 version-resolver:
   major:
     labels:
-      - 'major'
+      - 'major-release'
   minor:
     labels:
-      - 'minor'
+      - 'minor-release'
   patch:
     labels:
-      - 'patch'
+      - 'patch-release'
   default: patch

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,21 @@
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+categories:
+  - title: "⬆️ Dependencies"
+    collapse-after: 1
+    labels:
+      - "dependencies"
+template: |
+  ## What's Changed
+  $CHANGES
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch

--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+  workflow_call:
 
 permissions: {}
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+  workflow_call:
 
 permissions: {}
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,19 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+permissions: {}
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - uses: release-drafter/release-drafter@v5.24.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,10 @@
 name: Release
 
 on:
-  release:
-    types: [released]
+  # XT-3084: Enable released events once NPM and PyPI projects have been transferred to Arelle user.
+  # release:
+  #   types: [released]
+  workflow_dispatch:
 
 permissions: {}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release
+
+on:
+  release:
+    types: [released]
+
+permissions: {}
+
+jobs:
+  node-tests:
+    uses: ./.github/workflows/node-tests.yml
+  npm-package:
+    permissions:
+      contents: write
+    needs: node-tests
+    uses: ./.github/workflows/npm-package.yml
+    secrets: inherit
+
+  python-tests:
+    uses: ./.github/workflows/python-tests.yml
+  python-package:
+    permissions:
+      contents: write
+    needs: python-tests
+    uses: ./.github/workflows/python-package.yml
+    secrets: inherit
+


### PR DESCRIPTION
#### Reason for change
Resolves #451 

#### Description of change
* Create release drafter workflow and config
* Create release workflow (limited to manual runs until NPM and PyPI projects are transferred to Arelle user).

#### Steps to Test
* CI

**review**:
@Workiva/xt
@paulwarren-wk
