### PR TITLE
When fetching the config file, make the callback easier to understand and include the URL in its log message

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
@@ -258,13 +258,14 @@ export class iXBRLViewer {
             else {
                 fetch(this.options.configUrl)
                     .then((resp) => {
-                        if (resp.status === 404) {
-                            return Promise.resolve({});
-                        }
-                        if (resp.status !== 200) {
-                            return Promise.reject(`Fetch failed: ${resp.status}`);
-                        }
-                        return resp.json();
+                        switch (resp.status) {
+                            case 200:
+                                return resp.json();
+                            case 404:
+                                return Promise.resolve({});
+                            default:
+                                return Promise.reject(`Fetch of ${this.options.configUrl} failed: ${resp.status}`);
+                        };
                     })
                     .then((data) => {
                         resolve(data);


### PR DESCRIPTION
#### Reason for change

Code is a bit hard to follow with the check for 404 and then the check for !200 and then the (`return resp.json();`) for everything else (which is in fact only for the 200 case of course).

The log message does not tell you what URL it failed to fetch

#### Description of change

- Use a switch statement to make the fetch response callback easy to understand
- Include the URL in the log message

#### Steps to Test

**review**:
@Arelle/arelle
@paulwarren-wk
