### PR TITLE
Use OpenID Connect for npm package publishing

### DIFF
--- a/.github/workflows/npm-package.yml
+++ b/.github/workflows/npm-package.yml
@@ -53,35 +53,3 @@ jobs:
           name: npm package
           if-no-files-found: error
           path: ixbrl-viewer-*.tgz
-
-  publish-package:
-    needs: build-package
-    environment: release
-    permissions:
-      contents: write
-      id-token: write
-    runs-on: ubuntu-24.04
-    if: startsWith(github.ref, 'refs/tags')
-    steps:
-      - name: Install Node.js
-        uses: actions/setup-node@v6.0.0
-        with:
-          check-latest: true
-          node-version: ${{ inputs.node_version }}
-      - name: Download ixbrlviewer.js artifact
-        uses: actions/download-artifact@v6.0.0
-        with:
-          name: ixbrlviewer.js
-      - name: Download npm artifact
-        uses: actions/download-artifact@v6.0.0
-        with:
-          name: npm package
-      - name: Publish with npm
-        env:
-          NPM_CONFIG_DRY_RUN: ${{ github.repository != 'Arelle/ixbrl-viewer' }}
-        run: npm publish ixbrl-viewer-*.tgz --access public
-      - name: Upload release artifacts
-        uses: softprops/action-gh-release@v2.4.2
-        with:
-          fail_on_unmatched_files: true
-          files: './*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,42 @@ jobs:
   npm-package:
     permissions:
       contents: write
-      id-token: write
-    needs: node-tests
     uses: ./.github/workflows/npm-package.yml
     secrets: inherit
+  publish-npm-package:
+    # publish job is inline here because npm doesn't support trusted publishers from GitHub reusable workflows.
+    needs:
+      - node-tests
+      - npm-package
+    environment: release
+    permissions:
+      contents: write
+      id-token: write
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Install Node.js
+        uses: actions/setup-node@v6.0.0
+        with:
+          check-latest: true
+          node-version: latest
+          registry-url: 'https://registry.npmjs.org'
+      - name: Download ixbrlviewer.js artifact
+        uses: actions/download-artifact@v6.0.0
+        with:
+          name: ixbrlviewer.js
+      - name: Download npm artifact
+        uses: actions/download-artifact@v6.0.0
+        with:
+          name: npm package
+      - name: Publish with npm
+        env:
+          NPM_CONFIG_DRY_RUN: ${{ github.repository != 'Arelle/ixbrl-viewer' }}
+        run: npm publish ixbrl-viewer-*.tgz --access public
+      - name: Upload release artifacts
+        uses: softprops/action-gh-release@v2.4.2
+        with:
+          fail_on_unmatched_files: true
+          files: './*'
 
   python-tests:
     uses: ./.github/workflows/python-tests.yml


### PR DESCRIPTION
#### Reason for change
Similar to Arelle/Arelle/pull/2019, replace secret workflow token with OIDC temporary credentials to [authenticate with npm](https://docs.npmjs.com/trusted-publishers).

#### Description of change
Replace legacy token with OIDC trusted publisher.

#### Steps to Test
- [x] cut [a release using the modified workflow](https://github.com/Arelle/ixbrl-viewer/actions/runs/19241113063) and verify that the release [is published to npm](https://www.npmjs.com/package/ixbrl-viewer/v/1.4.78).


**review**:
@Arelle/arelle
@paulwarren-wk
