### PR TITLE
Set Dependabot update frequency to match Arelle

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: daily
-      time: "02:00"
-      timezone: America/Chicago
+      interval: weekly
     groups:
       dependencies:
         patterns:
@@ -15,9 +13,7 @@ updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: daily
-      time: "02:00"
-      timezone: America/Chicago
+      interval: weekly
     allow:
       - dependency-type: all
     groups:
@@ -58,9 +54,7 @@ updates:
     directory: "/"
     insecure-external-code-execution: allow
     schedule:
-      interval: daily
-      time: "02:00"
-      timezone: America/Chicago
+      interval: weekly
     allow:
       - dependency-type: all
     groups:
@@ -72,9 +66,7 @@ updates:
   - package-ecosystem: docker
     directory: "/"
     schedule:
-      interval: daily
-      time: "02:00"
-      timezone: America/Chicago
+      interval: weekly
     reviewers:
       - Workiva/xt
     allow:


### PR DESCRIPTION
#### Reason for change
Excessive updates makes external contributions more difficult. When dependencies are added or removed. Match frequency of our other open-source repo Arelle.

#### Description of change
Match Dependabot frequency of Arelle

#### Steps to Test
* CI

**review**:
@Workiva/xt
@paulwarren-wk
