### PR TITLE
Fix nested absolute tags

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -1883,6 +1883,9 @@ export class Inspector {
     switchItem(vuid, noScroll) {
         if (vuid !== null) {
             this._currentItem = this._reportSet.getItemById(vuid) ?? null;
+            if (this._currentItem === null) {
+                console.warn(`Failed to get item for vuid ${vuid}`);
+            }
         }
         else {
             this._currentItem = null

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -1882,14 +1882,18 @@ export class Inspector {
      */
     switchItem(vuid, noScroll) {
         if (vuid !== null) {
-            this._currentItem = this._reportSet.getItemById(vuid);
+            this._currentItem = this._reportSet.getItemById(vuid) ?? null;
+        }
+        else {
+            this._currentItem = null
+        }
+        if (this._currentItem !== null) {
             if (!noScroll) {
                 this._viewer.showItemById(vuid);
             }
             this._viewer.highlightItem(vuid);
         }
         else {
-            this._currentItem = null;
             this._viewer.clearHighlighting();
         }
         this.update();

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -471,8 +471,7 @@ export class Viewer {
                 // Handle SEC/ESEF links-to-hidden
                 const vuid = viewerUniqueId(reportIndex, getIXHiddenLinkStyle(n));
                 if (vuid !== null) {
-                    let nodes = this._findOrCreateWrapperNode(n, inHidden);
-                    nodes.addClass("ixbrl-element").data('ivids', [vuid]);
+                    let nodes = this._findOrCreateWrapperNode(n, inHidden, vuid);
                     this.docOrderItemIndex.addItem(vuid, docIndex);
                     /* We may have already seen the corresponding ix element in the hidden
                      * section */

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -879,8 +879,9 @@ export class Viewer {
                 }
                 // inline element but only contains sub-elements => don't highlight
                 else if (Array.from(e.childNodes).every(n => (
-                        n.nodeType !== Node.ELEMENT_NODE ||
-                        n.classList.contains("ixbrl-sub-element")
+                        (n.nodeType === Node.ELEMENT_NODE && n.classList.contains("ixbrl-sub-element")) ||
+                        (n.nodeType === Node.TEXT_NODE && n.data.trim().length == 0) || 
+                        (n.nodeType !== Node.ELEMENT_NODE && n.nodeType !== Node.TEXT_NODE)
                     ))) {
                     e.classList.add("ixbrl-no-highlight");
                 }

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -19,7 +19,6 @@ function localName(e) {
     }
 }
 
-
 export class Viewer {
     constructor(iv, iframes, reportSet) {
         this._iv = iv;
@@ -136,7 +135,7 @@ export class Viewer {
     // Returns an array of the chosen nodes as DOM nodes.
     //
     _wrapNode(n) {
-        if (Array.from(n.childNodes).some(n => n.nodeType === Node.TEXT_NODE && !/^\s*$/.test(n.nodeValue) )) {
+        if (Array.from(n.childNodes).some(n => n.nodeType === Node.TEXT_NODE && !/^\s*$/.test(n.nodeValue))) {
             let wrapper = "<span>";
             if (getComputedStyle(n).getPropertyValue("display") === "block") {
                 wrapper = '<div>';

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -269,7 +269,7 @@ export class Viewer {
         }
     }
 
-    _findOrCreateWrapperNode(domNode, inHidden) {
+    _findOrCreateWrapperNode(domNode, inHidden, vuid) {
         const v = this;
 
         if (inHidden) {
@@ -299,6 +299,7 @@ export class Viewer {
         const allNodes = [];
         for (const node of nodes) {
             let hasSubNodes = false;
+            this._addIdToNode(node, vuid);
             allNodes.push(node);
             node.classList.add("ixbrl-element");
             for (const subNode of node.querySelectorAll("*")) { 
@@ -317,14 +318,12 @@ export class Viewer {
 
 
     // Adds the specified ID to the "ivids" data list on the given node
-    _addIdToNodes(nodes, id) {
-        nodes.filter(".ixbrl-element").each((i, e) => {
-            const ivids = $(e).data('ivids') || [];
-            if (!ivids.includes(id)) {
-                ivids.push(id);
-            }
-            $(e).data('ivids', ivids);
-        });
+    _addIdToNode(node, id) {
+        const ivids = $(node).data('ivids') || [];
+        if (!ivids.includes(id)) {
+            ivids.push(id);
+        }
+        $(node).data('ivids', ivids);
     }
 
     _buildContinuationMaps() {
@@ -432,9 +431,8 @@ export class Viewer {
             if (isFact || isFootnote) {
                 // If @id is not present, it must be for a target document that wasn't processed.
                 if (n.hasAttribute("id")) {
-                    let nodes = this._findOrCreateWrapperNode(n, inHidden);
+                    let nodes = this._findOrCreateWrapperNode(n, inHidden, vuid);
 
-                    this._addIdToNodes(nodes, vuid);
                     let ixn = this._getOrCreateIXNode(vuid, nodes, docIndex, inHidden);
                     this.docOrderItemIndex.addItem(vuid, docIndex);
 
@@ -462,10 +460,8 @@ export class Viewer {
             }
             else if (isContinuation) {
                 if (n.hasAttribute("id") && this.continuationOfMap[vuid] !== undefined) {
-                    let nodes = this._findOrCreateWrapperNode(n, inHidden);
-
                     // For a continuation, store the IX ID(s) of the item(s), not the continuation
-                    this._addIdToNodes(nodes, this.continuationOfMap[vuid]);
+                    let nodes = this._findOrCreateWrapperNode(n, inHidden, this.continuationOfMap[vuid]);
 
                     this._getOrCreateIXNode(vuid, nodes, docIndex, inHidden);
 
@@ -666,7 +662,7 @@ export class Viewer {
     // have nested elements, we select the innermost, as this gives the most
     // intuitive behaviour when clicking "next".
     selectElementByClick(e) {
-        let itemIDList = [];
+        let itemIdList = [];
         const viewer = this;
         let sameContentAncestorVuid;
         // If the user clicked on a sub-element (and which is not also a proper
@@ -686,12 +682,16 @@ export class Viewer {
         // content as "e"
         e.parents(".ixbrl-element").addBack().each(function () { 
             const vuids = viewer._ixIdsForElement($(this));
-            itemIDList = itemIDList.concat(vuids);
-            if ($(this).text() == e.text() && sameContentAncestorVuid === undefined) {
+            for (const vuid of vuids) {
+                if (!itemIdList.includes(vuid)) {
+                    itemIdList.push(vuid);
+                }
+            }
+            if (sameContentAncestorVuid === undefined && $(this).text() == e.text()) {
                 sameContentAncestorVuid = vuids[0];
             }
         });
-        this.selectElement(sameContentAncestorVuid, itemIDList, true);
+        this.selectElement(sameContentAncestorVuid, itemIdList, true);
     }
 
     _mouseEnter(e) {
@@ -874,7 +874,16 @@ export class Viewer {
                 }
             }
             for (const [i, e] of elts.entries()) {
-                if (getComputedStyle(e).getPropertyValue("display") !== 'inline' && e.getBoundingClientRect().height == 0) {
+                if (getComputedStyle(e).getPropertyValue("display") !== 'inline') {
+                    if (e.getBoundingClientRect().height == 0) {
+                        e.classList.add("ixbrl-no-highlight");
+                    }
+                }
+                // inline element but only contains sub-elements => don't highlight
+                else if (Array.from(e.childNodes).every(n => (
+                        n.nodeType !== Node.ELEMENT_NODE ||
+                        n.classList.contains("ixbrl-sub-element")
+                    ))) {
                     e.classList.add("ixbrl-no-highlight");
                 }
                 if (i % 100 === 0) {


### PR DESCRIPTION
#### Reason for change

Reported bug in handling of nested `ix` tags around an absolutely positioned element. This caused:

1. Fact details to be repeated multiple times in the fact inspector
2. Nested fact details to be shown when using next/prev to navigate through the document.
3. Outline being shown around an empty container element in addition to the absolutely positioned node.

These regressions were introduced by https://github.com/Arelle/ixbrl-viewer/pull/993

#### Description of change

* De-duplicate the IDs returned as the `itemIdList` when processing a selection by click.  Fixes (1)
* Don't add IDs to sub-nodes (absolutely positioned descendents) at all. Fixes (2)
* Where a `display: inline` element wraps only absolutely positioned children, treat it as an `ixbrl-no-highlight` element. Fixes (3). 

Additionally:

* Replace `undefined` with `null` as current item when switching to a `vuid` that doesn't exist. This improves robustness on certain iXBRL-invalid documents.

#### Steps to Test

Test file:

[file.htm](https://github.com/user-attachments/files/25842322/file.htm)

Confirm that clicking on the tag results in both facts being shown, and that next/prev cycle through the two different facts. 


**review**:
@Arelle/arelle
@paulwarren-wk
