### PR TITLE
Make search filtering aware of calculation 1.1 relationships

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/calculation.js
+++ b/iXBRLViewerPlugin/viewer/src/js/calculation.js
@@ -4,7 +4,7 @@ import Decimal from 'decimal.js';
 import { setDefault } from './util.js';
 import { Interval } from './interval.js';
 import { FactSet } from './factset.js';
-import { CALC11_ARCROLE, CALC_ARCROLE } from './util.js';
+import { CALC11_ARCROLE, CALC_ARCROLE, CALC_ARCROLES } from './util.js';
 
 export class Calculation {
     
@@ -20,7 +20,7 @@ export class Calculation {
         const report = fact.report;
         if (!this._conceptToFact) {
             const ctf = {};
-            for (const version of [CALC_ARCROLE, CALC11_ARCROLE]) {
+            for (const version of CALC_ARCROLES) {
                 const rels = report.getChildRelationships(fact.conceptName(), version)
                 for (const [elr, rr] of Object.entries(rels)) {
                     setDefault(ctf, version, {});

--- a/iXBRLViewerPlugin/viewer/src/js/calculation.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/calculation.test.js
@@ -64,9 +64,9 @@ const testReportData = {
     }
 };
 
-function testReportSet(facts) {
+function testReportSet(facts, reportData) {
     // Deep copy of standing data
-    const data = JSON.parse(JSON.stringify(testReportData));
+    const data = JSON.parse(JSON.stringify(reportData ?? testReportData));
     data.facts = facts;
     const reportset = new ReportSet(data);
     reportset._initialize();
@@ -81,6 +81,76 @@ function testFact(aspectData, value, decimals) {
 function getFact(reportSet, id) {
   return reportSet.getItemById(viewerUniqueId(0, id));
 }
+
+describe("isCalculationSummation / isCalculationContributor - calc 1.0", () => {
+    const reportSet = testReportSet({
+        "f1": testFact({"c": "eg:Total", "u": "iso2417:GBP"}, 10000, -3),
+        "f2": testFact({"c": "eg:Item1", "u": "iso2417:GBP"}, 12000, -3),
+        "f3": testFact({"c": "eg:Item2", "u": "iso2417:GBP"}, 2000, -3),
+    });
+
+    test("calc 1.0 - summation", () => {
+        const f1 =  getFact(reportSet, "f1");
+        expect(f1.isCalculationSummation()).toBe(true);
+        expect(f1.isCalculationContributor()).toBe(false);
+    });
+
+    test("calc 1.0 - contributor", () => {
+        const f2 =  getFact(reportSet, "f2");
+        expect(f2.isCalculationSummation()).toBe(false);
+        expect(f2.isCalculationContributor()).toBe(true);
+    });
+});
+
+describe("isCalculationSummation / isCalculationContributor - calc 1.1", () => {
+
+    const calc11ReportData = JSON.parse(JSON.stringify(testReportData));
+    calc11ReportData.rels.calc11 = calc11ReportData.rels.calc;
+    delete calc11ReportData.rels.calc;
+
+    const reportSet = testReportSet({
+        "f1": testFact({"c": "eg:Total", "u": "iso2417:GBP"}, 10000, -3),
+        "f2": testFact({"c": "eg:Item1", "u": "iso2417:GBP"}, 12000, -3),
+        "f3": testFact({"c": "eg:Item2", "u": "iso2417:GBP"}, 2000, -3),
+    }, calc11ReportData);
+
+    test("calc 1.1 - summation", () => {
+        const f1 =  getFact(reportSet, "f1");
+        expect(f1.isCalculationSummation()).toBe(true);
+        expect(f1.isCalculationContributor()).toBe(false);
+    });
+
+    test("calc 1.1 - contributor", () => {
+        const f2 =  getFact(reportSet, "f2");
+        expect(f2.isCalculationSummation()).toBe(false);
+        expect(f2.isCalculationContributor()).toBe(true);
+    });
+});
+
+describe("isCalculationSummation / isCalculationContributor - unknown calc version", () => {
+
+    const calcXReportData = JSON.parse(JSON.stringify(testReportData));
+    calcXReportData.rels.calc9 = calcXReportData.rels.calc;
+    delete calcXReportData.rels.calc;
+
+    const reportSet = testReportSet({
+        "f1": testFact({"c": "eg:Total", "u": "iso2417:GBP"}, 10000, -3),
+        "f2": testFact({"c": "eg:Item1", "u": "iso2417:GBP"}, 12000, -3),
+        "f3": testFact({"c": "eg:Item2", "u": "iso2417:GBP"}, 2000, -3),
+    }, calcXReportData);
+
+    test("calc 1.1 - summation", () => {
+        const f1 =  getFact(reportSet, "f1");
+        expect(f1.isCalculationSummation()).toBe(false);
+        expect(f1.isCalculationContributor()).toBe(false);
+    });
+
+    test("calc 1.1 - contributor", () => {
+        const f2 =  getFact(reportSet, "f2");
+        expect(f2.isCalculationSummation()).toBe(false);
+        expect(f2.isCalculationContributor()).toBe(false);
+    });
+});
 
 describe("Simple consistent calculation", () => {
     const reportSet = testReportSet({

--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -1,7 +1,7 @@
 // See COPYRIGHT.md for copyright information
 
 import { Concept } from "./concept.js";
-import { setDefault } from "./util.js";
+import { setDefault, CALC_ARCROLES } from "./util.js";
 import i18next from "i18next";
 
 // Class to represent the XBRL data from a single target document in a single
@@ -292,30 +292,26 @@ export class XBRLReport {
 
     isCalculationContributor(c) {
         if (this._calculationContributors === undefined) {
-            if (this._reportData.rels?.calc) {
-                this._calculationContributors = new Set(Object.values(this._reportData.rels.calc).flatMap(calculations => {
-                    return Object.values(calculations).flatMap(contributors => {
-                        return contributors.map(c => c.t);
-                    });
-                }));
-            } else {
-                this._calculationContributors = new Set();
+            this._calculationContributors = {};
+            for (const version of CALC_ARCROLES) {
+                const calcRels = this._reportData.rels?.[version] ?? {};
+                this._calculationContributors[version] = new Set(Object.values(calcRels).flatMap(calculations =>
+                    Object.values(calculations).flatMap(calcRow => calcRow.map(c => c.t))
+                ));
             }
         }
-        return this._calculationContributors.has(c);
+        return Object.values(this._calculationContributors).some(x => x.has(c));
     }
 
     isCalculationSummation(c) {
         if (this._calculationSummations === undefined) {
-            if (this._reportData.rels?.calc) {
-                this._calculationSummations = new Set(Object.values(this._reportData.rels.calc).flatMap(calculations => {
-                    return Object.keys(calculations);
-                }));
-            } else {
-                this._calculationSummations = new Set();
+            this._calculationSummations = {}
+            for (const version of CALC_ARCROLES) {
+                const calcRels = this._reportData.rels?.[version] ?? {};
+                this._calculationSummations[version] = new Set(Object.values(calcRels).flatMap(calculations => Object.keys(calculations)));
             }
         }
-        return this._calculationSummations.has(c);
+        return Object.values(this._calculationSummations).some(x => x.has(c));
     }
 
     /**

--- a/iXBRLViewerPlugin/viewer/src/js/util.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.js
@@ -10,6 +10,7 @@ export const NAMESPACE_XBRLI = 'http://www.xbrl.org/2003/instance';
 
 export const CALC_ARCROLE = "calc";
 export const CALC11_ARCROLE = "calc11";
+export const CALC_ARCROLES = [ CALC_ARCROLE, CALC11_ARCROLE ];
 
 export const GLOSSARY_URL = "https://xbrl.org/glossary/";
 


### PR DESCRIPTION
#### Reason for change

The search filter had not been updated to check for Calculations 1.1 relationships. This meant that filtering to calculation contributors or summation items would always yield no results on a document using Calculations 1.1.

#### Description of change

Search filters now consider both calc 1.0 and calc 1.1 relationships.

#### Steps to Test

Take a document with Calculations 1.1 relationships (I used [this one](https://filings.xbrl.org/filing/213800H5873O9TC3XT22-2025-12-31-ESEF-GB-0)), go to search and then search filters, select either contributors or summation and confirm that you get some results.

**review**:
@Arelle/arelle
@paulwarren-wk
