### PR TITLE
Defer tkinter imports for headless server compatibility

### DIFF
--- a/iXBRLViewerPlugin/__init__.py
+++ b/iXBRLViewerPlugin/__init__.py
@@ -14,17 +14,20 @@ import traceback
 import webbrowser
 from optparse import OptionGroup, OptionParser
 from pathlib import Path
-from tkinter import Menu
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from arelle.Cntlr import Cntlr
-from arelle.CntlrWinMain import CntlrWinMain
 from arelle.LocalViewer import LocalViewer
 from arelle.ModelDocument import Type
 from arelle.ModelXbrl import ModelXbrl
 from arelle.typing import TypeGetText
 from arelle.UrlUtil import isHttpUrl
 from bottle import static_file  # type: ignore[import-untyped]
+
+if TYPE_CHECKING:
+    from tkinter import Menu
+
+    from arelle.CntlrWinMain import CntlrWinMain
 
 from .constants import (
     CONFIG_COPY_SCRIPT,

--- a/tests/unit_tests/iXBRLViewerPlugin/test_init.py
+++ b/tests/unit_tests/iXBRLViewerPlugin/test_init.py
@@ -1,0 +1,19 @@
+import subprocess
+import sys
+import textwrap
+
+
+def test_import_without_tkinter() -> None:
+    """Verify the module can be imported without tkinter available.
+
+    This test ensures that the iXBRLViewerPlugin can be loaded on headless
+    servers that don't have tkinter installed. tkinter is only needed when
+    GUI hooks are actually called.
+    """
+    code = textwrap.dedent("""
+        import sys
+        sys.modules['tkinter'] = None  # Block tkinter imports
+        import iXBRLViewerPlugin
+        assert 'name' in iXBRLViewerPlugin.__pluginInfo__
+    """)
+    subprocess.run([sys.executable, '-c', code], check=True)


### PR DESCRIPTION
#### Reason for change
Headless Python server environments often don't include tkinter. A recent commit (a2e68e8401d4f4acdb75656754ee19561d9a87ed) for type hints pulled in tkinter. These imports need to be behind a `TYPE_CHECKING` block.

#### Description of change
* Move tkinter and CntlrWinMain imports into `TYPE_CHECKING` block so the plugin can be loaded on servers without tkinter. These imports are only needed for type hints. GUI functions already have local imports for runtime usage.
* Add test to verify plugin can be imported successfully without tkinter.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
@paulwarren-wk
