### PR TITLE
UI redesign follow-up fixes

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -5,7 +5,9 @@ build JavaScript iXBRL viewers with additional functionality.
 
 A plugin is a class with one or more of the following methods:
 
-* `extendDisplayOptionsMenu(menu)` - provides a menu object that can be modified to add additional options.
+* `extendDisplayOptionsMenu(menu)` - called when the display options menu is created or recreated, with a menu object that can be modified to add additional options.
+* `extendToolbarHighlightMenu(menu)` - called when the toolbar highlight menu is created or recreated, with a menu object that can be modified to add additional highlight toolbar options.
+* `extendHighlightKey(key)` - called when the highlight color key is created, with an array of labels that can be modified or extended.
 * `preProcessiXBRL(body, docIndex)` - called once with the `<body>` DOM node for each document in the document set.
 * `updateViewerStyleElements(styleElts)` - called on initialization with a jQuery object containing the `<style>` element from each document in the document set, allow additional styles to be registered.
 

--- a/iXBRLViewerPlugin/viewer/src/html/fact-details.html
+++ b/iXBRLViewerPlugin/viewer/src/html/fact-details.html
@@ -20,7 +20,7 @@ See COPYRIGHT.md for copyright information
       <table class="property-table fact-properties">
         <tr class="value">
           <th data-i18n="factDetails.factValue">Fact Value</th>
-          <td><span class="value"></span> <button class="show-all inline-button" aria-label="Show full text">[...]</button> <span class="expand-text-block"></td>
+          <td><span class="value"></span> <button class="show-all inline-button" aria-label="Show full text">[...]</button> <span class="expand-text-block"></span></td>
         </tr>
         <tr class="period">
           <th class="has-tooltip">
@@ -33,7 +33,7 @@ See COPYRIGHT.md for copyright information
           <th >
             <span data-i18n="factDetails.source">Source</span>
           </th>
-          <td><span class="key"></span> <span class="text"></td>
+          <td><span class="key"></span> <span class="text"></span></td>
         </tr>
         <tr class="concept">
           <th class="has-tooltip">
@@ -89,6 +89,6 @@ See COPYRIGHT.md for copyright information
           <button class="next-tag" data-i18n="[title]inspector.nextTag" title="Show next instance">Next</button>
         </div>
       </div>
-    </div>
-  </nav>
+    </nav>
+  </div>
 </div>

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -24,7 +24,7 @@ See COPYRIGHT.md for copyright information
           <button id="highlight-untagged-dates" class="review-mode-only" title="Highlight untagged dates" data-i18n="[title]inspector.highlightUntaggedDates" ></button>
           <button id="highlight-tags" title="Highlight tags" data-i18n="[title]inspector.highlightTags" ></button>
           <button id="print" title="Print Document" data-i18n="[title]inspector.printDocument"></button>
-          <button data-i18n="[title]inspector.settings" title="Settings" id="settings-button"></button>
+          <button data-i18n="[title]inspector.settingsButton" title="Settings" id="settings-button"></button>
         </div>
       </header>
       <section id="viewer-pane" data-i18n="[aria-label]viewer.ixbrlDocumentView" aria-label="iXBRL Document View">

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -363,7 +363,7 @@ See COPYRIGHT.md for copyright information
                     <option value="calc10" data-i18n="calculation.useLegacyCalculations"></option>
                   </select>
                 </div>
-                <p data-i18n="inspector.settings.calculationMode.documentation">Select the language you'd like to use with Inline Viewer.</p>
+                <p data-i18n="inspector.settings.calculationMode.documentation">Select the calculation evaluation mode for legacy calculation relationships</p>
               </div>
               <div class="section">
                 <h3 data-i18n="inspector.documentation">Documentation</h3>
@@ -468,6 +468,6 @@ See COPYRIGHT.md for copyright information
         <div class="buttons">
         </div>
       </div>
-    </div>
-  </dialog>
+    </dialog>
+  </div>
 </div>

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -23,6 +23,12 @@ See COPYRIGHT.md for copyright information
           <button id="highlight-untagged-numbers" class="review-mode-only" title="Highlight untagged numbers" data-i18n="[title]inspector.highlightUntaggedNumbers" ></button>
           <button id="highlight-untagged-dates" class="review-mode-only" title="Highlight untagged dates" data-i18n="[title]inspector.highlightUntaggedDates" ></button>
           <button id="highlight-tags" title="Highlight tags" data-i18n="[title]inspector.highlightTags" ></button>
+          <div class="menu" id="toolbar-highlight-menu">
+            <button data-i18n="[title]inspector.highlightMenu" title="Highlight options" class="menu-title"></button>
+            <div class="content-container">
+              <div class="content"></div>
+            </div>
+          </div>
           <button id="print" title="Print Document" data-i18n="[title]inspector.printDocument"></button>
           <button data-i18n="[title]inspector.settingsButton" title="Settings" id="settings-button"></button>
         </div>
@@ -369,6 +375,14 @@ See COPYRIGHT.md for copyright information
                 <h3 data-i18n="inspector.documentation">Documentation</h3>
                 <ul class="documentation-links">
                 </ul>
+              </div>
+              <div class="section">
+                <h3 data-i18n="inspector.settings.plugins.title">Plugins</h3>
+                <div class="menu inline-menu" id="display-options-menu">
+                  <div class="content-container">
+                    <div class="content"></div>
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -180,15 +180,6 @@ See COPYRIGHT.md for copyright information
               <h2>Filter</h2>
             </div>
             <div class="modal-inspector-body search-filters-body">
-              <div class="checkboxes">
-                <div id="mandatory-fact-filter-checkbox">
-                  <label class="checkbox">
-                    <input id="search-mandatory-fact-filter" type="checkbox" style="display: none;"/> <span data-i18n="inspector.mandatoryFacts">Only Mandatory Facts</span>
-                    <span class="checkmark"></span>
-                  </label>
-                </div>
-              </div>
-
             </div>
 
             <div class="search-filter-buttons">

--- a/iXBRLViewerPlugin/viewer/src/i18n/cy/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/cy/translation.json
@@ -81,6 +81,7 @@
     "goToReference": "",
     "hidden": "Gudd",
     "hiddenFact": "Ffaith Gudd",
+    "highlightMenu": "",
     "highlightTags": "",
     "highlightUntaggedDates": "",
     "highlightUntaggedNumbers": "",
@@ -115,6 +116,9 @@
       },
       "colorMode": {
         "documentation": "",
+        "title": ""
+      },
+      "plugins": {
         "title": ""
       },
       "title": "",

--- a/iXBRLViewerPlugin/viewer/src/i18n/cy/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/cy/translation.json
@@ -190,12 +190,10 @@
     "matchingFactsSummary": "",
     "noMatchFound": "Heb ganfod cyfatebiaeth",
     "resetFilters": "",
-    "selected": "dethol",
     "showMoreResults": "Dangos mwy o ganlyniadau",
     "showResults": "",
     "toggleFilterControls": "",
-    "tryAgainDifferentKeywords": "Ceisiwch eto gyda geiriau allweddol gwahanol",
-    "viewFact": ""
+    "tryAgainDifferentKeywords": "Ceisiwch eto gyda geiriau allweddol gwahanol"
   },
   "toolbar": {
     "homePage": "Hafan"

--- a/iXBRLViewerPlugin/viewer/src/i18n/cy/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/cy/translation.json
@@ -1,24 +1,24 @@
 {
   "calculation": {
     "calculated-total": "Wedi'i gyfrifo",
-    "calculationIsConsistent": "",
-    "calculationIsInconsistent": "",
+    "calculationIsConsistent": "Mae'r cyfrifiad yn gyson",
+    "calculationIsInconsistent": "Nid yw'r cyfrifiad yn gyson",
     "concept": "Cysyniad",
     "consistent-duplicate-facts-present": "{{nfacts}} ffeithiau dyblyg cyson yn bresennol",
     "does-not-bind": "Nid yw cyfrifo yn rhwymo",
     "inconsistent-duplicate-facts-present": "{{nfacts}} ffeithiau dyblyg anghyson yn bresennol",
     "maximum": "Uchafswm",
     "minimum": "Isafswm",
-    "notReported": "",
+    "notReported": "heb ei adrodd",
     "reported-total": "Adroddwyd",
     "reported-value": "Gwerth a adroddwyd",
-    "showDetails": "",
-    "status": "",
+    "showDetails": "Dangos manylion",
+    "status": "Statws",
     "useCalculations11": "Defnyddiwch Gyfrifiadau v1.1",
-    "useLegacyCalculations": ""
+    "useLegacyCalculations": "Defnyddio hen gyfrifiadau"
   },
   "chart": {
-    "comparisonChart": ""
+    "comparisonChart": "Siart gymharu"
   },
   "common": {
     "accuracyInfinite": "Anfeidrol drachywiredd",
@@ -28,15 +28,15 @@
     "unspecified": "Amhenodol"
   },
   "dialog": {
-    "close": ""
+    "close": "cau"
   },
   "factDetails": {
     "accuracy": "Cywirdeb",
-    "balance": "",
+    "balance": "Balans",
     "calculationUnchecked": "Nid yw'r cyfrifiad wedi'i wirio oherwydd presenoldeb ffeithiau dyblyg",
     "calculationUncheckedIncorrectVersion": "Cyfrifiad 1.1 perthnasau heb eu gwirio yn y modd cyfrifo etifeddiaeth",
-    "calculationValuesDoNotMatch": "",
-    "calculationValuesMatch": "",
+    "calculationValuesDoNotMatch": "Nid yw'r gwerthoedd a adroddwyd a'r gwerthoedd a gyfrifwyd yn cyfateb",
+    "calculationValuesMatch": "Mae'r gwerthoedd a adroddwyd a'r gwerthoedd a gyfrifwyd yn cyfateb",
     "change": "Newid",
     "changeFromIn": "Oddiwrth {{from}} mewn ",
     "changePercentageDecrease": "{{decrease}}gostyngiad % ar ",
@@ -47,19 +47,19 @@
     "dimensions": "Dimensiynau",
     "duplicatesCount": "{{current}} o {{total}}",
     "entity": "Endid",
-    "factCount": "",
+    "factCount": "{{current}} o {{total}}",
     "factValue": "Gwerth Ffaith",
-    "nestedFactSummary": "",
+    "nestedFactSummary": "Yn dangos {{current}} o {{total}} ffaith nythog:",
     "nonNumericFact": "ffaith nad yw'n rhifol",
     "noPriorFactInThisReport": "Dim ffaith flaenorol yn yr adroddiad hwn",
     "noUnit": "<NOUNIT>",
     "properties": "Priodweddau",
     "scale": "Graddfa",
-    "source": "",
+    "source": "Ffynhonnell",
     "viewCalculationDetails": "Gweld manylion y cyfrifiad"
   },
   "footnotes": {
-    "content": "",
+    "content": "Cynnwys",
     "footnote": "Troednodyn"
   },
   "inspector": {
@@ -72,77 +72,77 @@
     "contributor": "Cyfranwr",
     "datatypes": "Mathau data",
     "dimensions": "Math Dimensiwn",
-    "documentation": "",
+    "documentation": "Dogfennaeth",
     "explicitDimension": "Dimensiynau Penodol",
     "fact-groups": "Adrannau",
     "factSearch": "Chwiliad Ffeithiau",
     "factValue": "Gwerth Ffaith",
     "footnotes": "Troednodiadau",
-    "goToReference": "",
+    "goToReference": "Ewch i'r cyfeirnod",
     "hidden": "Gudd",
     "hiddenFact": "Ffaith Gudd",
-    "highlightMenu": "",
-    "highlightTags": "",
-    "highlightUntaggedDates": "",
-    "highlightUntaggedNumbers": "",
+    "highlightMenu": "Opsiynau amlygu",
+    "highlightTags": "Amlygu tagiau",
+    "highlightUntaggedDates": "Amlygu dyddiadau heb dagiau",
+    "highlightUntaggedNumbers": "Amlygu rhifau heb dagiau",
     "initializing": "Cychwyn",
-    "ixbrlInspector": "",
-    "labels": "",
-    "language": "",
+    "ixbrlInspector": "Arolygydd iXBRL",
+    "labels": "Labeli",
+    "language": "Iaith",
     "loadingViewer": "Wrthi'n llwytho Gwyliwr iXBRL",
     "mandatoryFacts": "Dim ond Ffeithiau Gorfodol",
     "namespaces": "Gofodau Enw",
-    "narrowerAnchors": "",
+    "narrowerAnchors": "Angorion culach",
     "negative": "Negyddol",
     "nextTag": "Tag nesaf",
-    "noCalculations": "",
-    "noDimensions": "",
+    "noCalculations": "Dim Cyfrifiadau",
+    "noDimensions": "Dim Dimensiynau",
     "noFactSelected": "Dim Ffaith wedi'i Dewis",
     "numericOption": "Rhifol",
-    "occurrences": "",
-    "otherFacts": "",
+    "occurrences": "Digwyddiadau",
+    "otherFacts": "Ffeithiau Eraill",
     "period": "Cyfnod",
     "positive": "Cadarnhaol",
     "previousTag": "Tag blaenorol",
     "printDocument": "Argraffu Dogfen",
     "references": "Cyfeiriadau",
     "scales": "Graddfeydd",
-    "searchReport": "",
-    "searchResults": "",
+    "searchReport": "Chwilio Adroddiad iXBRL",
+    "searchResults": "Canlyniadau Chwilio",
     "settings": {
       "calculationMode": {
-        "documentation": "",
-        "title": ""
+        "documentation": "Dewiswch y modd gwerthuso cyfrifo ar gyfer perthnasoedd cyfrifo etifeddol",
+        "title": "Modd cyfrifo"
       },
       "colorMode": {
-        "documentation": "",
-        "title": ""
+        "documentation": "Dewiswch a ddylai golwg y Gwelydd Mewnlin fod yn olau neu'n dywyll",
+        "title": "Modd lliw'r gwelydd"
       },
       "plugins": {
-        "title": ""
+        "title": "Ategion"
       },
-      "title": "",
+      "title": "Gosodiadau",
       "viewerLanguage": {
-        "documentation": "",
+        "documentation": "Dewiswch yr iaith yr hoffech ei defnyddio gyda'r Gwelydd Mewnlin",
         "title": "Iaith Cais"
       }
     },
-    "settingsButton": "",
-    "showAnalysisChart": "",
-    "showMore": "",
+    "settingsButton": "Gosodiadau",
+    "showAnalysisChart": "Dangos siart ddadansoddi",
+    "showMore": "Dangos mwy",
     "showTextOnly": "Dangos testun yn unig",
     "summary": {
       "about": {
-        "entity": "",
-        "name": "",
-        "seeMoreReferenceData": "",
-        "title": ""
+        "entity": "Endid",
+        "name": "Enw",
+        "seeMoreReferenceData": "Gweld mwy o ddata cyfeirio {{type}}",
+        "title": "Teitl"
       },
       "aboutCompany": {
-        "header": ""
+        "header": "Am y cwmni"
       },
       "downloads": {
-        "header": ""
+        "header": "Llwythi i lawr"
       },
       "fact": {
         "header": "Crynodeb o Ffeithiau",
@@ -150,9 +150,9 @@
         "mandatory": "Ffeithiau Gorfodol",
         "total": "Cyfanswm y Ffeithiau"
       },
-      "factSource": "",
+      "factSource": "Ffynhonnell ffeithiau",
       "includedDocuments": {
-        "header": ""
+        "header": "Dogfennau wedi'u cynnwys"
       },
       "reportCreation": "Creu Adroddiad",
       "tag": {
@@ -165,9 +165,9 @@
     },
     "summation": "Crynhoad",
     "tabs": {
-      "overview": "",
-      "search": "",
-      "xbrlFacts": ""
+      "overview": "Trosolwg",
+      "search": "Chwilio",
+      "xbrlFacts": "Ffeithiau XBRL"
     },
     "targetDocument": "Dogfen Darged",
     "textOption": "Testun",
@@ -179,7 +179,7 @@
     "validationSeverity": "Difrifoldeb",
     "visibility": "Gwelededd",
     "visible": "Gweladwy",
-    "widerAnchors": "",
+    "widerAnchors": "Angorion ehangach",
     "xbrlGlossaryOpensInNewTab": "Geirfa XBRL (yn agor mewn tab newydd)"
   },
   "menu": {
@@ -191,20 +191,20 @@
     "concealedFact": "Ffaith guddiedig",
     "default": "rhagosodedig",
     "hiddenFact": "Ffaith gudd",
-    "matchingFactsSummary": "",
+    "matchingFactsSummary": "Yn dangos {{nMatches}} o {{nTotal}} ffaith",
     "noMatchFound": "Heb ganfod cyfatebiaeth",
-    "resetFilters": "",
+    "resetFilters": "Ailosod hidlwyr",
     "showMoreResults": "Dangos mwy o ganlyniadau",
-    "showResults": "",
-    "toggleFilterControls": "",
+    "showResults": "Dangos canlyniadau",
+    "toggleFilterControls": "Toglo rheolyddion hidlo",
     "tryAgainDifferentKeywords": "Ceisiwch eto gyda geiriau allweddol gwahanol"
   },
   "toolbar": {
     "homePage": "Hafan"
   },
   "viewer": {
-    "ixbrlDocumentView": "",
-    "zoomIn": "",
-    "zoomOut": ""
+    "ixbrlDocumentView": "Golwg Dogfen iXBRL",
+    "zoomIn": "chwyddo i mewn",
+    "zoomOut": "chwyddo allan"
   }
 }

--- a/iXBRLViewerPlugin/viewer/src/i18n/cy/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/cy/translation.json
@@ -1,15 +1,21 @@
 {
   "calculation": {
     "calculated-total": "Wedi'i gyfrifo",
+    "calculationIsConsistent": "",
+    "calculationIsInconsistent": "",
     "concept": "Cysyniad",
     "consistent-duplicate-facts-present": "{{nfacts}} ffeithiau dyblyg cyson yn bresennol",
     "does-not-bind": "Nid yw cyfrifo yn rhwymo",
     "inconsistent-duplicate-facts-present": "{{nfacts}} ffeithiau dyblyg anghyson yn bresennol",
     "maximum": "Uchafswm",
     "minimum": "Isafswm",
+    "notReported": "",
     "reported-total": "Adroddwyd",
     "reported-value": "Gwerth a adroddwyd",
-    "useCalculations11": "Defnyddiwch Gyfrifiadau v1.1"
+    "showDetails": "",
+    "status": "",
+    "useCalculations11": "Defnyddiwch Gyfrifiadau v1.1",
+    "useLegacyCalculations": ""
   },
   "chart": {
     "comparisonChart": ""
@@ -27,10 +33,10 @@
   "factDetails": {
     "accuracy": "Cywirdeb",
     "balance": "",
-    "calculationIsConsistent": "Mae'r cyfrifiad yn gyson",
-    "calculationIsInconsistent": "Mae'r cyfrifiad yn anghyson",
     "calculationUnchecked": "Nid yw'r cyfrifiad wedi'i wirio oherwydd presenoldeb ffeithiau dyblyg",
     "calculationUncheckedIncorrectVersion": "Cyfrifiad 1.1 perthnasau heb eu gwirio yn y modd cyfrifo etifeddiaeth",
+    "calculationValuesDoNotMatch": "",
+    "calculationValuesMatch": "",
     "change": "Newid",
     "changeFromIn": "Oddiwrth {{from}} mewn ",
     "changePercentageDecrease": "{{decrease}}gostyngiad % ar ",
@@ -41,15 +47,19 @@
     "dimensions": "Dimensiynau",
     "duplicatesCount": "{{current}} o {{total}}",
     "entity": "Endid",
+    "factCount": "",
     "factValue": "Gwerth Ffaith",
+    "nestedFactSummary": "",
     "nonNumericFact": "ffaith nad yw'n rhifol",
     "noPriorFactInThisReport": "Dim ffaith flaenorol yn yr adroddiad hwn",
     "noUnit": "<NOUNIT>",
     "properties": "Priodweddau",
     "scale": "Graddfa",
+    "source": "",
     "viewCalculationDetails": "Gweld manylion y cyfrifiad"
   },
   "footnotes": {
+    "content": "",
     "footnote": "Troednodyn"
   },
   "inspector": {
@@ -62,66 +72,82 @@
     "contributor": "Cyfranwr",
     "datatypes": "Mathau data",
     "dimensions": "Math Dimensiwn",
-    "documentOutline": "Amlinelliad o'r ddogfen",
-    "documentSummary": "Crynodeb o'r ddogfen",
+    "documentation": "",
     "explicitDimension": "Dimensiynau Penodol",
     "fact-groups": "Adrannau",
-    "factProperties": "Priodweddau Ffaith",
     "factSearch": "Chwiliad Ffeithiau",
     "factValue": "Gwerth Ffaith",
-    "footnoteProperties": "Priodweddau Troednodyn",
     "footnotes": "Troednodiadau",
+    "goToReference": "",
     "hidden": "Gudd",
     "hiddenFact": "Ffaith Gudd",
-    "highlight": "Uchafbwynt",
+    "highlightTags": "",
+    "highlightUntaggedDates": "",
+    "highlightUntaggedNumbers": "",
     "initializing": "Cychwyn",
     "ixbrlInspector": "",
     "labels": "",
+    "language": "",
     "loadingViewer": "Wrthi'n llwytho Gwyliwr iXBRL",
     "mandatoryFacts": "Dim ond Ffeithiau Gorfodol",
     "namespaces": "Gofodau Enw",
-    "narrowerAnchor": "Angorau culach",
+    "narrowerAnchors": "",
     "negative": "Negyddol",
     "nextTag": "Tag nesaf",
+    "noCalculations": "",
+    "noDimensions": "",
     "noFactSelected": "Dim Ffaith wedi'i Dewis",
     "numericOption": "Rhifol",
-    "outlineUnavailable": "Amlinelliad Ddim ar gael",
+    "occurrences": "",
+    "otherFacts": "",
     "period": "Cyfnod",
     "positive": "Cadarnhaol",
     "previousTag": "Tag blaenorol",
     "printDocument": "Argraffu Dogfen",
     "references": "Cyfeiriadau",
-    "reset": "Ailosod",
     "scales": "Graddfeydd",
-    "search": "Chwiliwch",
     "searchReport": "",
     "searchResults": "",
-    "searchTitle": "Chwiliwch",
-    "settingsMenu": "",
     "settings": {
-        "viewerLanguage": {
-            "title": "Iaith Cais"
-        }
+      "calculationMode": {
+        "documentation": "",
+        "title": ""
+      },
+      "colorMode": {
+        "documentation": "",
+        "title": ""
+      },
+      "title": "",
+      "viewerLanguage": {
+        "documentation": "",
+        "title": "Iaith Cais"
+      }
     },
     "showAnalysisChart": "",
+    "showMore": "",
     "showTextOnly": "Dangos testun yn unig",
     "summary": {
+      "about": {
+        "entity": "",
+        "name": "",
+        "seeMoreReferenceData": "",
+        "title": ""
+      },
+      "aboutCompany": {
+        "header": ""
+      },
+      "downloads": {
+        "header": ""
+      },
       "fact": {
         "header": "Crynodeb o Ffeithiau",
         "hidden": "Ffeithiau cudd",
         "mandatory": "Ffeithiau Gorfodol",
         "total": "Cyfanswm y Ffeithiau"
       },
-      "file": {
-        "calculations": "Cronfeydd Cyswllt Cyfrifo",
-        "definitions": "Diffiniad Basau Cyswllt",
-        "header": "Crynodeb Ffeil",
-        "inline": "Dogfennau Mewnol",
-        "labels": "Label Linkbases",
-        "other": "Cronfeydd Cyswllt Eraill",
-        "presentation": "Basau Cyswllt Cyflwyniad",
-        "references": "Basau Cyswllt Cyfeiriad",
-        "schemas": "Sgemâu"
+      "factSource": "",
+      "includedDocuments": {
+        "header": ""
       },
       "reportCreation": "Creu Adroddiad",
       "tag": {
@@ -129,12 +155,15 @@
         "colDimensions": "Dimensiynau",
         "colMembers": "Aelodau",
         "colNamespace": "Gofod Enw",
-        "colTotal": "Cyfanswm",
-        "header": "Crynodeb Tag",
         "rowTotal": "Cyfanswm"
       }
     },
     "summation": "Crynhoad",
+    "tabs": {
+      "overview": "",
+      "search": "",
+      "xbrlFacts": ""
+    },
     "targetDocument": "Dogfen Darged",
     "textOption": "Testun",
     "typedDimensions": "Dimensiynau wedi'u Teipio",
@@ -145,40 +174,34 @@
     "validationSeverity": "Difrifoldeb",
     "visibility": "Gwelededd",
     "visible": "Gweladwy",
-    "widerAnchor": "Angor ehangach",
+    "widerAnchors": "",
     "xbrlGlossaryOpensInNewTab": "Geirfa XBRL (yn agor mewn tab newydd)"
   },
   "menu": {
-    "actions": "Gweithredoedd",
-    "applicationLanguage": "Iaith Cais",
     "contactUs": "Cysylltwch â Ni",
-    "documentLanguage": "Iaith Dogfen",
-    "help": "Cymorth",
-    "options": "Opsiynau",
     "survey": "Arolwg",
     "userGuide": "Canllaw Defnyddiwr"
   },
   "search": {
     "concealedFact": "Ffaith guddiedig",
-    "dataTypeConflictWarning": "",
     "default": "rhagosodedig",
-    "filter": "Hidlo",
     "hiddenFact": "Ffaith gudd",
     "matchingFactsSummary": "",
     "noMatchFound": "Heb ganfod cyfatebiaeth",
-    "reset": "",
+    "resetFilters": "",
     "selected": "dethol",
     "showMoreResults": "Dangos mwy o ganlyniadau",
+    "showResults": "",
     "toggleFilterControls": "",
     "tryAgainDifferentKeywords": "Ceisiwch eto gyda geiriau allweddol gwahanol",
     "viewFact": ""
   },
   "toolbar": {
-    "homePage": "Hafan",
-    "toggleDarkMode": "Toggle modd tywyll",
-    "xbrlElements": "Elfennau XBRL"
+    "homePage": "Hafan"
   },
   "viewer": {
-    "ixbrlDocumentView": ""
+    "ixbrlDocumentView": "",
+    "zoomIn": "",
+    "zoomOut": ""
   }
 }

--- a/iXBRLViewerPlugin/viewer/src/i18n/cy/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/cy/translation.json
@@ -123,6 +123,7 @@
         "title": "Iaith Cais"
       }
     },
+    "settingsButton": "",
     "showAnalysisChart": "",
     "showMore": "",
     "showTextOnly": "Dangos testun yn unig",

--- a/iXBRLViewerPlugin/viewer/src/i18n/da/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/da/translation.json
@@ -1,15 +1,21 @@
 {
   "calculation": {
     "calculated-total": "Beregnet",
+    "calculationIsConsistent": "",
+    "calculationIsInconsistent": "",
     "concept": "Begreb",
     "consistent-duplicate-facts-present": "{{nfacts}} konsistente dublet-fakta til stede",
     "does-not-bind": "Beregning binder ikke",
     "inconsistent-duplicate-facts-present": "{{nfacts}} inkonsistente dublet-fakta til stede",
     "maximum": "Maksimum",
     "minimum": "Minimum",
+    "notReported": "",
     "reported-total": "Rapporteret",
     "reported-value": "Rapporteret værdi",
-    "useCalculations11": "Brug Beregninger v1.1"
+    "showDetails": "",
+    "status": "",
+    "useCalculations11": "Brug Beregninger v1.1",
+    "useLegacyCalculations": ""
   },
   "chart": {
     "comparisonChart": "Sammenligningsdiagram"
@@ -27,10 +33,10 @@
   "factDetails": {
     "accuracy": "Præcision",
     "balance": "Balance",
-    "calculationIsConsistent": "Beregning er konsistent",
-    "calculationIsInconsistent": "Beregning er inkonsistent",
     "calculationUnchecked": "Beregning ikke kontrolleret pga. dublet-fakta",
     "calculationUncheckedIncorrectVersion": "Beregning 1.1 relationer ikke kontrolleret i legacy-beregningstilstand",
+    "calculationValuesDoNotMatch": "",
+    "calculationValuesMatch": "",
     "change": "Ændring",
     "changeFromIn": "Fra {{from}} i ",
     "changePercentageDecrease": "{{decrease}}% fald på ",
@@ -41,15 +47,19 @@
     "dimensions": "Dimensioner",
     "duplicatesCount": "{{current}} af {{total}}",
     "entity": "Enhed",
+    "factCount": "",
     "factValue": "Faktaværdi",
+    "nestedFactSummary": "",
     "nonNumericFact": "ikke-numerisk faktum",
     "noPriorFactInThisReport": "Intet tidligere faktum i denne rapport",
     "noUnit": "<INGENENHED>",
     "properties": "Egenskaber",
     "scale": "Skala",
+    "source": "",
     "viewCalculationDetails": "Se beregningsdetaljer"
   },
   "footnotes": {
+    "content": "",
     "footnote": "Fodnote"
   },
   "inspector": {
@@ -62,61 +72,82 @@
     "contributor": "Bidragyder",
     "datatypes": "Typer",
     "dimensions": "Dimensionstype",
-    "documentOutline": "Dokumentoversigt",
-    "documentSummary": "Dokumentsammenfatning",
+    "documentation": "",
     "explicitDimension": "Eksplícitte dimensioner",
     "fact-groups": "Sektioner",
-    "factProperties": "Faktaegenskaber",
     "factSearch": "Faktasøgning",
     "factValue": "Faktaværdi",
-    "footnoteProperties": "Fodnoteegenskaber",
     "footnotes": "Fodnoter",
+    "goToReference": "",
     "hidden": "Skjult",
     "hiddenFact": "Skjult faktum",
-    "highlight": "Fremhæv",
+    "highlightTags": "",
+    "highlightUntaggedDates": "",
+    "highlightUntaggedNumbers": "",
     "initializing": "Initialiserer",
     "ixbrlInspector": "iXBRL Inspektør",
     "labels": "",
+    "language": "",
     "loadingViewer": "Indlæser iXBRL Viewer",
     "mandatoryFacts": "Kun obligatoriske fakta",
     "namespaces": "Navnerum",
-    "narrowerAnchor": "Smalere forankringer",
+    "narrowerAnchors": "",
     "negative": "Negativ",
     "nextTag": "Næste tag",
+    "noCalculations": "",
+    "noDimensions": "",
     "noFactSelected": "Intet faktum valgt",
     "numericOption": "Numerisk",
-    "outlineUnavailable": "Oversigt ikke tilgængelig",
+    "occurrences": "",
+    "otherFacts": "",
     "period": "Periode",
     "positive": "Positiv",
     "previousTag": "Forrige tag",
     "printDocument": "Udskriv dokument",
     "references": "Referencer",
-    "reset": "Nulstil",
     "scales": "Skalaer",
-    "search": "Søg",
     "searchReport": "Søg iXBRL rapport",
     "searchResults": "Søgeresultater",
-    "searchTitle": "Søg",
-    "settingsMenu": "Indstillingsmenu",
+    "settings": {
+      "calculationMode": {
+        "documentation": "",
+        "title": ""
+      },
+      "colorMode": {
+        "documentation": "",
+        "title": ""
+      },
+      "title": "",
+      "viewerLanguage": {
+        "documentation": "",
+        "title": ""
+      }
+    },
     "showAnalysisChart": "Vis analyse diagram",
+    "showMore": "",
     "showTextOnly": "Vis kun tekst",
     "summary": {
+      "about": {
+        "entity": "",
+        "name": "",
+        "seeMoreReferenceData": "",
+        "title": ""
+      },
+      "aboutCompany": {
+        "header": ""
+      },
+      "downloads": {
+        "header": ""
+      },
       "fact": {
         "header": "Faktaoversigt",
         "hidden": "Skjulte fakta",
         "mandatory": "Obligatoriske fakta",
         "total": "Totale fakta"
       },
-      "file": {
-        "calculations": "Beregning linkbaser",
-        "definitions": "Definitions linkbaser",
-        "header": "Filoversigt",
-        "inline": "Inline dokumenter",
-        "labels": "Label linkbaser",
-        "other": "Andre linkbaser",
-        "presentation": "Præsentations linkbaser",
-        "references": "Reference linkbaser",
-        "schemas": "Skemaer"
+      "factSource": "",
+      "includedDocuments": {
+        "header": ""
       },
       "reportCreation": "Rapportoprettelse",
       "tag": {
@@ -124,12 +155,15 @@
         "colDimensions": "Dimensioner",
         "colMembers": "Medlemmer",
         "colNamespace": "Navnerum",
-        "colTotal": "Total",
-        "header": "Tag oversigt",
         "rowTotal": "Total"
       }
     },
     "summation": "Opsummering",
+    "tabs": {
+      "overview": "",
+      "search": "",
+      "xbrlFacts": ""
+    },
     "targetDocument": "Måldokument",
     "textOption": "Tekst",
     "typedDimensions": "Typedimensioner",
@@ -140,40 +174,34 @@
     "validationSeverity": "Alvorlighed",
     "visibility": "Synlighed",
     "visible": "Synlig",
-    "widerAnchor": "Bredere forankring",
+    "widerAnchors": "",
     "xbrlGlossaryOpensInNewTab": "XBRL-ordbog (åbner i ny fane)"
   },
   "menu": {
-    "actions": "Handlinger",
-    "applicationLanguage": "Applikationssprog",
     "contactUs": "Kontakt os",
-    "documentLanguage": "Dokumentsprog",
-    "help": "Hjælp",
-    "options": "Indstillinger",
     "survey": "Undersøgelse",
     "userGuide": "Brugervejledning"
   },
   "search": {
     "concealedFact": "Skjult faktum",
-    "dataTypeConflictWarning": "Advarsel: valg konflikter med filter for begrebstype",
     "default": "standard",
-    "filter": "Filter",
     "hiddenFact": "Skjult faktum",
     "matchingFactsSummary": "Viser {{nMatches}} af {{nTotal}} fakta",
     "noMatchFound": "Ingen match fundet",
-    "reset": "Nulstil",
+    "resetFilters": "",
     "selected": "valgt",
     "showMoreResults": "Vis flere resultater",
+    "showResults": "",
     "toggleFilterControls": "Skift filterkontroller",
     "tryAgainDifferentKeywords": "Prøv igen med andre søgeord",
     "viewFact": "Se faktum"
   },
   "toolbar": {
-    "homePage": "Hjem",
-    "toggleDarkMode": "Skift mørk tilstand",
-    "xbrlElements": "XBRL-elementer"
+    "homePage": "Hjem"
   },
   "viewer": {
-    "ixbrlDocumentView": "iXBRL dokumentvisning"
+    "ixbrlDocumentView": "iXBRL dokumentvisning",
+    "zoomIn": "",
+    "zoomOut": ""
   }
 }

--- a/iXBRLViewerPlugin/viewer/src/i18n/da/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/da/translation.json
@@ -123,6 +123,7 @@
         "title": ""
       }
     },
+    "settingsButton": "",
     "showAnalysisChart": "Vis analyse diagram",
     "showMore": "",
     "showTextOnly": "Vis kun tekst",

--- a/iXBRLViewerPlugin/viewer/src/i18n/da/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/da/translation.json
@@ -1,21 +1,21 @@
 {
   "calculation": {
     "calculated-total": "Beregnet",
-    "calculationIsConsistent": "",
-    "calculationIsInconsistent": "",
+    "calculationIsConsistent": "Beregningen er konsistent",
+    "calculationIsInconsistent": "Beregningen er inkonsistent",
     "concept": "Begreb",
     "consistent-duplicate-facts-present": "{{nfacts}} konsistente dublet-fakta til stede",
     "does-not-bind": "Beregning binder ikke",
     "inconsistent-duplicate-facts-present": "{{nfacts}} inkonsistente dublet-fakta til stede",
     "maximum": "Maksimum",
     "minimum": "Minimum",
-    "notReported": "",
+    "notReported": "ikke indberettet",
     "reported-total": "Rapporteret",
     "reported-value": "Rapporteret værdi",
-    "showDetails": "",
-    "status": "",
+    "showDetails": "Vis detaljer",
+    "status": "Status",
     "useCalculations11": "Brug Beregninger v1.1",
-    "useLegacyCalculations": ""
+    "useLegacyCalculations": "Brug ældre beregninger"
   },
   "chart": {
     "comparisonChart": "Sammenligningsdiagram"
@@ -35,8 +35,8 @@
     "balance": "Balance",
     "calculationUnchecked": "Beregning ikke kontrolleret pga. dublet-fakta",
     "calculationUncheckedIncorrectVersion": "Beregning 1.1 relationer ikke kontrolleret i legacy-beregningstilstand",
-    "calculationValuesDoNotMatch": "",
-    "calculationValuesMatch": "",
+    "calculationValuesDoNotMatch": "Indberettede og beregnede værdier stemmer ikke overens",
+    "calculationValuesMatch": "Indberettede og beregnede værdier stemmer overens",
     "change": "Ændring",
     "changeFromIn": "Fra {{from}} i ",
     "changePercentageDecrease": "{{decrease}}% fald på ",
@@ -47,19 +47,19 @@
     "dimensions": "Dimensioner",
     "duplicatesCount": "{{current}} af {{total}}",
     "entity": "Enhed",
-    "factCount": "",
+    "factCount": "{{current}} af {{total}}",
     "factValue": "Faktaværdi",
-    "nestedFactSummary": "",
+    "nestedFactSummary": "Viser {{current}} af {{total}} indlejrede fakta:",
     "nonNumericFact": "ikke-numerisk faktum",
     "noPriorFactInThisReport": "Intet tidligere faktum i denne rapport",
     "noUnit": "<INGENENHED>",
     "properties": "Egenskaber",
     "scale": "Skala",
-    "source": "",
+    "source": "Kilde",
     "viewCalculationDetails": "Se beregningsdetaljer"
   },
   "footnotes": {
-    "content": "",
+    "content": "Indhold",
     "footnote": "Fodnote"
   },
   "inspector": {
@@ -72,35 +72,35 @@
     "contributor": "Bidragyder",
     "datatypes": "Typer",
     "dimensions": "Dimensionstype",
-    "documentation": "",
+    "documentation": "Dokumentation",
     "explicitDimension": "Eksplícitte dimensioner",
     "fact-groups": "Sektioner",
     "factSearch": "Faktasøgning",
     "factValue": "Faktaværdi",
     "footnotes": "Fodnoter",
-    "goToReference": "",
+    "goToReference": "Gå til reference",
     "hidden": "Skjult",
     "hiddenFact": "Skjult faktum",
-    "highlightMenu": "",
-    "highlightTags": "",
-    "highlightUntaggedDates": "",
-    "highlightUntaggedNumbers": "",
+    "highlightMenu": "Fremhævningsindstillinger",
+    "highlightTags": "Fremhæv tags",
+    "highlightUntaggedDates": "Fremhæv utaggede datoer",
+    "highlightUntaggedNumbers": "Fremhæv utaggede tal",
     "initializing": "Initialiserer",
     "ixbrlInspector": "iXBRL Inspektør",
-    "labels": "",
-    "language": "",
+    "labels": "Etiketter",
+    "language": "Sprog",
     "loadingViewer": "Indlæser iXBRL Viewer",
     "mandatoryFacts": "Kun obligatoriske fakta",
     "namespaces": "Navnerum",
-    "narrowerAnchors": "",
+    "narrowerAnchors": "Smallere ankre",
     "negative": "Negativ",
     "nextTag": "Næste tag",
-    "noCalculations": "",
-    "noDimensions": "",
+    "noCalculations": "Ingen beregninger",
+    "noDimensions": "Ingen dimensioner",
     "noFactSelected": "Intet faktum valgt",
     "numericOption": "Numerisk",
-    "occurrences": "",
-    "otherFacts": "",
+    "occurrences": "Forekomster",
+    "otherFacts": "Andre fakta",
     "period": "Periode",
     "positive": "Positiv",
     "previousTag": "Forrige tag",
@@ -111,38 +111,38 @@
     "searchResults": "Søgeresultater",
     "settings": {
       "calculationMode": {
-        "documentation": "",
-        "title": ""
+        "documentation": "Vælg beregningsevalueringstilstand for ældre beregningsrelationer",
+        "title": "Beregningstilstand"
       },
       "colorMode": {
-        "documentation": "",
-        "title": ""
+        "documentation": "Vælg om Inline Viewers udseende skal være lyst eller mørkt",
+        "title": "Fremviserens farvetilstand"
       },
       "plugins": {
-        "title": ""
+        "title": "Plugins"
       },
-      "title": "",
+      "title": "Indstillinger",
       "viewerLanguage": {
-        "documentation": "",
-        "title": ""
+        "documentation": "Vælg det sprog, du vil bruge med Inline Viewer",
+        "title": "Fremviserens sprog"
       }
     },
-    "settingsButton": "",
+    "settingsButton": "Indstillinger",
     "showAnalysisChart": "Vis analyse diagram",
-    "showMore": "",
+    "showMore": "Vis mere",
     "showTextOnly": "Vis kun tekst",
     "summary": {
       "about": {
-        "entity": "",
-        "name": "",
-        "seeMoreReferenceData": "",
-        "title": ""
+        "entity": "Enhed",
+        "name": "Navn",
+        "seeMoreReferenceData": "Se mere {{type}} referencedata",
+        "title": "Titel"
       },
       "aboutCompany": {
-        "header": ""
+        "header": "Om virksomheden"
       },
       "downloads": {
-        "header": ""
+        "header": "Downloads"
       },
       "fact": {
         "header": "Faktaoversigt",
@@ -150,9 +150,9 @@
         "mandatory": "Obligatoriske fakta",
         "total": "Totale fakta"
       },
-      "factSource": "",
+      "factSource": "Faktakilde",
       "includedDocuments": {
-        "header": ""
+        "header": "Inkluderede dokumenter"
       },
       "reportCreation": "Rapportoprettelse",
       "tag": {
@@ -165,9 +165,9 @@
     },
     "summation": "Opsummering",
     "tabs": {
-      "overview": "",
-      "search": "",
-      "xbrlFacts": ""
+      "overview": "Oversigt",
+      "search": "Søg",
+      "xbrlFacts": "XBRL-fakta"
     },
     "targetDocument": "Måldokument",
     "textOption": "Tekst",
@@ -179,7 +179,7 @@
     "validationSeverity": "Alvorlighed",
     "visibility": "Synlighed",
     "visible": "Synlig",
-    "widerAnchors": "",
+    "widerAnchors": "Bredere ankre",
     "xbrlGlossaryOpensInNewTab": "XBRL-ordbog (åbner i ny fane)"
   },
   "menu": {
@@ -193,9 +193,9 @@
     "hiddenFact": "Skjult faktum",
     "matchingFactsSummary": "Viser {{nMatches}} af {{nTotal}} fakta",
     "noMatchFound": "Ingen match fundet",
-    "resetFilters": "",
+    "resetFilters": "Nulstil filtre",
     "showMoreResults": "Vis flere resultater",
-    "showResults": "",
+    "showResults": "Vis resultater",
     "toggleFilterControls": "Skift filterkontroller",
     "tryAgainDifferentKeywords": "Prøv igen med andre søgeord"
   },
@@ -204,7 +204,7 @@
   },
   "viewer": {
     "ixbrlDocumentView": "iXBRL dokumentvisning",
-    "zoomIn": "",
-    "zoomOut": ""
+    "zoomIn": "zoom ind",
+    "zoomOut": "zoom ud"
   }
 }

--- a/iXBRLViewerPlugin/viewer/src/i18n/da/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/da/translation.json
@@ -81,6 +81,7 @@
     "goToReference": "",
     "hidden": "Skjult",
     "hiddenFact": "Skjult faktum",
+    "highlightMenu": "",
     "highlightTags": "",
     "highlightUntaggedDates": "",
     "highlightUntaggedNumbers": "",
@@ -115,6 +116,9 @@
       },
       "colorMode": {
         "documentation": "",
+        "title": ""
+      },
+      "plugins": {
         "title": ""
       },
       "title": "",

--- a/iXBRLViewerPlugin/viewer/src/i18n/da/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/da/translation.json
@@ -190,12 +190,10 @@
     "matchingFactsSummary": "Viser {{nMatches}} af {{nTotal}} fakta",
     "noMatchFound": "Ingen match fundet",
     "resetFilters": "",
-    "selected": "valgt",
     "showMoreResults": "Vis flere resultater",
     "showResults": "",
     "toggleFilterControls": "Skift filterkontroller",
-    "tryAgainDifferentKeywords": "Prøv igen med andre søgeord",
-    "viewFact": "Se faktum"
+    "tryAgainDifferentKeywords": "Prøv igen med andre søgeord"
   },
   "toolbar": {
     "homePage": "Hjem"

--- a/iXBRLViewerPlugin/viewer/src/i18n/de/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/de/translation.json
@@ -1,21 +1,21 @@
 {
   "calculation": {
     "calculated-total": "Berechnet",
-    "calculationIsConsistent": "",
-    "calculationIsInconsistent": "",
+    "calculationIsConsistent": "Berechnung ist konsistent",
+    "calculationIsInconsistent": "Berechnung ist inkonsistent",
     "concept": "Konzept",
     "consistent-duplicate-facts-present": "{{nfacts}} konsistente doppelte Fakten vorhanden",
     "does-not-bind": "Berechnung bindet nicht",
     "inconsistent-duplicate-facts-present": "{{nfacts}} inkonsistente doppelte Fakten vorhanden",
     "maximum": "Maximum",
     "minimum": "Minimum",
-    "notReported": "",
+    "notReported": "nicht gemeldet",
     "reported-total": "Gemeldet",
     "reported-value": "Gemeldeter Wert",
-    "showDetails": "",
-    "status": "",
+    "showDetails": "Details anzeigen",
+    "status": "Status",
     "useCalculations11": "Verwende Berechnungen v1.1",
-    "useLegacyCalculations": ""
+    "useLegacyCalculations": "Legacy-Berechnungen verwenden"
   },
   "chart": {
     "comparisonChart": "Vergleichsdiagramm"
@@ -35,8 +35,8 @@
     "balance": "Saldo",
     "calculationUnchecked": "Berechnung aufgrund doppelter Fakten nicht geprüft",
     "calculationUncheckedIncorrectVersion": "Berechnungsbeziehungen 1.1 im Legacy-Modus nicht geprüft",
-    "calculationValuesDoNotMatch": "",
-    "calculationValuesMatch": "",
+    "calculationValuesDoNotMatch": "Gemeldete und berechnete Werte stimmen nicht überein",
+    "calculationValuesMatch": "Gemeldete und berechnete Werte stimmen überein",
     "change": "Änderung",
     "changeFromIn": "Von {{from}} in ",
     "changePercentageDecrease": "{{decrease}}% Rückgang bei ",
@@ -47,19 +47,19 @@
     "dimensions": "Dimensionen",
     "duplicatesCount": "{{current}} von {{total}}",
     "entity": "Einheit",
-    "factCount": "",
+    "factCount": "{{current}} von {{total}}",
     "factValue": "Faktwert",
-    "nestedFactSummary": "",
+    "nestedFactSummary": "Zeige {{current}} von {{total}} verschachtelten Fakten:",
     "nonNumericFact": "nicht-numerischer Fakt",
     "noPriorFactInThisReport": "Kein vorheriger Fakt in diesem Bericht",
     "noUnit": "<KEINE EINHEIT>",
     "properties": "Eigenschaften",
     "scale": "Skalierung",
-    "source": "",
+    "source": "Quelle",
     "viewCalculationDetails": "Berechnungsdetails ansehen"
   },
   "footnotes": {
-    "content": "",
+    "content": "Inhalt",
     "footnote": "Fußnote"
   },
   "inspector": {
@@ -72,35 +72,35 @@
     "contributor": "Beitragender",
     "datatypes": "Typen",
     "dimensions": "Dimensionstyp",
-    "documentation": "",
+    "documentation": "Dokumentation",
     "explicitDimension": "Explizite Dimensionen",
     "fact-groups": "Abschnitte",
     "factSearch": "Faktsuche",
     "factValue": "Faktwert",
     "footnotes": "Fußnoten",
-    "goToReference": "",
+    "goToReference": "Zur Referenz gehen",
     "hidden": "Versteckt",
     "hiddenFact": "Versteckter Fakt",
-    "highlightMenu": "",
-    "highlightTags": "",
-    "highlightUntaggedDates": "",
-    "highlightUntaggedNumbers": "",
+    "highlightMenu": "Hervorhebungsoptionen",
+    "highlightTags": "Tags hervorheben",
+    "highlightUntaggedDates": "Nicht getaggte Daten hervorheben",
+    "highlightUntaggedNumbers": "Nicht getaggte Zahlen hervorheben",
     "initializing": "Initialisierung",
     "ixbrlInspector": "iXBRL-Inspektor",
-    "labels": "",
-    "language": "",
+    "labels": "Bezeichnungen",
+    "language": "Sprache",
     "loadingViewer": "Lade iXBRL-Viewer",
     "mandatoryFacts": "Nur Pflichtfakten",
     "namespaces": "Namespaces",
-    "narrowerAnchors": "",
+    "narrowerAnchors": "Engere Verankerungen",
     "negative": "Negativ",
     "nextTag": "Nächstes Tag",
-    "noCalculations": "",
-    "noDimensions": "",
+    "noCalculations": "Keine Berechnungen",
+    "noDimensions": "Keine Dimensionen",
     "noFactSelected": "Kein Fakt ausgewählt",
     "numericOption": "Numerisch",
-    "occurrences": "",
-    "otherFacts": "",
+    "occurrences": "Vorkommen",
+    "otherFacts": "Andere Fakten",
     "period": "Periode",
     "positive": "Positiv",
     "previousTag": "Vorheriges Tag",
@@ -111,38 +111,38 @@
     "searchResults": "Suchergebnisse",
     "settings": {
       "calculationMode": {
-        "documentation": "",
-        "title": ""
+        "documentation": "Wählen Sie den Berechnungsauswertungsmodus für Legacy-Berechnungsbeziehungen",
+        "title": "Berechnungsmodus"
       },
       "colorMode": {
-        "documentation": "",
-        "title": ""
+        "documentation": "Wählen Sie, ob das Erscheinungsbild des Inline Viewers hell oder dunkel sein soll",
+        "title": "Viewer-Farbmodus"
       },
       "plugins": {
-        "title": ""
+        "title": "Plugins"
       },
-      "title": "",
+      "title": "Einstellungen",
       "viewerLanguage": {
-        "documentation": "",
-        "title": ""
+        "documentation": "Wählen Sie die Sprache, die Sie mit dem Inline Viewer verwenden möchten",
+        "title": "Viewer-Sprache"
       }
     },
-    "settingsButton": "",
+    "settingsButton": "Einstellungen",
     "showAnalysisChart": "Analyse-Diagramm anzeigen",
-    "showMore": "",
+    "showMore": "Mehr anzeigen",
     "showTextOnly": "Nur Text anzeigen",
     "summary": {
       "about": {
-        "entity": "",
-        "name": "",
-        "seeMoreReferenceData": "",
-        "title": ""
+        "entity": "Einheit",
+        "name": "Name",
+        "seeMoreReferenceData": "Weitere {{type}}-Referenzdaten anzeigen",
+        "title": "Titel"
       },
       "aboutCompany": {
-        "header": ""
+        "header": "Über das Unternehmen"
       },
       "downloads": {
-        "header": ""
+        "header": "Downloads"
       },
       "fact": {
         "header": "Faktzusammenfassung",
@@ -150,9 +150,9 @@
         "mandatory": "Pflichtfakten",
         "total": "Gesamtfakten"
       },
-      "factSource": "",
+      "factSource": "Faktenquelle",
       "includedDocuments": {
-        "header": ""
+        "header": "Enthaltene Dokumente"
       },
       "reportCreation": "Berichtserstellung",
       "tag": {
@@ -165,9 +165,9 @@
     },
     "summation": "Summe",
     "tabs": {
-      "overview": "",
-      "search": "",
-      "xbrlFacts": ""
+      "overview": "Übersicht",
+      "search": "Suche",
+      "xbrlFacts": "XBRL-Fakten"
     },
     "targetDocument": "Zieldokument",
     "textOption": "Text",
@@ -179,7 +179,7 @@
     "validationSeverity": "Schweregrad",
     "visibility": "Sichtbarkeit",
     "visible": "Sichtbar",
-    "widerAnchors": "",
+    "widerAnchors": "Weitere Verankerungen",
     "xbrlGlossaryOpensInNewTab": "XBRL-Glossar (öffnet sich in neuem Tab)"
   },
   "menu": {
@@ -193,9 +193,9 @@
     "hiddenFact": "Versteckter Fakt",
     "matchingFactsSummary": "Zeige {{nMatches}} von {{nTotal}} Fakten",
     "noMatchFound": "Keine Übereinstimmung gefunden",
-    "resetFilters": "",
+    "resetFilters": "Filter zurücksetzen",
     "showMoreResults": "Mehr Ergebnisse anzeigen",
-    "showResults": "",
+    "showResults": "Ergebnisse anzeigen",
     "toggleFilterControls": "Filtersteuerung umschalten",
     "tryAgainDifferentKeywords": "Versuchen Sie es mit anderen Schlüsselwörtern erneut"
   },
@@ -204,7 +204,7 @@
   },
   "viewer": {
     "ixbrlDocumentView": "iXBRL-Dokumentansicht",
-    "zoomIn": "",
-    "zoomOut": ""
+    "zoomIn": "Vergrößern",
+    "zoomOut": "Verkleinern"
   }
 }

--- a/iXBRLViewerPlugin/viewer/src/i18n/de/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/de/translation.json
@@ -1,15 +1,21 @@
 {
   "calculation": {
     "calculated-total": "Berechnet",
+    "calculationIsConsistent": "",
+    "calculationIsInconsistent": "",
     "concept": "Konzept",
     "consistent-duplicate-facts-present": "{{nfacts}} konsistente doppelte Fakten vorhanden",
     "does-not-bind": "Berechnung bindet nicht",
     "inconsistent-duplicate-facts-present": "{{nfacts}} inkonsistente doppelte Fakten vorhanden",
     "maximum": "Maximum",
     "minimum": "Minimum",
+    "notReported": "",
     "reported-total": "Gemeldet",
     "reported-value": "Gemeldeter Wert",
-    "useCalculations11": "Verwende Berechnungen v1.1"
+    "showDetails": "",
+    "status": "",
+    "useCalculations11": "Verwende Berechnungen v1.1",
+    "useLegacyCalculations": ""
   },
   "chart": {
     "comparisonChart": "Vergleichsdiagramm"
@@ -27,10 +33,10 @@
   "factDetails": {
     "accuracy": "Genauigkeit",
     "balance": "Saldo",
-    "calculationIsConsistent": "Berechnung ist konsistent",
-    "calculationIsInconsistent": "Berechnung ist inkonsistent",
     "calculationUnchecked": "Berechnung aufgrund doppelter Fakten nicht geprüft",
     "calculationUncheckedIncorrectVersion": "Berechnungsbeziehungen 1.1 im Legacy-Modus nicht geprüft",
+    "calculationValuesDoNotMatch": "",
+    "calculationValuesMatch": "",
     "change": "Änderung",
     "changeFromIn": "Von {{from}} in ",
     "changePercentageDecrease": "{{decrease}}% Rückgang bei ",
@@ -41,15 +47,19 @@
     "dimensions": "Dimensionen",
     "duplicatesCount": "{{current}} von {{total}}",
     "entity": "Einheit",
+    "factCount": "",
     "factValue": "Faktwert",
+    "nestedFactSummary": "",
     "nonNumericFact": "nicht-numerischer Fakt",
     "noPriorFactInThisReport": "Kein vorheriger Fakt in diesem Bericht",
     "noUnit": "<KEINE EINHEIT>",
     "properties": "Eigenschaften",
     "scale": "Skalierung",
+    "source": "",
     "viewCalculationDetails": "Berechnungsdetails ansehen"
   },
   "footnotes": {
+    "content": "",
     "footnote": "Fußnote"
   },
   "inspector": {
@@ -62,61 +72,82 @@
     "contributor": "Beitragender",
     "datatypes": "Typen",
     "dimensions": "Dimensionstyp",
-    "documentOutline": "Dokumentübersicht",
-    "documentSummary": "Dokumentzusammenfassung",
+    "documentation": "",
     "explicitDimension": "Explizite Dimensionen",
     "fact-groups": "Abschnitte",
-    "factProperties": "Fakteigenschaften",
     "factSearch": "Faktsuche",
     "factValue": "Faktwert",
-    "footnoteProperties": "Fußnoteneigenschaften",
     "footnotes": "Fußnoten",
+    "goToReference": "",
     "hidden": "Versteckt",
     "hiddenFact": "Versteckter Fakt",
-    "highlight": "Hervorheben",
+    "highlightTags": "",
+    "highlightUntaggedDates": "",
+    "highlightUntaggedNumbers": "",
     "initializing": "Initialisierung",
     "ixbrlInspector": "iXBRL-Inspektor",
     "labels": "",
+    "language": "",
     "loadingViewer": "Lade iXBRL-Viewer",
     "mandatoryFacts": "Nur Pflichtfakten",
     "namespaces": "Namespaces",
-    "narrowerAnchor": "Engere Verankerungen",
+    "narrowerAnchors": "",
     "negative": "Negativ",
     "nextTag": "Nächstes Tag",
+    "noCalculations": "",
+    "noDimensions": "",
     "noFactSelected": "Kein Fakt ausgewählt",
     "numericOption": "Numerisch",
-    "outlineUnavailable": "Übersicht nicht verfügbar",
+    "occurrences": "",
+    "otherFacts": "",
     "period": "Periode",
     "positive": "Positiv",
     "previousTag": "Vorheriges Tag",
     "printDocument": "Dokument drucken",
     "references": "Referenzen",
-    "reset": "Zurücksetzen",
     "scales": "Skalen",
-    "search": "Suche",
     "searchReport": "iXBRL-Bericht durchsuchen",
     "searchResults": "Suchergebnisse",
-    "searchTitle": "Suche",
-    "settingsMenu": "Einstellungsmenü",
+    "settings": {
+      "calculationMode": {
+        "documentation": "",
+        "title": ""
+      },
+      "colorMode": {
+        "documentation": "",
+        "title": ""
+      },
+      "title": "",
+      "viewerLanguage": {
+        "documentation": "",
+        "title": ""
+      }
+    },
     "showAnalysisChart": "Analyse-Diagramm anzeigen",
+    "showMore": "",
     "showTextOnly": "Nur Text anzeigen",
     "summary": {
+      "about": {
+        "entity": "",
+        "name": "",
+        "seeMoreReferenceData": "",
+        "title": ""
+      },
+      "aboutCompany": {
+        "header": ""
+      },
+      "downloads": {
+        "header": ""
+      },
       "fact": {
         "header": "Faktzusammenfassung",
         "hidden": "Versteckte Fakten",
         "mandatory": "Pflichtfakten",
         "total": "Gesamtfakten"
       },
-      "file": {
-        "calculations": "Berechnungs-Linkbases",
-        "definitions": "Definitions-Linkbases",
-        "header": "Dateizusammenfassung",
-        "inline": "Inline-Dokumente",
-        "labels": "Label-Linkbases",
-        "other": "Andere Linkbases",
-        "presentation": "Präsentations-Linkbases",
-        "references": "Referenz-Linkbases",
-        "schemas": "Schemata"
+      "factSource": "",
+      "includedDocuments": {
+        "header": ""
       },
       "reportCreation": "Berichtserstellung",
       "tag": {
@@ -124,12 +155,15 @@
         "colDimensions": "Dimensionen",
         "colMembers": "Mitglieder",
         "colNamespace": "Namespace",
-        "colTotal": "Gesamt",
-        "header": "Tag-Zusammenfassung",
         "rowTotal": "Gesamt"
       }
     },
     "summation": "Summe",
+    "tabs": {
+      "overview": "",
+      "search": "",
+      "xbrlFacts": ""
+    },
     "targetDocument": "Zieldokument",
     "textOption": "Text",
     "typedDimensions": "Typisierte Dimensionen",
@@ -140,40 +174,34 @@
     "validationSeverity": "Schweregrad",
     "visibility": "Sichtbarkeit",
     "visible": "Sichtbar",
-    "widerAnchor": "Weitere Verankerung",
+    "widerAnchors": "",
     "xbrlGlossaryOpensInNewTab": "XBRL-Glossar (öffnet sich in neuem Tab)"
   },
   "menu": {
-    "actions": "Aktionen",
-    "applicationLanguage": "Anwendungssprache",
     "contactUs": "Kontaktieren Sie uns",
-    "documentLanguage": "Dokumentsprache",
-    "help": "Hilfe",
-    "options": "Optionen",
     "survey": "Umfrage",
     "userGuide": "Benutzerhandbuch"
   },
   "search": {
     "concealedFact": "Verdeckter Fakt",
-    "dataTypeConflictWarning": "Warnung: Auswahl steht im Konflikt mit dem Filter für Konzepttypen",
     "default": "Standard",
-    "filter": "Filter",
     "hiddenFact": "Versteckter Fakt",
     "matchingFactsSummary": "Zeige {{nMatches}} von {{nTotal}} Fakten",
     "noMatchFound": "Keine Übereinstimmung gefunden",
-    "reset": "Zurücksetzen",
+    "resetFilters": "",
     "selected": "ausgewählt",
     "showMoreResults": "Mehr Ergebnisse anzeigen",
+    "showResults": "",
     "toggleFilterControls": "Filtersteuerung umschalten",
     "tryAgainDifferentKeywords": "Versuchen Sie es mit anderen Schlüsselwörtern erneut",
     "viewFact": "Fakt anzeigen"
   },
   "toolbar": {
-    "homePage": "Startseite",
-    "toggleDarkMode": "Dunkelmodus umschalten",
-    "xbrlElements": "XBRL-Elemente"
+    "homePage": "Startseite"
   },
   "viewer": {
-    "ixbrlDocumentView": "iXBRL-Dokumentansicht"
+    "ixbrlDocumentView": "iXBRL-Dokumentansicht",
+    "zoomIn": "",
+    "zoomOut": ""
   }
 }

--- a/iXBRLViewerPlugin/viewer/src/i18n/de/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/de/translation.json
@@ -190,12 +190,10 @@
     "matchingFactsSummary": "Zeige {{nMatches}} von {{nTotal}} Fakten",
     "noMatchFound": "Keine Übereinstimmung gefunden",
     "resetFilters": "",
-    "selected": "ausgewählt",
     "showMoreResults": "Mehr Ergebnisse anzeigen",
     "showResults": "",
     "toggleFilterControls": "Filtersteuerung umschalten",
-    "tryAgainDifferentKeywords": "Versuchen Sie es mit anderen Schlüsselwörtern erneut",
-    "viewFact": "Fakt anzeigen"
+    "tryAgainDifferentKeywords": "Versuchen Sie es mit anderen Schlüsselwörtern erneut"
   },
   "toolbar": {
     "homePage": "Startseite"

--- a/iXBRLViewerPlugin/viewer/src/i18n/de/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/de/translation.json
@@ -123,6 +123,7 @@
         "title": ""
       }
     },
+    "settingsButton": "",
     "showAnalysisChart": "Analyse-Diagramm anzeigen",
     "showMore": "",
     "showTextOnly": "Nur Text anzeigen",

--- a/iXBRLViewerPlugin/viewer/src/i18n/de/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/de/translation.json
@@ -81,6 +81,7 @@
     "goToReference": "",
     "hidden": "Versteckt",
     "hiddenFact": "Versteckter Fakt",
+    "highlightMenu": "",
     "highlightTags": "",
     "highlightUntaggedDates": "",
     "highlightUntaggedNumbers": "",
@@ -115,6 +116,9 @@
       },
       "colorMode": {
         "documentation": "",
+        "title": ""
+      },
+      "plugins": {
         "title": ""
       },
       "title": "",

--- a/iXBRLViewerPlugin/viewer/src/i18n/en/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/en/translation.json
@@ -190,12 +190,10 @@
     "matchingFactsSummary": "Showing {{nMatches}} of {{nTotal}} facts",
     "noMatchFound": "No match found",
     "resetFilters": "Reset filters",
-    "selected": "selected",
     "showMoreResults": "Show more results",
     "showResults": "Show results",
     "toggleFilterControls": "Toggler filter controls",
-    "tryAgainDifferentKeywords": "Try again with different keywords",
-    "viewFact": "View fact"
+    "tryAgainDifferentKeywords": "Try again with different keywords"
   },
   "toolbar": {
     "homePage": "Home"

--- a/iXBRLViewerPlugin/viewer/src/i18n/en/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/en/translation.json
@@ -123,6 +123,7 @@
         "title": "Viewer language"
       }
     },
+    "settingsButton": "Settings",
     "showAnalysisChart": "Show analysis chart",
     "showMore": "Show more",
     "showTextOnly": "Show text only",

--- a/iXBRLViewerPlugin/viewer/src/i18n/en/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/en/translation.json
@@ -81,6 +81,7 @@
     "goToReference": "Go to reference",
     "hidden": "Hidden",
     "hiddenFact": "Hidden Fact",
+    "highlightMenu": "Highlight options",
     "highlightTags": "Highlight tags",
     "highlightUntaggedDates": "Highlight untagged dates",
     "highlightUntaggedNumbers": "Highlight untagged numbers",
@@ -116,6 +117,9 @@
       "colorMode": {
         "documentation": "Choose if Inline Viewer's appearance should be light or dark",
         "title": "Viewer color mode"
+      },
+      "plugins": {
+        "title": "Plugins"
       },
       "title": "Settings",
       "viewerLanguage": {

--- a/iXBRLViewerPlugin/viewer/src/i18n/en/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/en/translation.json
@@ -35,6 +35,8 @@
     "balance": "Balance",
     "calculationUnchecked": "Calculation not checked due to presence of duplicate facts",
     "calculationUncheckedIncorrectVersion": "Calculation 1.1 relationships not checked in legacy calculation mode",
+    "calculationValuesDoNotMatch": "Reported and calculated values do not match",
+    "calculationValuesMatch": "Reported and calculated values match",
     "change": "Change",
     "changeFromIn": "From {{from}} in ",
     "changePercentageDecrease": "{{decrease}}% decrease on ",
@@ -45,22 +47,20 @@
     "dimensions": "Dimensions",
     "duplicatesCount": "{{current}} of {{total}}",
     "entity": "Entity",
-    "factValue": "Fact Value",
     "factCount": "{{current}} of {{total}}",
+    "factValue": "Fact Value",
     "nestedFactSummary": "Showing {{current}} of {{total}} nested facts:",
     "nonNumericFact": "non-numeric fact",
     "noPriorFactInThisReport": "No prior fact in this report",
     "noUnit": "<NOUNIT>",
     "properties": "Properties",
     "scale": "Scale",
-    "source": "Source", 
-    "calculationValuesMatch": "Reported and calculated values match",
-    "calculationValuesDoNotMatch": "Reported and calculated values do not match",
+    "source": "Source",
     "viewCalculationDetails": "View calculation details"
   },
   "footnotes": {
-    "footnote": "Footnote",
-    "content": "Content"
+    "content": "Content",
+    "footnote": "Footnote"
   },
   "inspector": {
     "anchoring": "Anchoring",
@@ -72,23 +72,21 @@
     "contributor": "Contributor",
     "datatypes": "Types",
     "dimensions": "Dimension Type",
-    "documentOutline": "Document outline",
-    "documentSummary": "Document summary",
+    "documentation": "Documentation",
     "explicitDimension": "Explicit Dimensions",
     "fact-groups": "Sections",
-    "factProperties": "Fact Properties",
     "factSearch": "Fact Search",
     "factValue": "Fact Value",
-    "footnoteProperties": "Footnote Properties",
     "footnotes": "Footnotes",
     "goToReference": "Go to reference",
     "hidden": "Hidden",
     "hiddenFact": "Hidden Fact",
-    "highlight": "Highlight",
     "highlightTags": "Highlight tags",
+    "highlightUntaggedDates": "Highlight untagged dates",
+    "highlightUntaggedNumbers": "Highlight untagged numbers",
     "initializing": "Initializing",
     "ixbrlInspector": "iXBRL Inspector",
-    "labels": "",
+    "labels": "Labels",
     "language": "Language",
     "loadingViewer": "Loading iXBRL Viewer",
     "mandatoryFacts": "Mandatory Facts",
@@ -101,55 +99,55 @@
     "noFactSelected": "No Fact Selected",
     "numericOption": "Numeric",
     "occurrences": "Occurrences",
-    "outlineUnavailable": "Outline Unavailable",
     "otherFacts": "Other Facts",
     "period": "Period",
     "positive": "Positive",
     "previousTag": "Previous tag",
     "printDocument": "Print Document",
     "references": "References",
-    "reset": "Reset",
     "scales": "Scales",
-    "search": "Search",
     "searchReport": "Search iXBRL Report",
     "searchResults": "Search Results",
-    "searchTitle": "Search",
-    "settingsMenu": "Settings Menu",
     "settings": {
-        "title": "Settings",
-        "colorMode": {
-            "title": "Viewer color mode",
-            "documentation": "Choose if Inline Viewer's appearance should be light or dark"
-        },
-        "viewerLanguage": {
-            "title": "Viewer language",
-            "documentation": "Select the language you'd like to use with Inline Viewer"
-        },
-        "calculationMode": {
-            "title": "Calculation mode",
-            "documentation": "Select the calculation evaluation mode for legacy calculation relationships"
-        }
+      "calculationMode": {
+        "documentation": "Select the calculation evaluation mode for legacy calculation relationships",
+        "title": "Calculation mode"
+      },
+      "colorMode": {
+        "documentation": "Choose if Inline Viewer's appearance should be light or dark",
+        "title": "Viewer color mode"
+      },
+      "title": "Settings",
+      "viewerLanguage": {
+        "documentation": "Select the language you'd like to use with Inline Viewer",
+        "title": "Viewer language"
+      }
     },
     "showAnalysisChart": "Show analysis chart",
     "showMore": "Show more",
     "showTextOnly": "Show text only",
     "summary": {
+      "about": {
+        "entity": "Entity",
+        "name": "Name",
+        "seeMoreReferenceData": "See more {{type}} reference data",
+        "title": "Title"
+      },
+      "aboutCompany": {
+        "header": "About company"
+      },
+      "downloads": {
+        "header": "Downloads"
+      },
       "fact": {
         "header": "XBRL facts summary",
         "hidden": "Hidden",
         "mandatory": "Mandatory facts",
         "total": "Total"
       },
-      "file": {
-        "calculations": "Calculation Linkbases",
-        "definitions": "Definition Linkbases",
-        "header": "File Summary",
-        "inline": "Inline Documents",
-        "labels": "Label Linkbases",
-        "other": "Other Linkbases",
-        "presentation": "Presentation Linkbases",
-        "references": "Reference Linkbases",
-        "schemas": "Schemas"
+      "factSource": "Facts source",
+      "includedDocuments": {
+        "header": "Included documents"
       },
       "reportCreation": "Report creation",
       "tag": {
@@ -157,18 +155,15 @@
         "colDimensions": "Dimensions",
         "colMembers": "Members",
         "colNamespace": "Namespace",
-        "colTotal": "Total",
-        "header": "Tag Summary",
         "rowTotal": "Total"
-      },
-      "about": {
-        "title": "Title",
-        "name": "Name",
-        "entity": "Entity",
-        "seeMoreReferenceData": "See more {{type}} reference data"
       }
     },
     "summation": "Summation",
+    "tabs": {
+      "overview": "Overview",
+      "search": "Search",
+      "xbrlFacts": "XBRL facts"
+    },
     "targetDocument": "Target Document",
     "textOption": "Text",
     "typedDimensions": "Typed Dimensions",
@@ -183,36 +178,26 @@
     "xbrlGlossaryOpensInNewTab": "XBRL Glossary (opens in new tab)"
   },
   "menu": {
-    "actions": "Actions",
-    "applicationLanguage": "Application Language",
     "contactUs": "Contact Us",
-    "documentLanguage": "Document Language",
-    "help": "Help",
-    "options": "Options",
     "survey": "Survey",
     "userGuide": "User Guide"
   },
   "search": {
     "concealedFact": "Concealed fact",
-    "dataTypeConflictWarning": "Warning: selection conflicts with Concept Type filter",
     "default": "default",
-    "filter": "Filter",
     "hiddenFact": "Hidden fact",
     "matchingFactsSummary": "Showing {{nMatches}} of {{nTotal}} facts",
     "noMatchFound": "No match found",
-    "reset": "Reset",
     "resetFilters": "Reset filters",
     "selected": "selected",
-    "showResults": "Show results",
     "showMoreResults": "Show more results",
+    "showResults": "Show results",
     "toggleFilterControls": "Toggler filter controls",
     "tryAgainDifferentKeywords": "Try again with different keywords",
     "viewFact": "View fact"
   },
   "toolbar": {
-    "homePage": "Home",
-    "toggleDarkMode": "Toggle dark mode",
-    "xbrlElements": "XBRL Elements"
+    "homePage": "Home"
   },
   "viewer": {
     "ixbrlDocumentView": "iXBRL Document View",

--- a/iXBRLViewerPlugin/viewer/src/i18n/es/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/es/translation.json
@@ -190,12 +190,10 @@
     "matchingFactsSummary": "",
     "noMatchFound": "No se encontró ninguna coincidencia",
     "resetFilters": "",
-    "selected": "seleccionados",
     "showMoreResults": "Mostrar más resultados",
     "showResults": "",
     "toggleFilterControls": "",
-    "tryAgainDifferentKeywords": "Intente nuevamente con palabras clave diferentes",
-    "viewFact": ""
+    "tryAgainDifferentKeywords": "Intente nuevamente con palabras clave diferentes"
   },
   "toolbar": {
     "homePage": "Inicio"

--- a/iXBRLViewerPlugin/viewer/src/i18n/es/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/es/translation.json
@@ -81,6 +81,7 @@
     "goToReference": "",
     "hidden": "Oculto",
     "hiddenFact": "Hecho oculto",
+    "highlightMenu": "",
     "highlightTags": "",
     "highlightUntaggedDates": "",
     "highlightUntaggedNumbers": "",
@@ -115,6 +116,9 @@
       },
       "colorMode": {
         "documentation": "",
+        "title": ""
+      },
+      "plugins": {
         "title": ""
       },
       "title": "",

--- a/iXBRLViewerPlugin/viewer/src/i18n/es/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/es/translation.json
@@ -1,15 +1,21 @@
 {
   "calculation": {
     "calculated-total": "",
+    "calculationIsConsistent": "",
+    "calculationIsInconsistent": "",
     "concept": "",
     "consistent-duplicate-facts-present": "",
     "does-not-bind": "",
     "inconsistent-duplicate-facts-present": "",
     "maximum": "",
     "minimum": "",
+    "notReported": "",
     "reported-total": "",
     "reported-value": "",
-    "useCalculations11": ""
+    "showDetails": "",
+    "status": "",
+    "useCalculations11": "",
+    "useLegacyCalculations": ""
   },
   "chart": {
     "comparisonChart": ""
@@ -27,10 +33,10 @@
   "factDetails": {
     "accuracy": "Precisión",
     "balance": "",
-    "calculationIsConsistent": "",
-    "calculationIsInconsistent": "",
     "calculationUnchecked": "",
     "calculationUncheckedIncorrectVersion": "",
+    "calculationValuesDoNotMatch": "",
+    "calculationValuesMatch": "",
     "change": "Cambio",
     "changeFromIn": "Anteriormente {{from}} en ",
     "changePercentageDecrease": "{{decrease}}% menos que en ",
@@ -41,15 +47,19 @@
     "dimensions": "Dimensiones",
     "duplicatesCount": "{{current}} de {{total}}",
     "entity": "Entidad",
+    "factCount": "",
     "factValue": "Valor del hecho",
+    "nestedFactSummary": "",
     "nonNumericFact": "",
     "noPriorFactInThisReport": "No hay un hecho previo",
     "noUnit": "Sin unidad",
     "properties": "Características",
     "scale": "Escala",
+    "source": "",
     "viewCalculationDetails": ""
   },
   "footnotes": {
+    "content": "",
     "footnote": "Nota al pie de página"
   },
   "inspector": {
@@ -62,61 +72,82 @@
     "contributor": "",
     "datatypes": "Tipos de datos",
     "dimensions": "Tipo de dimensión",
-    "documentOutline": "Esquema del documento",
-    "documentSummary": "Resumen del documento",
+    "documentation": "",
     "explicitDimension": "",
     "fact-groups": "",
-    "factProperties": "Propiedades del hecho",
     "factSearch": "Búsqueda de hechos",
     "factValue": "",
-    "footnoteProperties": "Propiedades de la nota al pie de página",
     "footnotes": "Notas al pie de página",
+    "goToReference": "",
     "hidden": "Oculto",
     "hiddenFact": "Hecho oculto",
-    "highlight": "Destacar",
+    "highlightTags": "",
+    "highlightUntaggedDates": "",
+    "highlightUntaggedNumbers": "",
     "initializing": "",
     "ixbrlInspector": "",
     "labels": "",
+    "language": "",
     "loadingViewer": "Preparando el visor iXBRL",
     "mandatoryFacts": "Sólo hechos obligatorios",
     "namespaces": "Espacios de nombres",
-    "narrowerAnchor": "Anclaje angosto",
+    "narrowerAnchors": "",
     "negative": "Negativo",
     "nextTag": "",
+    "noCalculations": "",
+    "noDimensions": "",
     "noFactSelected": "Ningún hecho seleccionado",
     "numericOption": "Numérico",
-    "outlineUnavailable": "",
+    "occurrences": "",
+    "otherFacts": "",
     "period": "Periodo",
     "positive": "Positivo",
     "previousTag": "",
     "printDocument": "",
     "references": "Referencias",
-    "reset": "Limpiar",
     "scales": "Escalas",
-    "search": "Buscar",
     "searchReport": "",
     "searchResults": "",
-    "searchTitle": "Búsqueda de hechos",
-    "settingsMenu": "",
+    "settings": {
+      "calculationMode": {
+        "documentation": "",
+        "title": ""
+      },
+      "colorMode": {
+        "documentation": "",
+        "title": ""
+      },
+      "title": "",
+      "viewerLanguage": {
+        "documentation": "",
+        "title": ""
+      }
+    },
     "showAnalysisChart": "",
+    "showMore": "",
     "showTextOnly": "",
     "summary": {
+      "about": {
+        "entity": "",
+        "name": "",
+        "seeMoreReferenceData": "",
+        "title": ""
+      },
+      "aboutCompany": {
+        "header": ""
+      },
+      "downloads": {
+        "header": ""
+      },
       "fact": {
         "header": "Resumen de los hechos",
         "hidden": "Hechos ocultos",
         "mandatory": "Hechos obligatorios",
         "total": "Hechos totales"
       },
-      "file": {
-        "calculations": "",
-        "definitions": "",
-        "header": "Resumen del archivo",
-        "inline": "Documentos en línea",
-        "labels": "",
-        "other": "",
-        "presentation": "",
-        "references": "",
-        "schemas": ""
+      "factSource": "",
+      "includedDocuments": {
+        "header": ""
       },
       "reportCreation": "",
       "tag": {
@@ -124,12 +155,15 @@
         "colDimensions": "Dimensiones",
         "colMembers": "Miembros",
         "colNamespace": "Espacio de nombres",
-        "colTotal": "Total",
-        "header": "Resumen de la etiqueta",
         "rowTotal": "Total"
       }
     },
     "summation": "",
+    "tabs": {
+      "overview": "",
+      "search": "",
+      "xbrlFacts": ""
+    },
     "targetDocument": "",
     "textOption": "Texto",
     "typedDimensions": "",
@@ -140,40 +174,34 @@
     "validationSeverity": "",
     "visibility": "Visibilidad",
     "visible": "Visible",
-    "widerAnchor": "Anclaje amplio",
+    "widerAnchors": "",
     "xbrlGlossaryOpensInNewTab": "Glosario XBRL (se abre en una pestaña nueva)"
   },
   "menu": {
-    "actions": "Comportamientos",
-    "applicationLanguage": "Idioma de Aplicación",
     "contactUs": "Contacta con nosotros",
-    "documentLanguage": "Idioma del Documento",
-    "help": "Ayuda",
-    "options": "Opciones",
     "survey": "Encuesta",
     "userGuide": "Guía del Usuario"
   },
   "search": {
     "concealedFact": "",
-    "dataTypeConflictWarning": "",
     "default": "",
-    "filter": "Filtro",
     "hiddenFact": "Hecho oculto",
     "matchingFactsSummary": "",
     "noMatchFound": "No se encontró ninguna coincidencia",
-    "reset": "",
+    "resetFilters": "",
     "selected": "seleccionados",
     "showMoreResults": "Mostrar más resultados",
+    "showResults": "",
     "toggleFilterControls": "",
     "tryAgainDifferentKeywords": "Intente nuevamente con palabras clave diferentes",
     "viewFact": ""
   },
   "toolbar": {
-    "homePage": "Inicio",
-    "toggleDarkMode": "Alternar modo oscuro",
-    "xbrlElements": "Elementos XBRL"
+    "homePage": "Inicio"
   },
   "viewer": {
-    "ixbrlDocumentView": ""
+    "ixbrlDocumentView": "",
+    "zoomIn": "",
+    "zoomOut": ""
   }
 }

--- a/iXBRLViewerPlugin/viewer/src/i18n/es/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/es/translation.json
@@ -1,24 +1,24 @@
 {
   "calculation": {
-    "calculated-total": "",
-    "calculationIsConsistent": "",
-    "calculationIsInconsistent": "",
-    "concept": "",
-    "consistent-duplicate-facts-present": "",
-    "does-not-bind": "",
-    "inconsistent-duplicate-facts-present": "",
-    "maximum": "",
-    "minimum": "",
-    "notReported": "",
-    "reported-total": "",
-    "reported-value": "",
-    "showDetails": "",
-    "status": "",
-    "useCalculations11": "",
-    "useLegacyCalculations": ""
+    "calculated-total": "Calculado",
+    "calculationIsConsistent": "El cálculo es coherente",
+    "calculationIsInconsistent": "El cálculo no es coherente",
+    "concept": "Concepto",
+    "consistent-duplicate-facts-present": "{{nfacts}} hechos duplicados coherentes presentes",
+    "does-not-bind": "El cálculo no vincula",
+    "inconsistent-duplicate-facts-present": "{{nfacts}} hechos duplicados incoherentes presentes",
+    "maximum": "Máximo",
+    "minimum": "Mínimo",
+    "notReported": "no reportado",
+    "reported-total": "Reportado",
+    "reported-value": "Valor reportado",
+    "showDetails": "Mostrar detalles",
+    "status": "Estado",
+    "useCalculations11": "Usar cálculos v1.1",
+    "useLegacyCalculations": "Usar cálculos heredados"
   },
   "chart": {
-    "comparisonChart": ""
+    "comparisonChart": "Gráfico comparativo"
   },
   "common": {
     "accuracyInfinite": "Precisió infinita",
@@ -28,121 +28,121 @@
     "unspecified": "Sin especificar"
   },
   "dialog": {
-    "close": ""
+    "close": "cerrar"
   },
   "factDetails": {
     "accuracy": "Precisión",
-    "balance": "",
-    "calculationUnchecked": "",
-    "calculationUncheckedIncorrectVersion": "",
-    "calculationValuesDoNotMatch": "",
-    "calculationValuesMatch": "",
+    "balance": "Saldo",
+    "calculationUnchecked": "Cálculo no verificado debido a la presencia de hechos duplicados",
+    "calculationUncheckedIncorrectVersion": "Las relaciones de Cálculo 1.1 no se verificaron en el modo de cálculo heredado",
+    "calculationValuesDoNotMatch": "Los valores reportados y calculados no coinciden",
+    "calculationValuesMatch": "Los valores reportados y calculados coinciden",
     "change": "Cambio",
     "changeFromIn": "Anteriormente {{from}} en ",
     "changePercentageDecrease": "{{decrease}}% menos que en ",
     "changePercentageIncrease": "{{increase}}% más que en ",
     "concept": "Concepto",
-    "datatype": "",
+    "datatype": "Tipo",
     "date": "Fecha",
     "dimensions": "Dimensiones",
     "duplicatesCount": "{{current}} de {{total}}",
     "entity": "Entidad",
-    "factCount": "",
+    "factCount": "{{current}} de {{total}}",
     "factValue": "Valor del hecho",
-    "nestedFactSummary": "",
-    "nonNumericFact": "",
+    "nestedFactSummary": "Mostrando {{current}} de {{total}} hechos anidados:",
+    "nonNumericFact": "hecho no numérico",
     "noPriorFactInThisReport": "No hay un hecho previo",
     "noUnit": "Sin unidad",
     "properties": "Características",
     "scale": "Escala",
-    "source": "",
-    "viewCalculationDetails": ""
+    "source": "Fuente",
+    "viewCalculationDetails": "Ver detalles del cálculo"
   },
   "footnotes": {
-    "content": "",
+    "content": "Contenido",
     "footnote": "Nota al pie de página"
   },
   "inspector": {
     "anchoring": "Anclaje",
     "associatedFacts": "Hechos asociados",
-    "calculationDetails": "",
+    "calculationDetails": "Detalles del cálculo",
     "calculations": "Cálculos",
-    "concealedFact": "",
+    "concealedFact": "Hecho oculto",
     "conceptType": "Tipo de concepto",
-    "contributor": "",
+    "contributor": "Colaborador",
     "datatypes": "Tipos de datos",
     "dimensions": "Tipo de dimensión",
-    "documentation": "",
-    "explicitDimension": "",
-    "fact-groups": "",
+    "documentation": "Documentación",
+    "explicitDimension": "Dimensiones explícitas",
+    "fact-groups": "Secciones",
     "factSearch": "Búsqueda de hechos",
-    "factValue": "",
+    "factValue": "Valor del hecho",
     "footnotes": "Notas al pie de página",
-    "goToReference": "",
+    "goToReference": "Ir a la referencia",
     "hidden": "Oculto",
     "hiddenFact": "Hecho oculto",
-    "highlightMenu": "",
-    "highlightTags": "",
-    "highlightUntaggedDates": "",
-    "highlightUntaggedNumbers": "",
-    "initializing": "",
-    "ixbrlInspector": "",
-    "labels": "",
-    "language": "",
+    "highlightMenu": "Opciones de resaltado",
+    "highlightTags": "Resaltar etiquetas",
+    "highlightUntaggedDates": "Resaltar fechas sin etiquetar",
+    "highlightUntaggedNumbers": "Resaltar números sin etiquetar",
+    "initializing": "Inicializando",
+    "ixbrlInspector": "Inspector iXBRL",
+    "labels": "Etiquetas",
+    "language": "Idioma",
     "loadingViewer": "Preparando el visor iXBRL",
     "mandatoryFacts": "Sólo hechos obligatorios",
     "namespaces": "Espacios de nombres",
-    "narrowerAnchors": "",
+    "narrowerAnchors": "Anclajes más estrechos",
     "negative": "Negativo",
-    "nextTag": "",
-    "noCalculations": "",
-    "noDimensions": "",
+    "nextTag": "Siguiente etiqueta",
+    "noCalculations": "Sin cálculos",
+    "noDimensions": "Sin dimensiones",
     "noFactSelected": "Ningún hecho seleccionado",
     "numericOption": "Numérico",
-    "occurrences": "",
-    "otherFacts": "",
+    "occurrences": "Ocurrencias",
+    "otherFacts": "Otros hechos",
     "period": "Periodo",
     "positive": "Positivo",
-    "previousTag": "",
-    "printDocument": "",
+    "previousTag": "Etiqueta anterior",
+    "printDocument": "Imprimir documento",
     "references": "Referencias",
     "scales": "Escalas",
-    "searchReport": "",
-    "searchResults": "",
+    "searchReport": "Buscar en el informe iXBRL",
+    "searchResults": "Resultados de búsqueda",
     "settings": {
       "calculationMode": {
-        "documentation": "",
-        "title": ""
+        "documentation": "Seleccione el modo de evaluación de cálculo para las relaciones de cálculo heredadas",
+        "title": "Modo de cálculo"
       },
       "colorMode": {
-        "documentation": "",
-        "title": ""
+        "documentation": "Elija si la apariencia del Visor en Línea debe ser clara u oscura",
+        "title": "Modo de color del visor"
       },
       "plugins": {
-        "title": ""
+        "title": "Complementos"
       },
-      "title": "",
+      "title": "Configuración",
       "viewerLanguage": {
-        "documentation": "",
-        "title": ""
+        "documentation": "Seleccione el idioma que le gustaría usar con el Visor en Línea",
+        "title": "Idioma del visor"
       }
     },
-    "settingsButton": "",
-    "showAnalysisChart": "",
-    "showMore": "",
-    "showTextOnly": "",
+    "settingsButton": "Configuración",
+    "showAnalysisChart": "Mostrar gráfico de análisis",
+    "showMore": "Mostrar más",
+    "showTextOnly": "Mostrar solo texto",
     "summary": {
       "about": {
-        "entity": "",
-        "name": "",
-        "seeMoreReferenceData": "",
-        "title": ""
+        "entity": "Entidad",
+        "name": "Nombre",
+        "seeMoreReferenceData": "Ver más datos de referencia de {{type}}",
+        "title": "Título"
       },
       "aboutCompany": {
-        "header": ""
+        "header": "Sobre la empresa"
       },
       "downloads": {
-        "header": ""
+        "header": "Descargas"
       },
       "fact": {
         "header": "Resumen de los hechos",
@@ -150,11 +150,11 @@
         "mandatory": "Hechos obligatorios",
         "total": "Hechos totales"
       },
-      "factSource": "",
+      "factSource": "Fuente de los hechos",
       "includedDocuments": {
-        "header": ""
+        "header": "Documentos incluidos"
       },
-      "reportCreation": "",
+      "reportCreation": "Creación de informe",
       "tag": {
         "colConcepts": "Conceptos",
         "colDimensions": "Dimensiones",
@@ -163,23 +163,23 @@
         "rowTotal": "Total"
       }
     },
-    "summation": "",
+    "summation": "Suma",
     "tabs": {
-      "overview": "",
-      "search": "",
-      "xbrlFacts": ""
+      "overview": "Resumen",
+      "search": "Buscar",
+      "xbrlFacts": "Hechos XBRL"
     },
-    "targetDocument": "",
+    "targetDocument": "Documento de destino",
     "textOption": "Texto",
-    "typedDimensions": "",
+    "typedDimensions": "Dimensiones tipificadas",
     "units": "Unidads",
-    "validationCode": "",
-    "validationMessage": "",
-    "validationResults": "",
-    "validationSeverity": "",
+    "validationCode": "Código",
+    "validationMessage": "Mensaje",
+    "validationResults": "Resultados de validación",
+    "validationSeverity": "Gravedad",
     "visibility": "Visibilidad",
     "visible": "Visible",
-    "widerAnchors": "",
+    "widerAnchors": "Anclajes más amplios",
     "xbrlGlossaryOpensInNewTab": "Glosario XBRL (se abre en una pestaña nueva)"
   },
   "menu": {
@@ -188,23 +188,23 @@
     "userGuide": "Guía del Usuario"
   },
   "search": {
-    "concealedFact": "",
-    "default": "",
+    "concealedFact": "Hecho oculto",
+    "default": "predeterminado",
     "hiddenFact": "Hecho oculto",
-    "matchingFactsSummary": "",
+    "matchingFactsSummary": "Mostrando {{nMatches}} de {{nTotal}} hechos",
     "noMatchFound": "No se encontró ninguna coincidencia",
-    "resetFilters": "",
+    "resetFilters": "Restablecer filtros",
     "showMoreResults": "Mostrar más resultados",
-    "showResults": "",
-    "toggleFilterControls": "",
+    "showResults": "Mostrar resultados",
+    "toggleFilterControls": "Alternar controles de filtro",
     "tryAgainDifferentKeywords": "Intente nuevamente con palabras clave diferentes"
   },
   "toolbar": {
     "homePage": "Inicio"
   },
   "viewer": {
-    "ixbrlDocumentView": "",
-    "zoomIn": "",
-    "zoomOut": ""
+    "ixbrlDocumentView": "Vista de documento iXBRL",
+    "zoomIn": "acercar",
+    "zoomOut": "alejar"
   }
 }

--- a/iXBRLViewerPlugin/viewer/src/i18n/es/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/es/translation.json
@@ -123,6 +123,7 @@
         "title": ""
       }
     },
+    "settingsButton": "",
     "showAnalysisChart": "",
     "showMore": "",
     "showTextOnly": "",

--- a/iXBRLViewerPlugin/viewer/src/i18n/fr/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/fr/translation.json
@@ -1,21 +1,21 @@
 {
   "calculation": {
     "calculated-total": "Calculé",
-    "calculationIsConsistent": "",
-    "calculationIsInconsistent": "",
+    "calculationIsConsistent": "Le calcul est cohérent",
+    "calculationIsInconsistent": "Le calcul n'est pas cohérent",
     "concept": "Concept",
     "consistent-duplicate-facts-present": "{{nfacts}} faits dupliqués cohérents présents",
     "does-not-bind": "Le calcul ne lie pas",
     "inconsistent-duplicate-facts-present": "{{nfacts}} faits dupliqués incohérents présents",
     "maximum": "Maximum",
     "minimum": "Minimum",
-    "notReported": "",
+    "notReported": "non déclaré",
     "reported-total": "Déclaré",
     "reported-value": "Valeur déclarée",
-    "showDetails": "",
-    "status": "",
+    "showDetails": "Afficher les détails",
+    "status": "Statut",
     "useCalculations11": "Utiliser Calculations v1.1",
-    "useLegacyCalculations": ""
+    "useLegacyCalculations": "Utiliser les calculs hérités"
   },
   "chart": {
     "comparisonChart": "Graphique comparatif"
@@ -35,8 +35,8 @@
     "balance": "Solde",
     "calculationUnchecked": "Calcul non vérifié en raison de la présence de faits dupliqués",
     "calculationUncheckedIncorrectVersion": "Relations de calcul 1.1 non vérifiées en mode calcul hérité",
-    "calculationValuesDoNotMatch": "",
-    "calculationValuesMatch": "",
+    "calculationValuesDoNotMatch": "Les valeurs déclarées et calculées ne correspondent pas",
+    "calculationValuesMatch": "Les valeurs déclarées et calculées correspondent",
     "change": "Variation",
     "changeFromIn": "De {{from}} en ",
     "changePercentageDecrease": "diminution de {{decrease}}% sur ",
@@ -47,19 +47,19 @@
     "dimensions": "Dimensions",
     "duplicatesCount": "{{current}} sur {{total}}",
     "entity": "Entité",
-    "factCount": "",
+    "factCount": "{{current}} sur {{total}}",
     "factValue": "Valeur du fait",
-    "nestedFactSummary": "",
+    "nestedFactSummary": "Affichage de {{current}} sur {{total}} faits imbriqués :",
     "nonNumericFact": "fait non numérique",
     "noPriorFactInThisReport": "Aucun fait antérieur dans ce rapport",
     "noUnit": "<SANS_UNITÉ>",
     "properties": "Propriétés",
     "scale": "Échelle",
-    "source": "",
+    "source": "Source",
     "viewCalculationDetails": "Voir les détails du calcul"
   },
   "footnotes": {
-    "content": "",
+    "content": "Contenu",
     "footnote": "Note de bas de page"
   },
   "inspector": {
@@ -72,35 +72,35 @@
     "contributor": "Contributeur",
     "datatypes": "Types",
     "dimensions": "Type de dimension",
-    "documentation": "",
+    "documentation": "Documentation",
     "explicitDimension": "Dimensions explicites",
     "fact-groups": "Sections",
     "factSearch": "Recherche de faits",
     "factValue": "Valeur du fait",
     "footnotes": "Notes de bas de page",
-    "goToReference": "",
+    "goToReference": "Aller à la référence",
     "hidden": "Caché",
     "hiddenFact": "Fait caché",
-    "highlightMenu": "",
-    "highlightTags": "",
-    "highlightUntaggedDates": "",
-    "highlightUntaggedNumbers": "",
+    "highlightMenu": "Options de surbrillance",
+    "highlightTags": "Surligner les balises",
+    "highlightUntaggedDates": "Surligner les dates non balisées",
+    "highlightUntaggedNumbers": "Surligner les nombres non balisés",
     "initializing": "Initialisation",
     "ixbrlInspector": "Inspecteur iXBRL",
-    "labels": "",
-    "language": "",
+    "labels": "Libellés",
+    "language": "Langue",
     "loadingViewer": "Chargement du visualiseur iXBRL",
     "mandatoryFacts": "Seulement les faits obligatoires",
     "namespaces": "Espaces de noms",
-    "narrowerAnchors": "",
+    "narrowerAnchors": "Ancrages plus étroits",
     "negative": "Négatif",
     "nextTag": "Étiquette suivante",
-    "noCalculations": "",
-    "noDimensions": "",
+    "noCalculations": "Aucun calcul",
+    "noDimensions": "Aucune dimension",
     "noFactSelected": "Aucun fait sélectionné",
     "numericOption": "Numérique",
-    "occurrences": "",
-    "otherFacts": "",
+    "occurrences": "Occurrences",
+    "otherFacts": "Autres faits",
     "period": "Période",
     "positive": "Positif",
     "previousTag": "Étiquette précédente",
@@ -111,38 +111,38 @@
     "searchResults": "Résultats de la recherche",
     "settings": {
       "calculationMode": {
-        "documentation": "",
-        "title": ""
+        "documentation": "Sélectionnez le mode d'évaluation du calcul pour les relations de calcul héritées",
+        "title": "Mode de calcul"
       },
       "colorMode": {
-        "documentation": "",
-        "title": ""
+        "documentation": "Choisissez si l'apparence de la visionneuse intégrée doit être claire ou sombre",
+        "title": "Mode de couleur de la visionneuse"
       },
       "plugins": {
-        "title": ""
+        "title": "Extensions"
       },
-      "title": "",
+      "title": "Paramètres",
       "viewerLanguage": {
-        "documentation": "",
-        "title": ""
+        "documentation": "Sélectionnez la langue que vous souhaitez utiliser avec la visionneuse intégrée",
+        "title": "Langue de la visionneuse"
       }
     },
-    "settingsButton": "",
+    "settingsButton": "Paramètres",
     "showAnalysisChart": "Afficher le graphique d’analyse",
-    "showMore": "",
+    "showMore": "Afficher plus",
     "showTextOnly": "Afficher uniquement le texte",
     "summary": {
       "about": {
-        "entity": "",
-        "name": "",
-        "seeMoreReferenceData": "",
-        "title": ""
+        "entity": "Entité",
+        "name": "Nom",
+        "seeMoreReferenceData": "Voir plus de données de référence {{type}}",
+        "title": "Titre"
       },
       "aboutCompany": {
-        "header": ""
+        "header": "À propos de l'entreprise"
       },
       "downloads": {
-        "header": ""
+        "header": "Téléchargements"
       },
       "fact": {
         "header": "Résumé des faits",
@@ -150,9 +150,9 @@
         "mandatory": "Faits obligatoires",
         "total": "Total des faits"
       },
-      "factSource": "",
+      "factSource": "Source des faits",
       "includedDocuments": {
-        "header": ""
+        "header": "Documents inclus"
       },
       "reportCreation": "Création du rapport",
       "tag": {
@@ -165,9 +165,9 @@
     },
     "summation": "Somme",
     "tabs": {
-      "overview": "",
-      "search": "",
-      "xbrlFacts": ""
+      "overview": "Aperçu",
+      "search": "Rechercher",
+      "xbrlFacts": "Faits XBRL"
     },
     "targetDocument": "Document cible",
     "textOption": "Texte",
@@ -179,7 +179,7 @@
     "validationSeverity": "Gravité",
     "visibility": "Visibilité",
     "visible": "Visible",
-    "widerAnchors": "",
+    "widerAnchors": "Ancrages plus larges",
     "xbrlGlossaryOpensInNewTab": "Glossaire XBRL (ouvre dans un nouvel onglet)"
   },
   "menu": {
@@ -193,9 +193,9 @@
     "hiddenFact": "Fait caché",
     "matchingFactsSummary": "Affichage de {{nMatches}} faits sur {{nTotal}}",
     "noMatchFound": "Aucune correspondance trouvée",
-    "resetFilters": "",
+    "resetFilters": "Réinitialiser les filtres",
     "showMoreResults": "Afficher plus de résultats",
-    "showResults": "",
+    "showResults": "Afficher les résultats",
     "toggleFilterControls": "Basculer les contrôles de filtre",
     "tryAgainDifferentKeywords": "Essayez avec des mots-clés différents"
   },
@@ -204,7 +204,7 @@
   },
   "viewer": {
     "ixbrlDocumentView": "Vue du document iXBRL",
-    "zoomIn": "",
-    "zoomOut": ""
+    "zoomIn": "zoomer",
+    "zoomOut": "dézoomer"
   }
 }

--- a/iXBRLViewerPlugin/viewer/src/i18n/fr/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/fr/translation.json
@@ -1,15 +1,21 @@
 {
   "calculation": {
     "calculated-total": "Calculé",
+    "calculationIsConsistent": "",
+    "calculationIsInconsistent": "",
     "concept": "Concept",
     "consistent-duplicate-facts-present": "{{nfacts}} faits dupliqués cohérents présents",
     "does-not-bind": "Le calcul ne lie pas",
     "inconsistent-duplicate-facts-present": "{{nfacts}} faits dupliqués incohérents présents",
     "maximum": "Maximum",
     "minimum": "Minimum",
+    "notReported": "",
     "reported-total": "Déclaré",
     "reported-value": "Valeur déclarée",
-    "useCalculations11": "Utiliser Calculations v1.1"
+    "showDetails": "",
+    "status": "",
+    "useCalculations11": "Utiliser Calculations v1.1",
+    "useLegacyCalculations": ""
   },
   "chart": {
     "comparisonChart": "Graphique comparatif"
@@ -27,10 +33,10 @@
   "factDetails": {
     "accuracy": "Précision",
     "balance": "Solde",
-    "calculationIsConsistent": "Le calcul est cohérent",
-    "calculationIsInconsistent": "Le calcul est incohérent",
     "calculationUnchecked": "Calcul non vérifié en raison de la présence de faits dupliqués",
     "calculationUncheckedIncorrectVersion": "Relations de calcul 1.1 non vérifiées en mode calcul hérité",
+    "calculationValuesDoNotMatch": "",
+    "calculationValuesMatch": "",
     "change": "Variation",
     "changeFromIn": "De {{from}} en ",
     "changePercentageDecrease": "diminution de {{decrease}}% sur ",
@@ -41,15 +47,19 @@
     "dimensions": "Dimensions",
     "duplicatesCount": "{{current}} sur {{total}}",
     "entity": "Entité",
+    "factCount": "",
     "factValue": "Valeur du fait",
+    "nestedFactSummary": "",
     "nonNumericFact": "fait non numérique",
     "noPriorFactInThisReport": "Aucun fait antérieur dans ce rapport",
     "noUnit": "<SANS_UNITÉ>",
     "properties": "Propriétés",
     "scale": "Échelle",
+    "source": "",
     "viewCalculationDetails": "Voir les détails du calcul"
   },
   "footnotes": {
+    "content": "",
     "footnote": "Note de bas de page"
   },
   "inspector": {
@@ -62,61 +72,82 @@
     "contributor": "Contributeur",
     "datatypes": "Types",
     "dimensions": "Type de dimension",
-    "documentOutline": "Plan du document",
-    "documentSummary": "Résumé du document",
+    "documentation": "",
     "explicitDimension": "Dimensions explicites",
     "fact-groups": "Sections",
-    "factProperties": "Propriétés des faits",
     "factSearch": "Recherche de faits",
     "factValue": "Valeur du fait",
-    "footnoteProperties": "Propriétés des notes",
     "footnotes": "Notes de bas de page",
+    "goToReference": "",
     "hidden": "Caché",
     "hiddenFact": "Fait caché",
-    "highlight": "Surligner",
+    "highlightTags": "",
+    "highlightUntaggedDates": "",
+    "highlightUntaggedNumbers": "",
     "initializing": "Initialisation",
     "ixbrlInspector": "Inspecteur iXBRL",
     "labels": "",
+    "language": "",
     "loadingViewer": "Chargement du visualiseur iXBRL",
     "mandatoryFacts": "Seulement les faits obligatoires",
     "namespaces": "Espaces de noms",
-    "narrowerAnchor": "Ancrages plus spécifiques",
+    "narrowerAnchors": "",
     "negative": "Négatif",
     "nextTag": "Étiquette suivante",
+    "noCalculations": "",
+    "noDimensions": "",
     "noFactSelected": "Aucun fait sélectionné",
     "numericOption": "Numérique",
-    "outlineUnavailable": "Plan indisponible",
+    "occurrences": "",
+    "otherFacts": "",
     "period": "Période",
     "positive": "Positif",
     "previousTag": "Étiquette précédente",
     "printDocument": "Imprimer le document",
     "references": "Références",
-    "reset": "Réinitialiser",
     "scales": "Échelles",
-    "search": "Recherche",
     "searchReport": "Rechercher dans le rapport iXBRL",
     "searchResults": "Résultats de la recherche",
-    "searchTitle": "Recherche",
-    "settingsMenu": "Menu des paramètres",
+    "settings": {
+      "calculationMode": {
+        "documentation": "",
+        "title": ""
+      },
+      "colorMode": {
+        "documentation": "",
+        "title": ""
+      },
+      "title": "",
+      "viewerLanguage": {
+        "documentation": "",
+        "title": ""
+      }
+    },
     "showAnalysisChart": "Afficher le graphique d’analyse",
+    "showMore": "",
     "showTextOnly": "Afficher uniquement le texte",
     "summary": {
+      "about": {
+        "entity": "",
+        "name": "",
+        "seeMoreReferenceData": "",
+        "title": ""
+      },
+      "aboutCompany": {
+        "header": ""
+      },
+      "downloads": {
+        "header": ""
+      },
       "fact": {
         "header": "Résumé des faits",
         "hidden": "Faits cachés",
         "mandatory": "Faits obligatoires",
         "total": "Total des faits"
       },
-      "file": {
-        "calculations": "Bases de liens de calcul",
-        "definitions": "Bases de liens de définition",
-        "header": "Résumé du fichier",
-        "inline": "Documents en ligne",
-        "labels": "Bases de liens d’étiquettes",
-        "other": "Autres bases de liens",
-        "presentation": "Bases de liens de présentation",
-        "references": "Bases de liens de référence",
-        "schemas": "Schémas"
+      "factSource": "",
+      "includedDocuments": {
+        "header": ""
       },
       "reportCreation": "Création du rapport",
       "tag": {
@@ -124,12 +155,15 @@
         "colDimensions": "Dimensions",
         "colMembers": "Membres",
         "colNamespace": "Espace de noms",
-        "colTotal": "Total",
-        "header": "Résumé des étiquettes",
         "rowTotal": "Total"
       }
     },
     "summation": "Somme",
+    "tabs": {
+      "overview": "",
+      "search": "",
+      "xbrlFacts": ""
+    },
     "targetDocument": "Document cible",
     "textOption": "Texte",
     "typedDimensions": "Dimensions typées",
@@ -140,40 +174,34 @@
     "validationSeverity": "Gravité",
     "visibility": "Visibilité",
     "visible": "Visible",
-    "widerAnchor": "Ancrage plus large",
+    "widerAnchors": "",
     "xbrlGlossaryOpensInNewTab": "Glossaire XBRL (ouvre dans un nouvel onglet)"
   },
   "menu": {
-    "actions": "Actions",
-    "applicationLanguage": "Langue de l’application",
     "contactUs": "Contactez-nous",
-    "documentLanguage": "Langue du document",
-    "help": "Aide",
-    "options": "Options",
     "survey": "Sondage",
     "userGuide": "Guide de l’utilisateur"
   },
   "search": {
     "concealedFact": "Fait dissimulé",
-    "dataTypeConflictWarning": "Attention : sélection en conflit avec le filtre Type de concept",
     "default": "par défaut",
-    "filter": "Filtrer",
     "hiddenFact": "Fait caché",
     "matchingFactsSummary": "Affichage de {{nMatches}} faits sur {{nTotal}}",
     "noMatchFound": "Aucune correspondance trouvée",
-    "reset": "Réinitialiser",
+    "resetFilters": "",
     "selected": "sélectionné",
     "showMoreResults": "Afficher plus de résultats",
+    "showResults": "",
     "toggleFilterControls": "Basculer les contrôles de filtre",
     "tryAgainDifferentKeywords": "Essayez avec des mots-clés différents",
     "viewFact": "Voir le fait"
   },
   "toolbar": {
-    "homePage": "Accueil",
-    "toggleDarkMode": "Basculer en mode sombre",
-    "xbrlElements": "Éléments XBRL"
+    "homePage": "Accueil"
   },
   "viewer": {
-    "ixbrlDocumentView": "Vue du document iXBRL"
+    "ixbrlDocumentView": "Vue du document iXBRL",
+    "zoomIn": "",
+    "zoomOut": ""
   }
 }

--- a/iXBRLViewerPlugin/viewer/src/i18n/fr/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/fr/translation.json
@@ -190,12 +190,10 @@
     "matchingFactsSummary": "Affichage de {{nMatches}} faits sur {{nTotal}}",
     "noMatchFound": "Aucune correspondance trouvée",
     "resetFilters": "",
-    "selected": "sélectionné",
     "showMoreResults": "Afficher plus de résultats",
     "showResults": "",
     "toggleFilterControls": "Basculer les contrôles de filtre",
-    "tryAgainDifferentKeywords": "Essayez avec des mots-clés différents",
-    "viewFact": "Voir le fait"
+    "tryAgainDifferentKeywords": "Essayez avec des mots-clés différents"
   },
   "toolbar": {
     "homePage": "Accueil"

--- a/iXBRLViewerPlugin/viewer/src/i18n/fr/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/fr/translation.json
@@ -81,6 +81,7 @@
     "goToReference": "",
     "hidden": "Caché",
     "hiddenFact": "Fait caché",
+    "highlightMenu": "",
     "highlightTags": "",
     "highlightUntaggedDates": "",
     "highlightUntaggedNumbers": "",
@@ -115,6 +116,9 @@
       },
       "colorMode": {
         "documentation": "",
+        "title": ""
+      },
+      "plugins": {
         "title": ""
       },
       "title": "",

--- a/iXBRLViewerPlugin/viewer/src/i18n/fr/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/fr/translation.json
@@ -123,6 +123,7 @@
         "title": ""
       }
     },
+    "settingsButton": "",
     "showAnalysisChart": "Afficher le graphique d’analyse",
     "showMore": "",
     "showTextOnly": "Afficher uniquement le texte",

--- a/iXBRLViewerPlugin/viewer/src/i18n/nl/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/nl/translation.json
@@ -190,12 +190,10 @@
     "matchingFactsSummary": "{{nMatches}} van {{nTotal}} feiten worden getoond",
     "noMatchFound": "Geen overeenkomst gevonden",
     "resetFilters": "",
-    "selected": "geselecteerd",
     "showMoreResults": "Toon meer resultaten",
     "showResults": "",
     "toggleFilterControls": "Filterbediening schakelen",
-    "tryAgainDifferentKeywords": "Probeer het opnieuw met andere zoekwoorden",
-    "viewFact": "Feit bekijken"
+    "tryAgainDifferentKeywords": "Probeer het opnieuw met andere zoekwoorden"
   },
   "toolbar": {
     "homePage": "Startpagina"

--- a/iXBRLViewerPlugin/viewer/src/i18n/nl/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/nl/translation.json
@@ -1,21 +1,21 @@
 {
   "calculation": {
     "calculated-total": "Bereken totaal",
-    "calculationIsConsistent": "",
-    "calculationIsInconsistent": "",
+    "calculationIsConsistent": "Berekening is consistent",
+    "calculationIsInconsistent": "Berekening is inconsistent",
     "concept": "Concept",
     "consistent-duplicate-facts-present": "{{nfacts}} consistente dubbele feiten aanwezig",
     "does-not-bind": "Berekening bindt niet",
     "inconsistent-duplicate-facts-present": "{{nfacts}} inconsistente dubbele feiten aanwezig",
     "maximum": "Maximum",
     "minimum": "Minimum",
-    "notReported": "",
+    "notReported": "niet gerapporteerd",
     "reported-total": "Gerapporteerd totaal",
     "reported-value": "Gerapporteerde waarde",
-    "showDetails": "",
-    "status": "",
+    "showDetails": "Details tonen",
+    "status": "Status",
     "useCalculations11": "Gebruik Berekeningen v1.1",
-    "useLegacyCalculations": ""
+    "useLegacyCalculations": "Verouderde berekeningen gebruiken"
   },
   "chart": {
     "comparisonChart": "Vergelijkingsgrafiek"
@@ -35,8 +35,8 @@
     "balance": "Saldo",
     "calculationUnchecked": "Berekening niet gecontroleerd vanwege aanwezigheid van dubbele feiten",
     "calculationUncheckedIncorrectVersion": "Berekeningsrelaties 1.1 niet gecontroleerd in legacy berekeningsmodus",
-    "calculationValuesDoNotMatch": "",
-    "calculationValuesMatch": "",
+    "calculationValuesDoNotMatch": "Gerapporteerde en berekende waarden komen niet overeen",
+    "calculationValuesMatch": "Gerapporteerde en berekende waarden komen overeen",
     "change": "Wijziging",
     "changeFromIn": "Van {{from}} in ",
     "changePercentageDecrease": "{{decrease}}% daling op ",
@@ -47,19 +47,19 @@
     "dimensions": "Dimensies",
     "duplicatesCount": "{{current}} van {{total}}",
     "entity": "Entiteit",
-    "factCount": "",
+    "factCount": "{{current}} van {{total}}",
     "factValue": "Feitwaarde",
-    "nestedFactSummary": "",
+    "nestedFactSummary": "{{current}} van {{total}} geneste feiten weergegeven:",
     "nonNumericFact": "niet-numeriek feit",
     "noPriorFactInThisReport": "Geen eerder feit in dit rapport",
     "noUnit": "<GEEN EENHEID>",
     "properties": "Eigenschappen",
     "scale": "Schaal",
-    "source": "",
+    "source": "Bron",
     "viewCalculationDetails": "Bekijk berekeningsdetails"
   },
   "footnotes": {
-    "content": "",
+    "content": "Inhoud",
     "footnote": "Voetnoot"
   },
   "inspector": {
@@ -72,35 +72,35 @@
     "contributor": "Bijdrager",
     "datatypes": "Typen",
     "dimensions": "Dimensietype",
-    "documentation": "",
+    "documentation": "Documentatie",
     "explicitDimension": "Expliciete dimensies",
     "fact-groups": "Secties",
     "factSearch": "Feiten zoeken",
     "factValue": "Feitwaarde",
     "footnotes": "Voetnoten",
-    "goToReference": "",
+    "goToReference": "Ga naar referentie",
     "hidden": "Verborgen",
     "hiddenFact": "Verborgen feit",
-    "highlightMenu": "",
-    "highlightTags": "",
-    "highlightUntaggedDates": "",
-    "highlightUntaggedNumbers": "",
+    "highlightMenu": "Markeringsopties",
+    "highlightTags": "Tags markeren",
+    "highlightUntaggedDates": "Niet-getagde datums markeren",
+    "highlightUntaggedNumbers": "Niet-getagde getallen markeren",
     "initializing": "Initialiseren",
     "ixbrlInspector": "iXBRL Inspecteur",
-    "labels": "",
-    "language": "",
+    "labels": "Labels",
+    "language": "Taal",
     "loadingViewer": "iXBRL Viewer laden",
     "mandatoryFacts": "Alleen verplichte feiten",
     "namespaces": "Namespaces",
-    "narrowerAnchors": "",
+    "narrowerAnchors": "Nauwere ankers",
     "negative": "Negatief",
     "nextTag": "Volgende tag",
-    "noCalculations": "",
-    "noDimensions": "",
+    "noCalculations": "Geen berekeningen",
+    "noDimensions": "Geen dimensies",
     "noFactSelected": "Geen feit geselecteerd",
     "numericOption": "Numeriek",
-    "occurrences": "",
-    "otherFacts": "",
+    "occurrences": "Voorkomens",
+    "otherFacts": "Andere feiten",
     "period": "Periode",
     "positive": "Positief",
     "previousTag": "Vorige tag",
@@ -111,38 +111,38 @@
     "searchResults": "Zoekresultaten",
     "settings": {
       "calculationMode": {
-        "documentation": "",
-        "title": ""
+        "documentation": "Selecteer de berekeningsevaluatiemodus voor verouderde berekeningsrelaties",
+        "title": "Berekeningsmodus"
       },
       "colorMode": {
-        "documentation": "",
-        "title": ""
+        "documentation": "Kies of het uiterlijk van Inline Viewer licht of donker moet zijn",
+        "title": "Kleurmodus van de viewer"
       },
       "plugins": {
-        "title": ""
+        "title": "Plug-ins"
       },
-      "title": "",
+      "title": "Instellingen",
       "viewerLanguage": {
-        "documentation": "",
-        "title": ""
+        "documentation": "Selecteer de taal die u wilt gebruiken met Inline Viewer",
+        "title": "Taal van de viewer"
       }
     },
-    "settingsButton": "",
+    "settingsButton": "Instellingen",
     "showAnalysisChart": "Toon analysegrafiek",
-    "showMore": "",
+    "showMore": "Meer weergeven",
     "showTextOnly": "Toon alleen tekst",
     "summary": {
       "about": {
-        "entity": "",
-        "name": "",
-        "seeMoreReferenceData": "",
-        "title": ""
+        "entity": "Entiteit",
+        "name": "Naam",
+        "seeMoreReferenceData": "Bekijk meer {{type}} referentiegegevens",
+        "title": "Titel"
       },
       "aboutCompany": {
-        "header": ""
+        "header": "Over het bedrijf"
       },
       "downloads": {
-        "header": ""
+        "header": "Downloads"
       },
       "fact": {
         "header": "Feitsamenvatting",
@@ -150,9 +150,9 @@
         "mandatory": "Verplichte feiten",
         "total": "Totaal feiten"
       },
-      "factSource": "",
+      "factSource": "Bron van feiten",
       "includedDocuments": {
-        "header": ""
+        "header": "Opgenomen documenten"
       },
       "reportCreation": "Rapportage creatie",
       "tag": {
@@ -165,9 +165,9 @@
     },
     "summation": "Opsomming",
     "tabs": {
-      "overview": "",
-      "search": "",
-      "xbrlFacts": ""
+      "overview": "Overzicht",
+      "search": "Zoeken",
+      "xbrlFacts": "XBRL-feiten"
     },
     "targetDocument": "Doeldocument",
     "textOption": "Tekst",
@@ -179,7 +179,7 @@
     "validationSeverity": "Ernst",
     "visibility": "Zichtbaarheid",
     "visible": "Zichtbaar",
-    "widerAnchors": "",
+    "widerAnchors": "Bredere ankers",
     "xbrlGlossaryOpensInNewTab": "XBRL Woordenlijst (opent in nieuw tabblad)"
   },
   "menu": {
@@ -193,9 +193,9 @@
     "hiddenFact": "Verborgen feit",
     "matchingFactsSummary": "{{nMatches}} van {{nTotal}} feiten worden getoond",
     "noMatchFound": "Geen overeenkomst gevonden",
-    "resetFilters": "",
+    "resetFilters": "Filters resetten",
     "showMoreResults": "Toon meer resultaten",
-    "showResults": "",
+    "showResults": "Resultaten weergeven",
     "toggleFilterControls": "Filterbediening schakelen",
     "tryAgainDifferentKeywords": "Probeer het opnieuw met andere zoekwoorden"
   },
@@ -204,7 +204,7 @@
   },
   "viewer": {
     "ixbrlDocumentView": "iXBRL-documentweergave",
-    "zoomIn": "",
-    "zoomOut": ""
+    "zoomIn": "inzoomen",
+    "zoomOut": "uitzoomen"
   }
 }

--- a/iXBRLViewerPlugin/viewer/src/i18n/nl/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/nl/translation.json
@@ -1,15 +1,21 @@
 {
   "calculation": {
     "calculated-total": "Bereken totaal",
+    "calculationIsConsistent": "",
+    "calculationIsInconsistent": "",
     "concept": "Concept",
     "consistent-duplicate-facts-present": "{{nfacts}} consistente dubbele feiten aanwezig",
     "does-not-bind": "Berekening bindt niet",
     "inconsistent-duplicate-facts-present": "{{nfacts}} inconsistente dubbele feiten aanwezig",
     "maximum": "Maximum",
     "minimum": "Minimum",
+    "notReported": "",
     "reported-total": "Gerapporteerd totaal",
     "reported-value": "Gerapporteerde waarde",
-    "useCalculations11": "Gebruik Berekeningen v1.1"
+    "showDetails": "",
+    "status": "",
+    "useCalculations11": "Gebruik Berekeningen v1.1",
+    "useLegacyCalculations": ""
   },
   "chart": {
     "comparisonChart": "Vergelijkingsgrafiek"
@@ -27,10 +33,10 @@
   "factDetails": {
     "accuracy": "Nauwkeurigheid",
     "balance": "Saldo",
-    "calculationIsConsistent": "Berekening is consistent",
-    "calculationIsInconsistent": "Berekening is inconsistent",
     "calculationUnchecked": "Berekening niet gecontroleerd vanwege aanwezigheid van dubbele feiten",
     "calculationUncheckedIncorrectVersion": "Berekeningsrelaties 1.1 niet gecontroleerd in legacy berekeningsmodus",
+    "calculationValuesDoNotMatch": "",
+    "calculationValuesMatch": "",
     "change": "Wijziging",
     "changeFromIn": "Van {{from}} in ",
     "changePercentageDecrease": "{{decrease}}% daling op ",
@@ -41,15 +47,19 @@
     "dimensions": "Dimensies",
     "duplicatesCount": "{{current}} van {{total}}",
     "entity": "Entiteit",
+    "factCount": "",
     "factValue": "Feitwaarde",
+    "nestedFactSummary": "",
     "nonNumericFact": "niet-numeriek feit",
     "noPriorFactInThisReport": "Geen eerder feit in dit rapport",
     "noUnit": "<GEEN EENHEID>",
     "properties": "Eigenschappen",
     "scale": "Schaal",
+    "source": "",
     "viewCalculationDetails": "Bekijk berekeningsdetails"
   },
   "footnotes": {
+    "content": "",
     "footnote": "Voetnoot"
   },
   "inspector": {
@@ -62,61 +72,82 @@
     "contributor": "Bijdrager",
     "datatypes": "Typen",
     "dimensions": "Dimensietype",
-    "documentOutline": "Documentoverzicht",
-    "documentSummary": "Documentsamenvatting",
+    "documentation": "",
     "explicitDimension": "Expliciete dimensies",
     "fact-groups": "Secties",
-    "factProperties": "Feiteigenschappen",
     "factSearch": "Feiten zoeken",
     "factValue": "Feitwaarde",
-    "footnoteProperties": "Voetnooteigenschappen",
     "footnotes": "Voetnoten",
+    "goToReference": "",
     "hidden": "Verborgen",
     "hiddenFact": "Verborgen feit",
-    "highlight": "Markeren",
+    "highlightTags": "",
+    "highlightUntaggedDates": "",
+    "highlightUntaggedNumbers": "",
     "initializing": "Initialiseren",
     "ixbrlInspector": "iXBRL Inspecteur",
     "labels": "",
+    "language": "",
     "loadingViewer": "iXBRL Viewer laden",
     "mandatoryFacts": "Alleen verplichte feiten",
     "namespaces": "Namespaces",
-    "narrowerAnchor": "Nauwere ankers",
+    "narrowerAnchors": "",
     "negative": "Negatief",
     "nextTag": "Volgende tag",
+    "noCalculations": "",
+    "noDimensions": "",
     "noFactSelected": "Geen feit geselecteerd",
     "numericOption": "Numeriek",
-    "outlineUnavailable": "Overzicht niet beschikbaar",
+    "occurrences": "",
+    "otherFacts": "",
     "period": "Periode",
     "positive": "Positief",
     "previousTag": "Vorige tag",
     "printDocument": "Document afdrukken",
     "references": "Referenties",
-    "reset": "Resetten",
     "scales": "Schalen",
-    "search": "Zoeken",
     "searchReport": "Zoek iXBRL-rapport",
     "searchResults": "Zoekresultaten",
-    "searchTitle": "Zoeken",
-    "settingsMenu": "Instellingenmenu",
+    "settings": {
+      "calculationMode": {
+        "documentation": "",
+        "title": ""
+      },
+      "colorMode": {
+        "documentation": "",
+        "title": ""
+      },
+      "title": "",
+      "viewerLanguage": {
+        "documentation": "",
+        "title": ""
+      }
+    },
     "showAnalysisChart": "Toon analysegrafiek",
+    "showMore": "",
     "showTextOnly": "Toon alleen tekst",
     "summary": {
+      "about": {
+        "entity": "",
+        "name": "",
+        "seeMoreReferenceData": "",
+        "title": ""
+      },
+      "aboutCompany": {
+        "header": ""
+      },
+      "downloads": {
+        "header": ""
+      },
       "fact": {
         "header": "Feitsamenvatting",
         "hidden": "Verborgen feiten",
         "mandatory": "Verplichte feiten",
         "total": "Totaal feiten"
       },
-      "file": {
-        "calculations": "Berekeningslinkbases",
-        "definitions": "Definitielinkbases",
-        "header": "Bestandssamenvatting",
-        "inline": "Inline documenten",
-        "labels": "Labellinkbases",
-        "other": "Andere linkbases",
-        "presentation": "Presentatielinkbases",
-        "references": "Referentielinkbases",
-        "schemas": "Schemas"
+      "factSource": "",
+      "includedDocuments": {
+        "header": ""
       },
       "reportCreation": "Rapportage creatie",
       "tag": {
@@ -124,12 +155,15 @@
         "colDimensions": "Dimensies",
         "colMembers": "Leden",
         "colNamespace": "Namespace",
-        "colTotal": "Totaal",
-        "header": "Tagsamenvatting",
         "rowTotal": "Totaal"
       }
     },
     "summation": "Opsomming",
+    "tabs": {
+      "overview": "",
+      "search": "",
+      "xbrlFacts": ""
+    },
     "targetDocument": "Doeldocument",
     "textOption": "Tekst",
     "typedDimensions": "Getypte dimensies",
@@ -140,40 +174,34 @@
     "validationSeverity": "Ernst",
     "visibility": "Zichtbaarheid",
     "visible": "Zichtbaar",
-    "widerAnchor": "Breder anker",
+    "widerAnchors": "",
     "xbrlGlossaryOpensInNewTab": "XBRL Woordenlijst (opent in nieuw tabblad)"
   },
   "menu": {
-    "actions": "Acties",
-    "applicationLanguage": "Toepassings taal",
     "contactUs": "Contacteer ons",
-    "documentLanguage": "Documenttaal",
-    "help": "Help",
-    "options": "Opties",
     "survey": "Enquête",
     "userGuide": "Gebruikershandleiding"
   },
   "search": {
     "concealedFact": "Verborgen feit",
-    "dataTypeConflictWarning": "Waarschuwing: selectie conflicteert met filter op concepttype",
     "default": "standaard",
-    "filter": "Filter",
     "hiddenFact": "Verborgen feit",
     "matchingFactsSummary": "{{nMatches}} van {{nTotal}} feiten worden getoond",
     "noMatchFound": "Geen overeenkomst gevonden",
-    "reset": "Resetten",
+    "resetFilters": "",
     "selected": "geselecteerd",
     "showMoreResults": "Toon meer resultaten",
+    "showResults": "",
     "toggleFilterControls": "Filterbediening schakelen",
     "tryAgainDifferentKeywords": "Probeer het opnieuw met andere zoekwoorden",
     "viewFact": "Feit bekijken"
   },
   "toolbar": {
-    "homePage": "Startpagina",
-    "toggleDarkMode": "Donkere modus aan/uit",
-    "xbrlElements": "XBRL-elementen"
+    "homePage": "Startpagina"
   },
   "viewer": {
-    "ixbrlDocumentView": "iXBRL-documentweergave"
+    "ixbrlDocumentView": "iXBRL-documentweergave",
+    "zoomIn": "",
+    "zoomOut": ""
   }
 }

--- a/iXBRLViewerPlugin/viewer/src/i18n/nl/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/nl/translation.json
@@ -123,6 +123,7 @@
         "title": ""
       }
     },
+    "settingsButton": "",
     "showAnalysisChart": "Toon analysegrafiek",
     "showMore": "",
     "showTextOnly": "Toon alleen tekst",

--- a/iXBRLViewerPlugin/viewer/src/i18n/nl/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/nl/translation.json
@@ -81,6 +81,7 @@
     "goToReference": "",
     "hidden": "Verborgen",
     "hiddenFact": "Verborgen feit",
+    "highlightMenu": "",
     "highlightTags": "",
     "highlightUntaggedDates": "",
     "highlightUntaggedNumbers": "",
@@ -115,6 +116,9 @@
       },
       "colorMode": {
         "documentation": "",
+        "title": ""
+      },
+      "plugins": {
         "title": ""
       },
       "title": "",

--- a/iXBRLViewerPlugin/viewer/src/i18n/uk/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/uk/translation.json
@@ -81,6 +81,7 @@
     "goToReference": "",
     "hidden": "Приховано",
     "hiddenFact": "Прихований факт",
+    "highlightMenu": "",
     "highlightTags": "",
     "highlightUntaggedDates": "",
     "highlightUntaggedNumbers": "",
@@ -115,6 +116,9 @@
       },
       "colorMode": {
         "documentation": "",
+        "title": ""
+      },
+      "plugins": {
         "title": ""
       },
       "title": "",

--- a/iXBRLViewerPlugin/viewer/src/i18n/uk/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/uk/translation.json
@@ -123,6 +123,7 @@
         "title": ""
       }
     },
+    "settingsButton": "",
     "showAnalysisChart": "Показати діаграму аналізу",
     "showMore": "",
     "showTextOnly": "Показати тільки текст",

--- a/iXBRLViewerPlugin/viewer/src/i18n/uk/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/uk/translation.json
@@ -1,15 +1,21 @@
 {
   "calculation": {
     "calculated-total": "Розраховано",
+    "calculationIsConsistent": "",
+    "calculationIsInconsistent": "",
     "concept": "Концепція",
     "consistent-duplicate-facts-present": "{{nfacts}} послідовних дублікованих фактів присутні",
     "does-not-bind": "Розрахунок не зв'язується",
     "inconsistent-duplicate-facts-present": "{{nfacts}} непослідовних дублікованих фактів присутні",
     "maximum": "Максимум",
     "minimum": "Мінімум",
+    "notReported": "",
     "reported-total": "Звітний",
     "reported-value": "Звітне значення",
-    "useCalculations11": "Використовувати розрахунки v1.1"
+    "showDetails": "",
+    "status": "",
+    "useCalculations11": "Використовувати розрахунки v1.1",
+    "useLegacyCalculations": ""
   },
   "chart": {
     "comparisonChart": "Діаграма порівняння"
@@ -27,10 +33,10 @@
   "factDetails": {
     "accuracy": "Точність",
     "balance": "Баланс",
-    "calculationIsConsistent": "Розрахунок є послідовним",
-    "calculationIsInconsistent": "Розрахунок є непослідовним",
     "calculationUnchecked": "Розрахунок не перевірено через наявність дублікованих фактів",
     "calculationUncheckedIncorrectVersion": "Розрахунки 1.1 не перевірено в режимі старої версії розрахунків",
+    "calculationValuesDoNotMatch": "",
+    "calculationValuesMatch": "",
     "change": "Зміна",
     "changeFromIn": "З {{from}} в ",
     "changePercentageDecrease": "{{decrease}}% зменшення на ",
@@ -41,15 +47,19 @@
     "dimensions": "Вимірювання",
     "duplicatesCount": "{{current}} з {{total}}",
     "entity": "Суб'єкт",
+    "factCount": "",
     "factValue": "Значення факту",
+    "nestedFactSummary": "",
     "nonNumericFact": "нечисловий факт",
     "noPriorFactInThisReport": "Немає попереднього факту в цьому звіті",
     "noUnit": "<НІОДИНИЦЮ>",
     "properties": "Властивості",
     "scale": "Масштаб",
+    "source": "",
     "viewCalculationDetails": "Переглянути деталі розрахунку"
   },
   "footnotes": {
+    "content": "",
     "footnote": "Примітка"
   },
   "inspector": {
@@ -62,61 +72,82 @@
     "contributor": "Автор",
     "datatypes": "Типи",
     "dimensions": "Тип вимірювання",
-    "documentOutline": "Структура документа",
-    "documentSummary": "Резюме документа",
+    "documentation": "",
     "explicitDimension": "Явні вимірювання",
     "fact-groups": "Розділи",
-    "factProperties": "Властивості факту",
     "factSearch": "Пошук фактів",
     "factValue": "Значення факту",
-    "footnoteProperties": "Властивості примітки",
     "footnotes": "Примітки",
+    "goToReference": "",
     "hidden": "Приховано",
     "hiddenFact": "Прихований факт",
-    "highlight": "Підсвітити",
+    "highlightTags": "",
+    "highlightUntaggedDates": "",
+    "highlightUntaggedNumbers": "",
     "initializing": "Ініціалізація",
     "ixbrlInspector": "iXBRL Інспектор",
     "labels": "",
+    "language": "",
     "loadingViewer": "Завантаження переглядача iXBRL",
     "mandatoryFacts": "Тільки обов'язкові факти",
     "namespaces": "Простори імен",
-    "narrowerAnchor": "Вужчі якоря",
+    "narrowerAnchors": "",
     "negative": "Негативний",
     "nextTag": "Наступний тег",
+    "noCalculations": "",
+    "noDimensions": "",
     "noFactSelected": "Не вибрано факт",
     "numericOption": "Числовий",
-    "outlineUnavailable": "Структура недоступна",
+    "occurrences": "",
+    "otherFacts": "",
     "period": "Період",
     "positive": "Позитивний",
     "previousTag": "Попередній тег",
     "printDocument": "Друк документа",
     "references": "Посилання",
-    "reset": "Скинути",
     "scales": "Масштаби",
-    "search": "Пошук",
     "searchReport": "Пошук у звіті iXBRL",
     "searchResults": "Результати пошуку",
-    "searchTitle": "Пошук",
-    "settingsMenu": "Меню налаштувань",
+    "settings": {
+      "calculationMode": {
+        "documentation": "",
+        "title": ""
+      },
+      "colorMode": {
+        "documentation": "",
+        "title": ""
+      },
+      "title": "",
+      "viewerLanguage": {
+        "documentation": "",
+        "title": ""
+      }
+    },
     "showAnalysisChart": "Показати діаграму аналізу",
+    "showMore": "",
     "showTextOnly": "Показати тільки текст",
     "summary": {
+      "about": {
+        "entity": "",
+        "name": "",
+        "seeMoreReferenceData": "",
+        "title": ""
+      },
+      "aboutCompany": {
+        "header": ""
+      },
+      "downloads": {
+        "header": ""
+      },
       "fact": {
         "header": "Резюме фактів",
         "hidden": "Приховані факти",
         "mandatory": "Обов'язкові факти",
         "total": "Всього фактів"
       },
-      "file": {
-        "calculations": "Лінкбази розрахунків",
-        "definitions": "Лінкбази визначень",
-        "header": "Резюме файлу",
-        "inline": "Вбудовані документи",
-        "labels": "Лінкбази міток",
-        "other": "Інші лінкбази",
-        "presentation": "Лінкбази презентації",
-        "references": "Лінкбази посилань",
-        "schemas": "Схеми"
+      "factSource": "",
+      "includedDocuments": {
+        "header": ""
       },
       "reportCreation": "Створення звіту",
       "tag": {
@@ -124,12 +155,15 @@
         "colDimensions": "Вимірювання",
         "colMembers": "Члени",
         "colNamespace": "Простір імен",
-        "colTotal": "Всього",
-        "header": "Резюме тегів",
         "rowTotal": "Всього"
       }
     },
     "summation": "Підсумок",
+    "tabs": {
+      "overview": "",
+      "search": "",
+      "xbrlFacts": ""
+    },
     "targetDocument": "Цільовий документ",
     "textOption": "Текст",
     "typedDimensions": "Типізовані вимірювання",
@@ -140,40 +174,34 @@
     "validationSeverity": "Рівень серйозності",
     "visibility": "Видимість",
     "visible": "Видимий",
-    "widerAnchor": "Ширший якір",
+    "widerAnchors": "",
     "xbrlGlossaryOpensInNewTab": "Глосарій XBRL (відкривається в новій вкладці)"
   },
   "menu": {
-    "actions": "Дії",
-    "applicationLanguage": "Мова застосунку",
     "contactUs": "Зв'яжіться з нами",
-    "documentLanguage": "Мова документа",
-    "help": "Допомога",
-    "options": "Параметри",
     "survey": "Опитування",
     "userGuide": "Керівництво користувача"
   },
   "search": {
     "concealedFact": "Прихований факт",
-    "dataTypeConflictWarning": "Попередження: вибір конфліктує з фільтром типу концепції",
     "default": "за замовчуванням",
-    "filter": "Фільтр",
     "hiddenFact": "Прихований факт",
     "matchingFactsSummary": "Показано {{nMatches}} з {{nTotal}} фактів",
     "noMatchFound": "Збігів не знайдено",
-    "reset": "Скинути",
+    "resetFilters": "",
     "selected": "вибрано",
     "showMoreResults": "Показати більше результатів",
+    "showResults": "",
     "toggleFilterControls": "Перемкнути фільтри",
     "tryAgainDifferentKeywords": "Спробуйте інші ключові слова",
     "viewFact": "Переглянути факт"
   },
   "toolbar": {
-    "homePage": "Головна",
-    "toggleDarkMode": "Увімкнути/вимкнути темну тему",
-    "xbrlElements": "Елементи XBRL"
+    "homePage": "Головна"
   },
   "viewer": {
-    "ixbrlDocumentView": "Перегляд документа iXBRL"
+    "ixbrlDocumentView": "Перегляд документа iXBRL",
+    "zoomIn": "",
+    "zoomOut": ""
   }
 }

--- a/iXBRLViewerPlugin/viewer/src/i18n/uk/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/uk/translation.json
@@ -1,21 +1,21 @@
 {
   "calculation": {
     "calculated-total": "Розраховано",
-    "calculationIsConsistent": "",
-    "calculationIsInconsistent": "",
+    "calculationIsConsistent": "Обчислення узгоджене",
+    "calculationIsInconsistent": "Обчислення неузгоджене",
     "concept": "Концепція",
     "consistent-duplicate-facts-present": "{{nfacts}} послідовних дублікованих фактів присутні",
     "does-not-bind": "Розрахунок не зв'язується",
     "inconsistent-duplicate-facts-present": "{{nfacts}} непослідовних дублікованих фактів присутні",
     "maximum": "Максимум",
     "minimum": "Мінімум",
-    "notReported": "",
+    "notReported": "не повідомлено",
     "reported-total": "Звітний",
     "reported-value": "Звітне значення",
-    "showDetails": "",
-    "status": "",
+    "showDetails": "Показати деталі",
+    "status": "Статус",
     "useCalculations11": "Використовувати розрахунки v1.1",
-    "useLegacyCalculations": ""
+    "useLegacyCalculations": "Використовувати застарілі обчислення"
   },
   "chart": {
     "comparisonChart": "Діаграма порівняння"
@@ -35,8 +35,8 @@
     "balance": "Баланс",
     "calculationUnchecked": "Розрахунок не перевірено через наявність дублікованих фактів",
     "calculationUncheckedIncorrectVersion": "Розрахунки 1.1 не перевірено в режимі старої версії розрахунків",
-    "calculationValuesDoNotMatch": "",
-    "calculationValuesMatch": "",
+    "calculationValuesDoNotMatch": "Повідомлені та обчислені значення не збігаються",
+    "calculationValuesMatch": "Повідомлені та обчислені значення збігаються",
     "change": "Зміна",
     "changeFromIn": "З {{from}} в ",
     "changePercentageDecrease": "{{decrease}}% зменшення на ",
@@ -47,19 +47,19 @@
     "dimensions": "Вимірювання",
     "duplicatesCount": "{{current}} з {{total}}",
     "entity": "Суб'єкт",
-    "factCount": "",
+    "factCount": "{{current}} з {{total}}",
     "factValue": "Значення факту",
-    "nestedFactSummary": "",
+    "nestedFactSummary": "Показано {{current}} з {{total}} вкладених фактів:",
     "nonNumericFact": "нечисловий факт",
     "noPriorFactInThisReport": "Немає попереднього факту в цьому звіті",
     "noUnit": "<НІОДИНИЦЮ>",
     "properties": "Властивості",
     "scale": "Масштаб",
-    "source": "",
+    "source": "Джерело",
     "viewCalculationDetails": "Переглянути деталі розрахунку"
   },
   "footnotes": {
-    "content": "",
+    "content": "Зміст",
     "footnote": "Примітка"
   },
   "inspector": {
@@ -72,35 +72,35 @@
     "contributor": "Автор",
     "datatypes": "Типи",
     "dimensions": "Тип вимірювання",
-    "documentation": "",
+    "documentation": "Документація",
     "explicitDimension": "Явні вимірювання",
     "fact-groups": "Розділи",
     "factSearch": "Пошук фактів",
     "factValue": "Значення факту",
     "footnotes": "Примітки",
-    "goToReference": "",
+    "goToReference": "Перейти до посилання",
     "hidden": "Приховано",
     "hiddenFact": "Прихований факт",
-    "highlightMenu": "",
-    "highlightTags": "",
-    "highlightUntaggedDates": "",
-    "highlightUntaggedNumbers": "",
+    "highlightMenu": "Параметри виділення",
+    "highlightTags": "Виділити теги",
+    "highlightUntaggedDates": "Виділити непозначені дати",
+    "highlightUntaggedNumbers": "Виділити непозначені числа",
     "initializing": "Ініціалізація",
     "ixbrlInspector": "iXBRL Інспектор",
-    "labels": "",
-    "language": "",
+    "labels": "Мітки",
+    "language": "Мова",
     "loadingViewer": "Завантаження переглядача iXBRL",
     "mandatoryFacts": "Тільки обов'язкові факти",
     "namespaces": "Простори імен",
-    "narrowerAnchors": "",
+    "narrowerAnchors": "Вужчі прив'язки",
     "negative": "Негативний",
     "nextTag": "Наступний тег",
-    "noCalculations": "",
-    "noDimensions": "",
+    "noCalculations": "Немає обчислень",
+    "noDimensions": "Немає вимірів",
     "noFactSelected": "Не вибрано факт",
     "numericOption": "Числовий",
-    "occurrences": "",
-    "otherFacts": "",
+    "occurrences": "Випадки",
+    "otherFacts": "Інші факти",
     "period": "Період",
     "positive": "Позитивний",
     "previousTag": "Попередній тег",
@@ -111,38 +111,38 @@
     "searchResults": "Результати пошуку",
     "settings": {
       "calculationMode": {
-        "documentation": "",
-        "title": ""
+        "documentation": "Виберіть режим оцінки обчислення для застарілих зв'язків обчислення",
+        "title": "Режим обчислення"
       },
       "colorMode": {
-        "documentation": "",
-        "title": ""
+        "documentation": "Виберіть, чи має вигляд вбудованого переглядача бути світлим чи темним",
+        "title": "Кольоровий режим переглядача"
       },
       "plugins": {
-        "title": ""
+        "title": "Плагіни"
       },
-      "title": "",
+      "title": "Налаштування",
       "viewerLanguage": {
-        "documentation": "",
-        "title": ""
+        "documentation": "Виберіть мову, яку ви хочете використовувати з вбудованим переглядачем",
+        "title": "Мова переглядача"
       }
     },
-    "settingsButton": "",
+    "settingsButton": "Налаштування",
     "showAnalysisChart": "Показати діаграму аналізу",
-    "showMore": "",
+    "showMore": "Показати більше",
     "showTextOnly": "Показати тільки текст",
     "summary": {
       "about": {
-        "entity": "",
-        "name": "",
-        "seeMoreReferenceData": "",
-        "title": ""
+        "entity": "Суб'єкт",
+        "name": "Назва",
+        "seeMoreReferenceData": "Переглянути додаткові довідкові дані {{type}}",
+        "title": "Заголовок"
       },
       "aboutCompany": {
-        "header": ""
+        "header": "Про компанію"
       },
       "downloads": {
-        "header": ""
+        "header": "Завантаження"
       },
       "fact": {
         "header": "Резюме фактів",
@@ -150,9 +150,9 @@
         "mandatory": "Обов'язкові факти",
         "total": "Всього фактів"
       },
-      "factSource": "",
+      "factSource": "Джерело фактів",
       "includedDocuments": {
-        "header": ""
+        "header": "Включені документи"
       },
       "reportCreation": "Створення звіту",
       "tag": {
@@ -165,9 +165,9 @@
     },
     "summation": "Підсумок",
     "tabs": {
-      "overview": "",
-      "search": "",
-      "xbrlFacts": ""
+      "overview": "Огляд",
+      "search": "Пошук",
+      "xbrlFacts": "Факти XBRL"
     },
     "targetDocument": "Цільовий документ",
     "textOption": "Текст",
@@ -179,7 +179,7 @@
     "validationSeverity": "Рівень серйозності",
     "visibility": "Видимість",
     "visible": "Видимий",
-    "widerAnchors": "",
+    "widerAnchors": "Ширші прив'язки",
     "xbrlGlossaryOpensInNewTab": "Глосарій XBRL (відкривається в новій вкладці)"
   },
   "menu": {
@@ -193,9 +193,9 @@
     "hiddenFact": "Прихований факт",
     "matchingFactsSummary": "Показано {{nMatches}} з {{nTotal}} фактів",
     "noMatchFound": "Збігів не знайдено",
-    "resetFilters": "",
+    "resetFilters": "Скинути фільтри",
     "showMoreResults": "Показати більше результатів",
-    "showResults": "",
+    "showResults": "Показати результати",
     "toggleFilterControls": "Перемкнути фільтри",
     "tryAgainDifferentKeywords": "Спробуйте інші ключові слова"
   },
@@ -204,7 +204,7 @@
   },
   "viewer": {
     "ixbrlDocumentView": "Перегляд документа iXBRL",
-    "zoomIn": "",
-    "zoomOut": ""
+    "zoomIn": "збільшити",
+    "zoomOut": "зменшити"
   }
 }

--- a/iXBRLViewerPlugin/viewer/src/i18n/uk/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/uk/translation.json
@@ -190,12 +190,10 @@
     "matchingFactsSummary": "Показано {{nMatches}} з {{nTotal}} фактів",
     "noMatchFound": "Збігів не знайдено",
     "resetFilters": "",
-    "selected": "вибрано",
     "showMoreResults": "Показати більше результатів",
     "showResults": "",
     "toggleFilterControls": "Перемкнути фільтри",
-    "tryAgainDifferentKeywords": "Спробуйте інші ключові слова",
-    "viewFact": "Переглянути факт"
+    "tryAgainDifferentKeywords": "Спробуйте інші ключові слова"
   },
   "toolbar": {
     "homePage": "Головна"

--- a/iXBRLViewerPlugin/viewer/src/js/docOrderIndex.js
+++ b/iXBRLViewerPlugin/viewer/src/js/docOrderIndex.js
@@ -13,7 +13,7 @@ export class DocOrderIndex {
         return this._index.findIndex(n => n.vuid === vuid);
     }
 
-    length(vuid) {
+    length() {
         return this._index.length;
     }
 

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -47,10 +47,6 @@ export class Fact {
         return this.f.a.c;
     }
 
-    conceptDisplayName() {
-        return this.report.reportSet.taxonomyNamer.convertQName(this.conceptQName());
-    }
-
     conceptTaxonomyName() {
         return this.report.reportSet.taxonomyNamer.fromQName(this.conceptQName());
     }

--- a/iXBRLViewerPlugin/viewer/src/js/fact.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.test.js
@@ -249,7 +249,9 @@ describe("Simple fact properties", () => {
         expect(f.isNumeric()).toBeFalsy();
         expect(f.decimals()).toBeUndefined();
         expect(f.isMonetaryValue()).toBeFalsy();
-        expect(f.readableValue()).toEqual("Member One, <no label>");
+        jest.spyOn(console, 'log').withImplementation(() => {}, () => {
+            expect(f.readableValue()).toEqual("Member One, <no label>");
+        });
         expect(f.isInvalidIXValue()).toBeFalsy();
 
         f.f.v = "eg:Member1 eg:UnlabelledMember";

--- a/iXBRLViewerPlugin/viewer/src/js/identifiers.js
+++ b/iXBRLViewerPlugin/viewer/src/js/identifiers.js
@@ -65,9 +65,12 @@ export class Identifiers {
             return undefined
         }
         const url = Identifiers.identifierURL(identifier);
-        return { 
-          "href": url, 
-          "text": i18next.t("inspector.summary.about.seeMoreReferenceData", { type: data.name })
+        if (url === undefined) {
+            return undefined;
+        }
+        return {
+            "href": url,
+            "text": i18next.t("inspector.summary.about.seeMoreReferenceData", { type: data.name })
         };
     }
 }

--- a/iXBRLViewerPlugin/viewer/src/js/identifiers.js
+++ b/iXBRLViewerPlugin/viewer/src/js/identifiers.js
@@ -27,10 +27,6 @@ export class Identifiers {
         return undefined;
     }
 
-    static identifierNameForFact(fact) {
-        return identifierName(fact.identifier());
-    }
-
     static readableName(identifier) {
         const data = schemes[identifier.namespace];
         if (data !== undefined) {

--- a/iXBRLViewerPlugin/viewer/src/js/identifiers.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/identifiers.test.js
@@ -51,3 +51,13 @@ describe("readableNameHTML", () => {
         expect(html.childNodes[1].textContent).toBe("1234");
     });
 });
+
+describe("seeMoreLink", () => {
+    test("Known scheme without URL", () => {
+        expect(Identifiers.seeMoreLink(qname("ua:1234"))).toBe(undefined);
+    });
+    test("Known scheme with URL", () => {
+        const link = Identifiers.seeMoreLink(qname("cik:1234"));
+        expect(link.href).toBe("https://www.sec.gov/cgi-bin/browse-edgar?CIK=1234");
+    });
+});

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -153,7 +153,11 @@ export class Inspector {
 
                 inspector.initializeReviewMode();
 
+                inspector._optionsMenu = new Menu($("#display-options-menu"), {type: "static"});
+                inspector.buildDisplayOptionsMenu();
+
                 inspector._toolbarMenu = new Menu($("#toolbar-highlight-menu"));
+                inspector.buildToolbarHighlightMenu();
 
                 inspector.setDefaultDocumentLanguage();
                 inspector.buildDocumentLanguages();
@@ -473,6 +477,18 @@ export class Inspector {
         }
     }
 
+    buildDisplayOptionsMenu() {
+        this._optionsMenu.reset();
+        this._iv.callPluginMethod("extendDisplayOptionsMenu", this._optionsMenu);
+        $("#display-options-menu").closest(".section").toggle(!this._optionsMenu.isEmpty());
+    }
+
+    buildToolbarHighlightMenu() {
+        this._toolbarMenu.reset();
+        this._iv.callPluginMethod("extendToolbarHighlightMenu", this._toolbarMenu);
+        $("#toolbar-highlight-menu").toggle(!this._toolbarMenu.isEmpty());
+    }
+
     buildDocumentationLink(id, label, target) {
         const link = $('<a></a>')
                 .attr('href', target)
@@ -510,6 +526,8 @@ export class Inspector {
         $('html').attr('lang', i18next.resolvedLanguage);
         this.buildDocumentLanguages();
         this.buildHomeLink()
+        this.buildDisplayOptionsMenu();
+        this.buildToolbarHighlightMenu();
         this.buildDocumentationLinks();
         this.buildSettingsPage();
         this.setupSearchControls();

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -294,18 +294,18 @@ export class Inspector {
         }
     }
 
-    addFactListByGroupFacts(container, next, last) {
+    addFactListByGroupFacts(container, facts, next) {
         $(".show-more", container).remove();
-        for (let i = next; i < last; i++) {
+        for (let i = next; i < facts.length; i++) {
             if (i - next >= FACTS_PER_GROUP - 1) {
-                $("<button></button>") 
+                $("<button></button>")
                     .addClass("show-more")
                     .text(i18next.t("inspector.showMore"))
-                    .on("click",  () => this.addFactListByGroupFacts(container, i, last))
+                    .on("click",  () => this.addFactListByGroupFacts(container, facts, i))
                     .appendTo(container);
                 break;
             }
-            this.factListRow(this._reportSet.facts()[i]).appendTo(container);
+            this.factListRow(facts[i]).appendTo(container);
         }
 
     }
@@ -337,9 +337,7 @@ export class Inspector {
                 .addClass("fact-list")
                 .appendTo(section);
 
-            const first = this._reportSet.facts().indexOf(group.firstFact);
-            const last = this._reportSet.facts().indexOf(group.lastFact);
-            this.addFactListByGroupFacts(body, first, last);
+            this.addFactListByGroupFacts(body, group.facts, 0);
         }
     }
 

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -280,7 +280,13 @@ export class Inspector {
     }
 
     doInitialSelection() {
-        if (!this._currentItem) {
+        if (this._currentItem) {
+            return;
+        }
+        if (this._iv.isFeatureEnabled(FEATURE_SEARCH_ON_STARTUP)) {
+            this.inspectorMode("search-mode");
+        }
+        else {
             this.inspectorMode("fact-mode");
             if (this.outline.hasOutline()) {
                 $("#inspector").addClass("show-facts-by-group");

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -1171,7 +1171,9 @@ export class Inspector {
 
         function insertFileSummary(docs) {
             const ul = summaryFilesContent.find('ul.files-summary-list')
-            visibleItems += 1;
+            if (docs.length > 0) {
+                visibleItems += 1;
+            }
             for (const doc of docs) {
                 ul.append($("<li></li>").text(doc));
             }
@@ -1228,7 +1230,7 @@ export class Inspector {
             summaryDom.find(".filing-documents .download-link").attr("href", this._reportSet.filingDocuments());
         }
         else {
-            summaryDom.find(".filingDocuments").hide();
+            summaryDom.find(".filing-documents").hide();
             summaryDom.find(".downloads-summary").hide();
         }
     }

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -168,7 +168,6 @@ export class Inspector {
                 inspector.summary = new DocumentSummary(reportSet);
                 inspector.createSummary()
                 inspector.outline = new ReportSetOutline(reportSet);
-                inspector.createOutline();
                 inspector.initializeZoom();
                 inspector._iv.setProgress(i18next.t("inspector.initializing")).then(() => {
                     inspector._search = new ReportSearch(reportSet);
@@ -607,14 +606,6 @@ export class Inspector {
             .on("mouseenter", () => this._viewer.linkedHighlightFact(f))
             .on("mouseleave", () => this._viewer.clearLinkedHighlightFact(f))
             .data('ivid', f.vuid);
-      /*
-        $('<button class="select-icon"></button>')
-            .attr("title", i18next.t("search.viewFact"))
-            .on("click", () => {
-                this.selectItem(f.vuid);
-            })
-            .appendTo(row)
-            */
         this._setLabelWithLang($('<div class="title"></div>'), f.getLabelOrNameAndLang("std"))
             .on("click", () => this.selectItem(f.vuid))
             .appendTo(row);
@@ -805,10 +796,6 @@ export class Inspector {
         $(".search-filters .close").on("click", () => $("#ixv").removeClass('show-filters'));
         $(".search-filters button.search-apply-filters").on("click", () => $("#ixv").removeClass('show-filters'));
         $(".search-filters button.search-reset-filters").on("click", () => this.resetSearchFilters());
-        $(".search-controls .search-filters .reset-multiselect").on("click", function () {
-            $(this).siblings().children('select option:selected').prop('selected', false);
-            inspector.search();
-        });
     }
 
     _getScalesOptions() {
@@ -878,23 +865,6 @@ export class Inspector {
         /* Don't highlight search results if there's no search string */
         if (spec.searchString != "") {
             this._viewer.highlightRelatedFacts(results.map(r => r.fact));
-        }
-        for (const name of Object.values(SEARCH_FILTER_MULTISELECTS)) {
-          this.updateMultiSelectSubheader(name);
-        }
-    }
-
-    updateMultiSelectSubheader(id) {
-        const subheader = $(`#${id} .collapsible-subheader`);
-        const selectedOptions = $(`#${id} select option:selected`);
-        if (selectedOptions.length === 1) {
-            subheader.text(` ${selectedOptions.text()}`);
-        }
-        else if (selectedOptions.length > 0) {
-            const totalOptions = $(`#${id} select option`).length;
-            subheader.text(` (${selectedOptions.length}/${totalOptions} ${i18next.t("search.selected")})`)
-        } else {
-            subheader.empty();
         }
     }
 
@@ -1277,27 +1247,6 @@ export class Inspector {
             reportCreationContent.hide();
         }
     };
-
-    createOutline() {
-        if (this.outline.hasOutline()) {
-            $('.outline .no-outline-overlay').hide();
-            $('.outline .body').empty();
-            const container = $('<div class="fact-list"></div>').appendTo($('.outline .body'));
-            for (const group of this.outline.sortedSections()) {
-                $('<button class="fact-list-item"></button>')
-                    .text(group.report.getRoleLabelOrURI(group.elr))
-                    .on("click", () => this.selectItem(group.firstFact.vuid))
-                    .on("dblclick", () => $('#inspector').removeClass("outline-mode"))
-                    .on("mousedown", (e) => {
-                        // Prevent text selection by double click
-                        if (e.detail > 1) { 
-                            e.preventDefault() 
-                        } 
-                    })
-                    .appendTo(container);
-            }
-        }
-    }
 
     updateOutline(cf) {
         $('.fact-groups').empty();
@@ -1953,7 +1902,6 @@ export class Inspector {
 
     setDocumentLanguage(lang) {
         this._viewerOptions.language = lang;
-        this.createOutline();
         this.update();
     }
 

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -1957,7 +1957,7 @@ export class Inspector {
     }
 
     zoomAbsolute(level) {
-        this._zoomLevel = parseInt(level);
+        this._zoomLevel = Math.min(ZOOM_LEVELS.length - 1, Math.max(0, Number.parseInt(level, 10)));
         this._viewer.zoom(ZOOM_LEVELS[this._zoomLevel]);
     }
 }

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.test.js
@@ -258,6 +258,46 @@ describe("Fact deep link", () => {
     })
 });
 
+describe("doInitialSelection", () => {
+    const setUpInspector = (searchOnStartup, hasOutline = false) => {
+        const insp = new TestInspector();
+        insp._iv.setFeatures({ "search_on_startup": searchOnStartup }, "");
+        insp.outline = { hasOutline: jest.fn(() => hasOutline) };
+        insp.inspectorMode = jest.fn();
+        return insp;
+    };
+
+    test("enters search mode when search_on_startup is enabled and no deep link is present", () => {
+        const insp = setUpInspector(true);
+        insp._currentItem = undefined;
+        insp.doInitialSelection();
+        expect(insp.inspectorMode).toHaveBeenCalledWith("search-mode");
+    });
+
+    test("enters fact-mode when search_on_startup is disabled", () => {
+        const insp = setUpInspector(false);
+        insp._currentItem = undefined;
+        insp.doInitialSelection();
+        expect(insp.inspectorMode).toHaveBeenCalledWith("fact-mode");
+    });
+
+    test("adds show-facts-by-group class when the outline has an outline and search_on_startup is disabled", () => {
+        const insp = setUpInspector(false, true);
+        insp._currentItem = undefined;
+        $("#inspector").remove();
+        $(document.body).append('<div id="inspector"></div>');
+        insp.doInitialSelection();
+        expect($("#inspector").hasClass("show-facts-by-group")).toBe(true);
+    });
+
+    test("uses the deep-linked fact when one is present, regardless of search_on_startup", () => {
+        const insp = setUpInspector(true);
+        insp._currentItem = { some: "fact" };
+        insp.doInitialSelection();
+        expect(insp.inspectorMode).not.toHaveBeenCalled();
+    });
+});
+
 describe("Handle message", () => {
     const generateEvent = (data) => {
         return {

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.test.js
@@ -1,5 +1,6 @@
 // See COPYRIGHT.md for copyright information
 
+import $ from 'jquery';
 import { ReportSet } from "./reportset.js";
 import { TestInspector } from "./test-utils.js";
 import { NAMESPACE_ISO4217, SHOW_FACT, viewerUniqueId } from "./util.js";
@@ -336,4 +337,88 @@ describe("Handle message", () => {
         insp.handleMessage(event);
         expect(mockSelect).not.toHaveBeenCalled();
     })
+});
+
+describe("_populateFileSummary", () => {
+    const emptyDocuments = {
+        inline: [],
+        schema: [],
+        calcLinkbase: [],
+        defLinkbase: [],
+        labelLinkbase: [],
+        presLinkbase: [],
+        refLinkbase: [],
+        unrecognizedLinkbase: [],
+    };
+
+    const buildSummaryDom = () => $(`
+        <div>
+          <div class="collapsible-section files-summary">
+            <div class="collapsible-body">
+              <ul class="plain-list files-summary-list"></ul>
+            </div>
+          </div>
+        </div>
+    `);
+
+    test("hides the files summary section when there are no local documents", () => {
+        const insp = new TestInspector();
+        insp.summary = { getLocalDocuments: () => emptyDocuments };
+        const summaryDom = buildSummaryDom();
+
+        insp._populateFileSummary(summaryDom);
+
+        expect(summaryDom.find(".files-summary").css("display")).toBe("none");
+    });
+
+    test("shows the files summary section when there are local documents", () => {
+        const insp = new TestInspector();
+        insp.summary = {
+            getLocalDocuments: () => ({
+                ...emptyDocuments,
+                inline: ["report.html"],
+            }),
+        };
+        const summaryDom = buildSummaryDom();
+
+        insp._populateFileSummary(summaryDom);
+
+        expect(summaryDom.find(".files-summary").css("display")).not.toBe("none");
+        expect(summaryDom.find(".files-summary-list li").text()).toBe("report.html");
+    });
+});
+
+describe("_populateDownloadsSummary", () => {
+    const buildSummaryDom = () => $(`
+        <div>
+          <div class="collapsible-section downloads-summary">
+            <div class="bordered-section filing-documents">
+              <a class="download-link" href=""></a>
+            </div>
+          </div>
+        </div>
+    `);
+
+    test("sets the download link href on the .filing-documents element when present", () => {
+        const insp = new TestInspector();
+        insp._reportSet = { filingDocuments: () => "https://example.com/documents.zip" };
+        const summaryDom = buildSummaryDom();
+
+        insp._populateDownloadsSummary(summaryDom);
+
+        expect(summaryDom.find(".filing-documents .download-link").attr("href")).toBe("https://example.com/documents.zip");
+        expect(summaryDom.find(".filing-documents").css("display")).not.toBe("none");
+        expect(summaryDom.find(".downloads-summary").css("display")).not.toBe("none");
+    });
+
+    test("hides the .filing-documents element when there are no filing documents", () => {
+        const insp = new TestInspector();
+        insp._reportSet = { filingDocuments: () => undefined };
+        const summaryDom = buildSummaryDom();
+
+        insp._populateDownloadsSummary(summaryDom);
+
+        expect(summaryDom.find(".filing-documents").css("display")).toBe("none");
+        expect(summaryDom.find(".downloads-summary").css("display")).toBe("none");
+    });
 });

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.test.js
@@ -318,7 +318,9 @@ describe("Handle message", () => {
         const event = generateEvent({
             task: "INVALID_TASK",
         });
-        insp.handleMessage(event);
+        jest.spyOn(console, 'log').withImplementation(() => {}, () => {
+            insp.handleMessage(event);
+        });
         expect(mockSelect).not.toHaveBeenCalled();
     })
     test("Invalid JSON", () => {

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.test.js
@@ -2,8 +2,10 @@
 
 import $ from 'jquery';
 import { ReportSet } from "./reportset.js";
+import { ReportSetOutline } from "./outline.js";
+import { IXNode } from "./ixnode.js";
 import { TestInspector } from "./test-utils.js";
-import { NAMESPACE_ISO4217, SHOW_FACT, viewerUniqueId } from "./util.js";
+import { NAMESPACE_ISO4217, SHOW_FACT, viewerUniqueId, FACTS_PER_GROUP } from "./util.js";
 
 
 const testReportData = {
@@ -377,6 +379,113 @@ describe("Handle message", () => {
         insp.handleMessage(event);
         expect(mockSelect).not.toHaveBeenCalled();
     })
+});
+
+describe("Facts by group", () => {
+    const groupReportData = {
+        prefixes: {
+            eg: "http://www.example.com",
+        },
+        concepts: {
+            "eg:Root1": { labels: { std: { en: "Root 1" } } },
+            "eg:LineItem1": { labels: { std: { en: "Line Item 1" } } },
+            "eg:LineItem2": { labels: { std: { en: "Line Item 2" } } },
+        },
+        roles: {
+            elr1: "http://www.example.com/elr1",
+            elr2: "http://www.example.com/elr2",
+        },
+        roleDefs: {
+            elr1: { en: "001 Group 1" },
+            elr2: { en: "002 Group 2" },
+        },
+        rels: {
+            pres: {
+                elr1: { "eg:Root1": [{ t: "eg:LineItem1" }] },
+                elr2: { "eg:Root1": [{ t: "eg:LineItem2" }] },
+            },
+        },
+        facts: {},
+        languages: {},
+    };
+
+    // insertionOrder controls the key order of the "facts" object (and thus
+    // reportSet.facts() order); docOrder controls the order IXNode objects
+    // are constructed in, which determines document order (docOrderindex).
+    function buildGroupReportSet(insertionOrder, docOrder, conceptOf) {
+        const data = JSON.parse(JSON.stringify(groupReportData));
+        data.facts = {};
+        for (const id of insertionOrder) {
+            data.facts[id] = { a: { c: conceptOf(id), p: "2019-01-01" } };
+        }
+        const reportSet = new ReportSet(data);
+        const ixNodeMap = {};
+        for (const id of docOrder) {
+            ixNodeMap[viewerUniqueId(0, id)] = new IXNode(id, $('<span></span>'));
+        }
+        reportSet.setIXNodeMap(ixNodeMap);
+        return reportSet;
+    }
+
+    function conceptOf(id) {
+        return id.startsWith("f1") ? "eg:LineItem1" : "eg:LineItem2";
+    }
+
+    function setUpInspector(reportSet) {
+        const insp = new TestInspector();
+        insp._reportSet = reportSet;
+        insp.outline = new ReportSetOutline(reportSet);
+        $("#inspector").remove();
+        $(document.body).append('<div id="inspector"><div class="facts-by-group"></div></div>');
+        return insp;
+    }
+
+    test("only renders facts belonging to the specified group, even when fact-array order differs from document order", () => {
+        // Insertion order into reportSet.facts() puts f2 (an elr2 fact)
+        // between f1 and f1a (both elr1), even though document order is
+        // f1, f1a, f2. This reproduces the bug where index-based slicing of
+        // reportSet.facts() pulled in facts from other groups.
+        const reportSet = buildGroupReportSet(["f1", "f2", "f1a"], ["f1", "f1a", "f2"], conceptOf);
+        const insp = setUpInspector(reportSet);
+
+        insp.buildFactListByGroup();
+
+        const groupBodies = $("#inspector .facts-by-group .collapsible-body");
+        const elr1Body = groupBodies.eq(0);
+        const renderedIds = elr1Body.find(".fact-list-item").map((_, el) => $(el).data("ivid")).get();
+        expect(renderedIds).not.toContain(viewerUniqueId(0, "f2"));
+    });
+
+    test("includes the last fact in the group (no off-by-one)", () => {
+        const reportSet = buildGroupReportSet(["f1", "f2", "f1a"], ["f1", "f1a", "f2"], conceptOf);
+        const insp = setUpInspector(reportSet);
+
+        insp.buildFactListByGroup();
+
+        const elr1Body = $("#inspector .facts-by-group .collapsible-body").eq(0);
+        const renderedIds = elr1Body.find(".fact-list-item").map((_, el) => $(el).data("ivid")).get();
+        expect(renderedIds).toEqual([viewerUniqueId(0, "f1"), viewerUniqueId(0, "f1a")]);
+    });
+
+    test("paginates a group's facts with a show-more button", () => {
+        const ids = [];
+        for (let i = 0; i < FACTS_PER_GROUP + 5; i++) {
+            ids.push(`f1-${i}`);
+        }
+        const reportSet = buildGroupReportSet(ids, ids, () => "eg:LineItem1");
+        const insp = setUpInspector(reportSet);
+
+        insp.buildFactListByGroup();
+
+        const body = $("#inspector .facts-by-group .collapsible-body").eq(0);
+        expect(body.find(".fact-list-item").length).toBe(FACTS_PER_GROUP - 1);
+        expect(body.find(".show-more").length).toBe(1);
+
+        body.find(".show-more").trigger("click");
+
+        expect(body.find(".fact-list-item").length).toBe(ids.length);
+        expect(body.find(".show-more").length).toBe(0);
+    });
 });
 
 describe("_populateFileSummary", () => {

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.test.js
@@ -301,6 +301,54 @@ describe("doInitialSelection", () => {
     });
 });
 
+describe("highlightTagsOnStartup", () => {
+    afterEach(() => {
+        window.localStorage.clear();
+    });
+
+    test("returns true when highlight_facts_on_startup is enabled and no stored preference exists", () => {
+        const insp = new TestInspector();
+        insp._iv.setFeatures({ "highlight_facts_on_startup": true }, "");
+        expect(insp.highlightTagsOnStartup()).toBe(true);
+    });
+
+    test("returns false when highlight_facts_on_startup is disabled and no stored preference exists", () => {
+        const insp = new TestInspector();
+        insp._iv.setFeatures({ "highlight_facts_on_startup": false }, "");
+        expect(insp.highlightTagsOnStartup()).toBe(false);
+    });
+});
+
+describe("Calculation mode setting visibility", () => {
+    beforeAll(() => {
+        return new TestInspector().i18nInit();
+    });
+
+    const setUpInspector = (usesCalculations10, hideCalculationModeOption) => {
+        const insp = new TestInspector();
+        insp._iv.setFeatures({ "hide_calculation_mode_option": hideCalculationModeOption }, "");
+        insp._reportSet = { usesCalculations10: jest.fn(() => usesCalculations10) };
+        $(document.body).append('<table><tbody><tr class="section"><td><select id="setting-calculation-mode"></select></td></tr></tbody></table>');
+        return insp;
+    };
+
+    afterEach(() => {
+        $("#setting-calculation-mode").closest(".section").remove();
+    });
+
+    test("hides calc-mode section when hide_calculation_mode_option is enabled", () => {
+        const insp = setUpInspector(true, true);
+        insp.buildSettingsPage();
+        expect($("#setting-calculation-mode").closest(".section").css("display")).toBe("none");
+    });
+
+    test("shows calc-mode section when hide_calculation_mode_option is disabled and report uses calculations 1.0", () => {
+        const insp = setUpInspector(true, false);
+        insp.buildSettingsPage();
+        expect($("#setting-calculation-mode").closest(".section").css("display")).not.toBe("none");
+    });
+});
+
 describe("Handle message", () => {
     const generateEvent = (data) => {
         return {

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.test.js
@@ -6,7 +6,7 @@ import { ReportSetOutline } from "./outline.js";
 import { IXNode } from "./ixnode.js";
 import { Menu } from "./menu.js";
 import { TestInspector } from "./test-utils.js";
-import { NAMESPACE_ISO4217, SHOW_FACT, viewerUniqueId, FACTS_PER_GROUP } from "./util.js";
+import { NAMESPACE_ISO4217, SHOW_FACT, viewerUniqueId, FACTS_PER_GROUP, ZOOM_LEVELS } from "./util.js";
 
 
 const testReportData = {
@@ -585,6 +585,59 @@ describe("Plugin extension points", () => {
         const items = insp._toolbarMenu._elt.find(".content .item");
         expect(items).toHaveLength(1);
         expect(items.eq(0).text()).toBe("Untagged Facts");
+    });
+});
+
+describe("Zoom boundary clamping", () => {
+    const setUpInspector = () => {
+        const insp = new TestInspector();
+        insp._viewer = { zoom: jest.fn() };
+        return insp;
+    };
+
+    test("zoomRelative does not go below the minimum zoom level", () => {
+        const insp = setUpInspector();
+        insp._zoomLevel = 0;
+        insp.zoomRelative(-1);
+        expect(insp._zoomLevel).toBe(0);
+        expect(insp._viewer.zoom).toHaveBeenCalledWith(ZOOM_LEVELS[0]);
+    });
+
+    test("zoomRelative does not go above the maximum zoom level", () => {
+        const insp = setUpInspector();
+        insp._zoomLevel = ZOOM_LEVELS.length - 1;
+        insp.zoomRelative(1);
+        expect(insp._zoomLevel).toBe(ZOOM_LEVELS.length - 1);
+        expect(insp._viewer.zoom).toHaveBeenCalledWith(ZOOM_LEVELS[ZOOM_LEVELS.length - 1]);
+    });
+
+    test("zoomRelative moves one step within bounds", () => {
+        const insp = setUpInspector();
+        insp._zoomLevel = 5;
+        insp.zoomRelative(1);
+        expect(insp._zoomLevel).toBe(6);
+        expect(insp._viewer.zoom).toHaveBeenCalledWith(ZOOM_LEVELS[6]);
+    });
+
+    test("zoomAbsolute sets the zoom level to the given index", () => {
+        const insp = setUpInspector();
+        insp.zoomAbsolute("3");
+        expect(insp._zoomLevel).toBe(3);
+        expect(insp._viewer.zoom).toHaveBeenCalledWith(ZOOM_LEVELS[3]);
+    });
+
+    test("zoomAbsolute clamps an index below the minimum zoom level", () => {
+        const insp = setUpInspector();
+        insp.zoomAbsolute("-1");
+        expect(insp._zoomLevel).toBe(0);
+        expect(insp._viewer.zoom).toHaveBeenCalledWith(ZOOM_LEVELS[0]);
+    });
+
+    test("zoomAbsolute clamps an index above the maximum zoom level", () => {
+        const insp = setUpInspector();
+        insp.zoomAbsolute(String(ZOOM_LEVELS.length));
+        expect(insp._zoomLevel).toBe(ZOOM_LEVELS.length - 1);
+        expect(insp._viewer.zoom).toHaveBeenCalledWith(ZOOM_LEVELS[ZOOM_LEVELS.length - 1]);
     });
 });
 

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.test.js
@@ -4,6 +4,7 @@ import $ from 'jquery';
 import { ReportSet } from "./reportset.js";
 import { ReportSetOutline } from "./outline.js";
 import { IXNode } from "./ixnode.js";
+import { Menu } from "./menu.js";
 import { TestInspector } from "./test-utils.js";
 import { NAMESPACE_ISO4217, SHOW_FACT, viewerUniqueId, FACTS_PER_GROUP } from "./util.js";
 
@@ -534,6 +535,56 @@ describe("_populateFileSummary", () => {
 
         expect(summaryDom.find(".files-summary").css("display")).not.toBe("none");
         expect(summaryDom.find(".files-summary-list li").text()).toBe("report.html");
+    });
+});
+
+describe("Plugin extension points", () => {
+    const menuFixture = (id) => $(`
+        <div class="menu" id="${id}">
+          <button class="menu-title"></button>
+          <div class="content-container">
+            <div class="content"></div>
+          </div>
+        </div>
+    `);
+
+    test("extendDisplayOptionsMenu is invoked on registered plugins and rendered menu items appear in the DOM", () => {
+        const insp = new TestInspector();
+        const plugin = {
+            extendDisplayOptionsMenu: jest.fn((menu) => {
+                menu.addCheckboxItem("Plugin option", () => {}, "plugin-option");
+                menu.addLink("Plugin link", "https://example.com");
+            }),
+        };
+        insp._iv.registerPlugin(plugin);
+        insp._optionsMenu = new Menu(menuFixture("display-options-menu"));
+
+        insp.buildDisplayOptionsMenu();
+
+        expect(plugin.extendDisplayOptionsMenu).toHaveBeenCalledWith(insp._optionsMenu);
+        const items = insp._optionsMenu._elt.find(".content .item");
+        expect(items).toHaveLength(2);
+        expect(items.eq(0).text()).toBe("Plugin option");
+        expect(items.eq(1).text()).toBe("Plugin link");
+        expect(items.eq(1).attr("href")).toBe("https://example.com");
+    });
+
+    test("extendToolbarHighlightMenu is invoked on registered plugins and rendered menu items appear in the DOM", () => {
+        const insp = new TestInspector();
+        const plugin = {
+            extendToolbarHighlightMenu: jest.fn((menu) => {
+                menu.addCheckboxItem("Untagged Facts", () => {}, "highlight-untagged-facts");
+            }),
+        };
+        insp._iv.registerPlugin(plugin);
+        insp._toolbarMenu = new Menu(menuFixture("toolbar-highlight-menu"));
+
+        insp.buildToolbarHighlightMenu();
+
+        expect(plugin.extendToolbarHighlightMenu).toHaveBeenCalledWith(insp._toolbarMenu);
+        const items = insp._toolbarMenu._elt.find(".content .item");
+        expect(items).toHaveLength(1);
+        expect(items.eq(0).text()).toBe("Untagged Facts");
     });
 });
 

--- a/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
@@ -44,6 +44,16 @@ export class iXBRLViewer {
      * contents, or additional header elements inserted relative to the provided
      * style element.
      *
+     * extendDisplayOptionsMenu(menu)
+     *
+     * Called when the display options menu is created or recreated.  menu is a
+     * Menu object, and can be modified to add additional menu items.
+     *
+     * extendToolbarHighlightMenu(menu)
+     *
+     * Called when the toolbar highlight menu is created or recreated.  menu is
+     * a Menu object, and can be modified to add additional menu items.
+     *
      * extendHighlightKey(key)
      *
      * Called when the highlight color key is created.  key is an array of labels,

--- a/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.test.js
@@ -3,6 +3,8 @@
 import {iXBRLViewer} from "./ixbrlviewer";
 import {
     FEATURE_GUIDE_LINK,
+    FEATURE_HOME_LINK_LABEL,
+    FEATURE_HOME_LINK_URL,
     FEATURE_REVIEW,
     FEATURE_SUPPORT_LINK,
     FEATURE_SURVEY_LINK,
@@ -168,6 +170,29 @@ describe("Survey link enablement", () => {
     test("Survey link disabled by query", () => {
         viewer.setFeatures({[FEATURE_SURVEY_LINK]: '/survey'}, FEATURE_SURVEY_LINK + '=false')
         expect(viewer.getSurveyLinkUrl()).toEqual('/survey');
+    });
+});
+
+describe("Home link feature values", () => {
+    var viewer = null;
+    beforeAll(() => {
+        viewer = new iXBRLViewer({})
+    });
+
+    test("getStaticFeatureValue returns configured home link url and label", () => {
+        viewer.setFeatures({[FEATURE_HOME_LINK_URL]: '/home', [FEATURE_HOME_LINK_LABEL]: 'Home'}, '')
+        expect(viewer.getStaticFeatureValue(FEATURE_HOME_LINK_URL)).toEqual('/home');
+        expect(viewer.getStaticFeatureValue(FEATURE_HOME_LINK_LABEL)).toEqual('Home');
+    });
+
+    test("Query string cannot override static-only home link url", () => {
+        viewer.setFeatures({[FEATURE_HOME_LINK_URL]: '/home'}, FEATURE_HOME_LINK_URL + '=/other')
+        expect(viewer.getStaticFeatureValue(FEATURE_HOME_LINK_URL)).toEqual('/home');
+    });
+
+    test("Query string cannot override static-only home link label", () => {
+        viewer.setFeatures({[FEATURE_HOME_LINK_LABEL]: 'Home'}, FEATURE_HOME_LINK_LABEL + '=Other')
+        expect(viewer.getStaticFeatureValue(FEATURE_HOME_LINK_LABEL)).toEqual('Home');
     });
 });
 

--- a/iXBRLViewerPlugin/viewer/src/js/menu.js
+++ b/iXBRLViewerPlugin/viewer/src/js/menu.js
@@ -1,7 +1,6 @@
 // See COPYRIGHT.md for copyright information
 
 import $ from 'jquery'
-import i18next from "i18next";
 
 export class Menu {
     constructor(elt, attr) {
@@ -25,6 +24,10 @@ export class Menu {
 
     reset() {
         this._elt.find(".content").empty();
+    }
+
+    isEmpty() {
+        return this._elt.find(".content").children().length === 0;
     }
 
     close() {
@@ -67,7 +70,7 @@ export class Menu {
                     .prop("checked", onByDefault)
                     .change(function () {
                         callback($(this).prop("checked"), true);
-                        menu.close(); 
+                        menu.close();
                     })
             )
             .append($("<span></span>").addClass("checkmark"));

--- a/iXBRLViewerPlugin/viewer/src/js/menu.js
+++ b/iXBRLViewerPlugin/viewer/src/js/menu.js
@@ -28,7 +28,7 @@ export class Menu {
     }
 
     close() {
-        if (this.type == "dropdown") {
+        if (this.type === "dropdown") {
             this._elt.find(".content-container").hide();
         }
     }

--- a/iXBRLViewerPlugin/viewer/src/js/menu.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/menu.test.js
@@ -1,0 +1,33 @@
+// See COPYRIGHT.md for copyright information
+
+import $ from 'jquery'
+import { Menu } from "./menu.js";
+
+const menuFixture = () => $(`
+    <div class="menu" id="test-menu">
+      <button class="menu-title"></button>
+      <div class="content-container">
+        <div class="content"></div>
+      </div>
+    </div>
+`);
+
+describe("Menu.isEmpty", () => {
+    test("returns true for an empty menu", () => {
+        const menu = new Menu(menuFixture());
+        expect(menu.isEmpty()).toBe(true);
+    });
+
+    test("returns false once an item has been added", () => {
+        const menu = new Menu(menuFixture());
+        menu.addLink("Link", "https://example.com");
+        expect(menu.isEmpty()).toBe(false);
+    });
+
+    test("returns true again after reset()", () => {
+        const menu = new Menu(menuFixture());
+        menu.addLink("Link", "https://example.com");
+        menu.reset();
+        expect(menu.isEmpty()).toBe(true);
+    });
+});

--- a/iXBRLViewerPlugin/viewer/src/js/outline.js
+++ b/iXBRLViewerPlugin/viewer/src/js/outline.js
@@ -7,7 +7,7 @@ export class ReportSetOutline {
     }
 
     hasOutline() {
-        return this.outlines.some(o => Object.keys(o.sections).length > 0);
+        return this.outlines.some(o => Object.keys(o.sectionFacts).length > 0);
     }
 
     sortedSections() {
@@ -28,12 +28,8 @@ export class DocumentOutline {
     constructor(report) {
         this.report = report;
         const facts = report.facts().sort((a, b) => a.ixNode.docOrderindex - b.ixNode.docOrderindex);
-        const runLength = {};
-        const runStart = {};
-        const runEnd = {};
-        const longestRun = {};
-        const longestRunStart = {};
-        const longestRunEnd = {};
+        const runFacts = {};
+        const longestRunFacts = {};
         this._buildDimensionMap();
         const elrs = report.relationshipGroups("pres");
         for (const f of facts) {
@@ -42,39 +38,31 @@ export class DocumentOutline {
             }
             for (const elr of elrs) {
                 if (this.factInGroup(f, elr)) {
-                    if (!(elr in runLength)) {
-                        // Start counting a run
-                        runLength[elr] = 0;
-                        runStart[elr] = f;
+                    if (!(elr in runFacts)) {
+                        // Start a new run
+                        runFacts[elr] = [];
                     }
-                    runLength[elr]++;
-                    runEnd[elr] = f;
+                    runFacts[elr].push(f);
                 }
-                else if (elr in runLength) { 
+                else if (elr in runFacts) {
                     // End of a run
-                    if (!(elr in longestRun) || longestRun[elr] < runLength[elr]) {
-                        longestRun[elr] = runLength[elr];
-                        longestRunStart[elr] = runStart[elr];
-                        longestRunEnd[elr] = runEnd[elr];
+                    if (!(elr in longestRunFacts) || longestRunFacts[elr].length < runFacts[elr].length) {
+                        longestRunFacts[elr] = runFacts[elr];
                     }
-                    delete runLength[elr];
-                    delete runStart[elr];
+                    delete runFacts[elr];
                 }
             }
         }
 
         // End of document, check if any current runs are the longest run for the
         // ELR.
-        for (const elr in runLength) {
-            if (!(elr in longestRun) || longestRun[elr] < runLength[elr]) {
-                longestRun[elr] = runLength[elr];
-                longestRunStart[elr] = runStart[elr];
-                longestRunEnd[elr] = runEnd[elr];
+        for (const elr in runFacts) {
+            if (!(elr in longestRunFacts) || longestRunFacts[elr].length < runFacts[elr].length) {
+                longestRunFacts[elr] = runFacts[elr];
             }
         }
 
-        this.sections = longestRunStart;
-        this.sectionEnds = longestRunEnd;
+        this.sectionFacts = longestRunFacts;
     }
 
     // Returns true if a fact participates in the given presentation group.
@@ -164,22 +152,22 @@ export class DocumentOutline {
         const factGroups = [];
         for (const group of this.report.relationshipGroups("pres")) {
             if (this.factInGroup(fact, group)) {
-                factGroups.push({ elr: group, fact: this.sections[group], report: this.report});
+                factGroups.push({ elr: group, fact: this.sectionFacts[group][0], report: this.report});
             }
         }
         return factGroups;
     }
 
     hasOutline() {
-        return Object.keys(this.sections).length > 0;
+        return Object.keys(this.sectionFacts).length > 0;
     }
 
     sortedSections() {
-        const sections = Object.keys(this.sections);
+        const sections = Object.keys(this.sectionFacts);
         const re = /\(parenthetical\)\s*$/i;
         const filteredSections = sections.filter(s => !re.test(this.report.getRoleLabelOrURI(s)));
         return filteredSections
             .sort((a, b) => this.report.getRoleLabelOrURI(a).localeCompare(this.report.getRoleLabelOrURI(b)))
-            .map(elr => ({ report: this.report, firstFact: this.sections[elr], lastFact: this.sectionEnds[elr], elr: elr }));
+            .map(elr => ({ report: this.report, firstFact: this.sectionFacts[elr][0], facts: this.sectionFacts[elr], elr }));
     }
 }

--- a/iXBRLViewerPlugin/viewer/src/js/outline.js
+++ b/iXBRLViewerPlugin/viewer/src/js/outline.js
@@ -82,7 +82,7 @@ export class DocumentOutline {
         // Roots are abstract so no need to check for concepts with outgoing
         // relationships only.
 
-        if (this.report.getParentRelationshipsInGroup(fact.conceptName(), "pres", elr).length == 0) {
+        if (this.report.getParentRelationshipsInGroup(fact.conceptName(), "pres", elr).length === 0) {
             return false;
         }
         const fd = fact.dimensions();

--- a/iXBRLViewerPlugin/viewer/src/js/outline.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/outline.test.js
@@ -301,8 +301,8 @@ describe("Section grouping", () => {
         const reportSet = testReportSet(["f1", "f1a"]);
         const outline = new DocumentOutline(reportSet.reports[0]);
         expect(outline.sortedSections().map(g => g.elr)).toEqual(["elr1"]);
-        expect(outline.sections["elr1"].localId()).toEqual("f1");
-        expect(outline.sections["elr3"]).toBeUndefined();
+        expect(outline.sectionFacts["elr1"][0].localId()).toEqual("f1");
+        expect(outline.sectionFacts["elr3"]).toBeUndefined();
     });
 
     test("Longest runs 1", () => {
@@ -311,8 +311,8 @@ describe("Section grouping", () => {
         const reportSet = testReportSet(["f1", "f1a", "f2", "f1b", "f2a", "f2b"]);
         const outline = new DocumentOutline(reportSet.reports[0]);
         expect(outline.sortedSections().map(g => g.elr)).toEqual(["elr1", "elr3"]);
-        expect(outline.sections["elr1"].localId()).toEqual("f1");
-        expect(outline.sections["elr3"].localId()).toEqual("f2a");
+        expect(outline.sectionFacts["elr1"][0].localId()).toEqual("f1");
+        expect(outline.sectionFacts["elr3"][0].localId()).toEqual("f2a");
     });
 
     test("Longest runs 2", () => {
@@ -321,8 +321,8 @@ describe("Section grouping", () => {
         const reportSet = testReportSet(["f1", "f2", "f2b", "f1a", "f1b", "f2a"]);
         const outline = new DocumentOutline(reportSet.reports[0]);
         expect(outline.sortedSections().map(g => g.elr)).toEqual(["elr1", "elr3"]);
-        expect(outline.sections["elr1"].localId()).toEqual("f1a");
-        expect(outline.sections["elr3"].localId()).toEqual("f2");
+        expect(outline.sectionFacts["elr1"][0].localId()).toEqual("f1a");
+        expect(outline.sectionFacts["elr3"][0].localId()).toEqual("f2");
     });
 
     test("Equal length runs", () => {
@@ -331,8 +331,27 @@ describe("Section grouping", () => {
         const reportSet = testReportSet(["f1", "f1a", "f2", "f1b", "f1c", "f2b" ]);
         const outline = new DocumentOutline(reportSet.reports[0]);
         expect(outline.sortedSections().map(g => g.elr)).toEqual(["elr1", "elr3"]);
-        expect(outline.sections["elr1"].localId()).toEqual("f1");
-        expect(outline.sections["elr3"].localId()).toEqual("f2");
+        expect(outline.sectionFacts["elr1"][0].localId()).toEqual("f1");
+        expect(outline.sectionFacts["elr3"][0].localId()).toEqual("f2");
+    });
+
+    test("Per-group fact list matches the run, with no leakage from other groups", () => {
+        // f1, f1a form the ELR1 run; f2 belongs only to ELR3; f1b starts a
+        // second (shorter) ELR1 run that loses out to f1/f1a.
+        const reportSet = testReportSet(["f1", "f1a", "f2", "f1b"]);
+        const outline = new DocumentOutline(reportSet.reports[0]);
+        const sections = outline.sortedSections();
+        const elr1 = sections.find(s => s.elr === "elr1");
+        const elr3 = sections.find(s => s.elr === "elr3");
+        expect(elr1.facts.map(f => f.localId())).toEqual(["f1", "f1a"]);
+        expect(elr3.facts.map(f => f.localId())).toEqual(["f2"]);
+    });
+
+    test("Per-group fact list includes the last fact in the run", () => {
+        const reportSet = testReportSet(["f1", "f1a", "f1b"]);
+        const outline = new DocumentOutline(reportSet.reports[0]);
+        const elr1 = outline.sortedSections().find(s => s.elr === "elr1");
+        expect(elr1.facts.map(f => f.localId())).toEqual(["f1", "f1a", "f1b"]);
     });
 
     test("Hidden facts", () => {
@@ -340,29 +359,29 @@ describe("Section grouping", () => {
         const reportSet = testReportSet(["f1a", "f1", "f2", "f1b", "f1c", "f1d"]);
         let outline = new DocumentOutline(reportSet.reports[0]);
         expect(outline.sortedSections().map(g => g.elr)).toEqual(["elr1", "elr3"]);
-        expect(outline.sections["elr1"].localId()).toEqual("f1b");
-        expect(outline.sections["elr3"].localId()).toEqual("f2");
+        expect(outline.sectionFacts["elr1"][0].localId()).toEqual("f1b");
+        expect(outline.sectionFacts["elr3"][0].localId()).toEqual("f2");
 
         // Make f1c hidden.  We now have ELR1*2 ELR3*1 ELR1*2
         // The first ELR1 run should be selected.
         getFact(reportSet, "f1c").ixNode.isHidden = true;
         outline = new DocumentOutline(reportSet.reports[0]);
         expect(outline.sortedSections().map(g => g.elr)).toEqual(["elr1", "elr3"]);
-        expect(outline.sections["elr1"].localId()).toEqual("f1a");
-        expect(outline.sections["elr3"].localId()).toEqual("f2");
+        expect(outline.sectionFacts["elr1"][0].localId()).toEqual("f1a");
+        expect(outline.sectionFacts["elr3"][0].localId()).toEqual("f2");
 
         // Make f1a hidden.  f1b-[f1c]-f1d is now the longest run.
         getFact(reportSet, "f1a").ixNode.isHidden = true;
         outline = new DocumentOutline(reportSet.reports[0]);
         expect(outline.sortedSections().map(g => g.elr)).toEqual(["elr1", "elr3"]);
-        expect(outline.sections["elr1"].localId()).toEqual("f1b");
-        expect(outline.sections["elr3"].localId()).toEqual("f2");
+        expect(outline.sectionFacts["elr1"][0].localId()).toEqual("f1b");
+        expect(outline.sectionFacts["elr3"][0].localId()).toEqual("f2");
 
         // Hide f2.  We now have a single run for ELR1
         getFact(reportSet, "f2").ixNode.isHidden = true;
         outline = new DocumentOutline(reportSet.reports[0]);
         expect(outline.sortedSections().map(g => g.elr)).toEqual(["elr1"]);
-        expect(outline.sections["elr1"].localId()).toEqual("f1");
+        expect(outline.sectionFacts["elr1"][0].localId()).toEqual("f1");
 
     });
 });

--- a/iXBRLViewerPlugin/viewer/src/js/search.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.test.js
@@ -224,23 +224,24 @@ describe("Search calculation filter", () => {
         const results = reportSearch.search(spec).map(r => r.fact.localId()).sort();
         expect(results).toEqual(['item1', 'item2', 'summation']);
     });
-    const emptyReport = testReport(
-            {
-                "concepts": {
-                    ...createSimpleConcept("test:Concept", "Concept"),
-                },
-                "facts": {
-                    ...createSimpleFact("fact", "test:Fact"),
-                },
-            },
-    )
-    const emptyReportSearch = getReportSearch(emptyReport);
-
     test("Calculations filter works on empty report", () => {
-        const spec = testSearchSpec();
-        spec.calculationsFilter = ['summation', 'contributor'];
-        const results = emptyReportSearch.search(spec).map(r => r.fact.localId()).sort();
-        expect(results).toEqual([]);
+        const emptyReport = testReport(
+                {
+                    "concepts": {
+                        ...createSimpleConcept("test:Concept", "Concept"),
+                    },
+                    "facts": {
+                        ...createSimpleFact("fact", "test:Fact"),
+                    },
+                },
+        );
+        jest.spyOn(console, 'log').withImplementation(() => {}, () => {
+            const emptyReportSearch = getReportSearch(emptyReport);
+            const spec = testSearchSpec();
+            spec.calculationsFilter = ['summation', 'contributor'];
+            const results = emptyReportSearch.search(spec).map(r => r.fact.localId()).sort();
+            expect(results).toEqual([]);
+        });
     });
 });
 
@@ -431,23 +432,24 @@ describe("Search dimension type filter", () => {
         expect(results).toEqual(['explicit', 'explicit2', 'explicitAndTyped', 'explicitAndTyped2', 'typed', 'typed2']);
     });
 
-    const emptyReport = testReport(
-            {
-                "concepts": {
-                    ...createSimpleConcept("test:Concept", "Concept"),
-                },
-                "facts": {
-                    ...createSimpleFact("fact", "test:Fact"),
-                },
-            },
-    )
-    const emptyReportSearch = getReportSearch(emptyReport);
-
     test("Dimension filter works on empty report", () => {
-        const spec = testSearchSpec();
-        spec.dimensionTypeFilter = ['explicit'];
-        const results = emptyReportSearch.search(spec).map(r => r.fact.localId()).sort();
-        expect(results).toEqual([]);
+        const emptyReport = testReport(
+                {
+                    "concepts": {
+                        ...createSimpleConcept("test:Concept", "Concept"),
+                    },
+                    "facts": {
+                        ...createSimpleFact("fact", "test:Fact"),
+                    },
+                },
+        );
+        jest.spyOn(console, 'log').withImplementation(() => {}, () => {
+            const emptyReportSearch = getReportSearch(emptyReport);
+            const spec = testSearchSpec();
+            spec.dimensionTypeFilter = ['explicit'];
+            const results = emptyReportSearch.search(spec).map(r => r.fact.localId()).sort();
+            expect(results).toEqual([]);
+        });
     });
 });
 

--- a/iXBRLViewerPlugin/viewer/src/js/search.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.test.js
@@ -243,6 +243,13 @@ describe("Search calculation filter", () => {
             expect(results).toEqual([]);
         });
     });
+
+    test("Calculations 'none' filter works", () => {
+        const spec = testSearchSpec();
+        spec.calculationsFilter = ['none'];
+        const results = reportSearch.search(spec).map(r => r.fact.localId()).sort();
+        expect(results).toEqual(['other']);
+    });
 });
 
 describe("Search namespaces filter", () => {
@@ -371,7 +378,7 @@ describe("Search units filter", () => {
         spec1.unitsFilter = Array.from(report.getUsedUnits());
         const results1 = reportSearch.search(spec1).map(r => r.fact.localId()).sort();
         const spec2 = testSearchSpec()
-        spec2.conceptTypeFilter = 'numeric';
+        spec2.conceptTypeFilter = ['numeric'];
         const results2 = reportSearch.search(spec2).map(r => r.fact.localId()).sort();
         expect(results1).toEqual(results2);
         expect(results1).toEqual(['itemA', 'itemAB', 'itemB', 'itemBA'])
@@ -450,6 +457,13 @@ describe("Search dimension type filter", () => {
             const results = emptyReportSearch.search(spec).map(r => r.fact.localId()).sort();
             expect(results).toEqual([]);
         });
+    });
+
+    test("Dimension 'none' filter works", () => {
+        const spec = testSearchSpec();
+        spec.dimensionTypeFilter = ['none'];
+        const results = reportSearch.search(spec).map(r => r.fact.localId()).sort();
+        expect(results).toEqual(['simple', 'simple2']);
     });
 });
 
@@ -619,4 +633,99 @@ describe("Search target document filter", () => {
         expect(results).toEqual(['item0', 'item1', 'item2', 'item3', 'item4', 'item5' ]);
     });
 
+});
+
+describe("Search visibility filter", () => {
+    const report = testReport(
+            {
+                "concepts": {
+                    ...createSimpleConcept("a:Item1"),
+                    ...createSimpleConcept("a:Item2"),
+                },
+                "facts": {
+                    ...createSimpleFact("visible1", "a:Item1"),
+                    ...createSimpleFact("hidden1", "a:Item2"),
+                }
+            },
+            {
+                "visible1": { "isHidden": false },
+                "hidden1": { "isHidden": true },
+            }
+    )
+    const reportSearch = getReportSearch(report);
+
+    test("Visibility filter works without selection", () => {
+        const spec = testSearchSpec();
+        spec.visibilityFilter = [];
+        const results = reportSearch.search(spec).map(r => r.fact.localId()).sort();
+        expect(results).toEqual(['hidden1', 'visible1']);
+    });
+
+    test("Visibility filter works with 'visible' selection", () => {
+        const spec = testSearchSpec();
+        spec.visibilityFilter = ['visible'];
+        const results = reportSearch.search(spec).map(r => r.fact.localId()).sort();
+        expect(results).toEqual(['visible1']);
+    });
+
+    test("Visibility filter works with 'hidden' selection", () => {
+        const spec = testSearchSpec();
+        spec.visibilityFilter = ['hidden'];
+        const results = reportSearch.search(spec).map(r => r.fact.localId()).sort();
+        expect(results).toEqual(['hidden1']);
+    });
+
+    test("Visibility filter works with both selections", () => {
+        const spec = testSearchSpec();
+        spec.visibilityFilter = ['visible', 'hidden'];
+        const results = reportSearch.search(spec).map(r => r.fact.localId()).sort();
+        expect(results).toEqual(['hidden1', 'visible1']);
+    });
+});
+
+describe("Search mandatory facts filter", () => {
+    const facts = {
+        ...createSimpleFact("mandatory1", "a:Item1"),
+        ...createSimpleFact("other1", "a:Item2"),
+    };
+    facts["mandatory1"]["a"]["m"] = true;
+
+    const report = testReport(
+            {
+                "concepts": {
+                    ...createSimpleConcept("a:Item1"),
+                    ...createSimpleConcept("a:Item2"),
+                },
+                "facts": facts
+            }
+    )
+    const reportSearch = getReportSearch(report);
+
+    test("Mandatory facts filter works without selection", () => {
+        const spec = testSearchSpec();
+        spec.mandatoryFactsFilter = [];
+        const results = reportSearch.search(spec).map(r => r.fact.localId()).sort();
+        expect(results).toEqual(['mandatory1', 'other1']);
+    });
+
+    test("Mandatory facts filter works with 'mandatory' selection", () => {
+        const spec = testSearchSpec();
+        spec.mandatoryFactsFilter = ['mandatory'];
+        const results = reportSearch.search(spec).map(r => r.fact.localId()).sort();
+        expect(results).toEqual(['mandatory1']);
+    });
+
+    test("Mandatory facts filter works with 'other' selection", () => {
+        const spec = testSearchSpec();
+        spec.mandatoryFactsFilter = ['other'];
+        const results = reportSearch.search(spec).map(r => r.fact.localId()).sort();
+        expect(results).toEqual(['other1']);
+    });
+
+    test("Mandatory facts filter works with both selections", () => {
+        const spec = testSearchSpec();
+        spec.mandatoryFactsFilter = ['mandatory', 'other'];
+        const results = reportSearch.search(spec).map(r => r.fact.localId()).sort();
+        expect(results).toEqual(['mandatory1', 'other1']);
+    });
 });

--- a/iXBRLViewerPlugin/viewer/src/js/summary.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/summary.test.js
@@ -23,6 +23,7 @@ function testConcept(typedDomainElement) {
 function testFact(conceptName, dimensions, identifier) {
     return {
         conceptName: () => conceptName,
+        conceptQName: () => ({ localname: conceptName.split(':')[1] }),
         dimensions: () => dimensions,
         identifier: () => identifier
     }
@@ -211,6 +212,60 @@ describe("Tags summary", () => {
                 "total": 1
             }
         });
+    });
+});
+
+describe("Identifiers summary", () => {
+
+    test("no facts yields no identifiers", () => {
+        const reportSet = testReportSet({}, [], {}, []);
+        const summary = new DocumentSummary(reportSet);
+
+        expect(summary.identifiers()).toEqual([]);
+    });
+
+    test("orders identifiers by descending fact count", () => {
+        const conceptName = "eg:Concept1";
+        const idA = testQName('lei', 'A', 'http://example.com');
+        const idB = testQName('lei', 'B', 'http://example.com');
+        const facts = [
+            testFact(conceptName, {}, idA),
+            testFact(conceptName, {}, idB),
+            testFact(conceptName, {}, idB),
+        ];
+        const reportSet = testReportSet({}, facts, {}, []);
+        const summary = new DocumentSummary(reportSet);
+
+        expect(summary.identifiers()).toEqual([idB.qname, idA.qname]);
+    });
+});
+
+describe("Entity names summary", () => {
+
+    test("no facts yields no entity names", () => {
+        const reportSet = testReportSet({}, [], {}, []);
+        const summary = new DocumentSummary(reportSet);
+
+        expect(summary.entityNames()).toEqual([]);
+    });
+
+    test("returns facts tagged with recognized entity name concepts", () => {
+        const identifier = testQName('lei', '123', 'http://example.com');
+        const entityFact = testFact("dei:EntityRegistrantName", {}, identifier);
+        const otherFact = testFact("eg:Concept1", {}, identifier);
+        const reportSet = testReportSet({}, [entityFact, otherFact], {}, []);
+        const summary = new DocumentSummary(reportSet);
+
+        expect(summary.entityNames()).toEqual([entityFact]);
+    });
+
+    test("returns no facts when no entity name concepts are present", () => {
+        const identifier = testQName('lei', '123', 'http://example.com');
+        const otherFact = testFact("eg:Concept1", {}, identifier);
+        const reportSet = testReportSet({}, [otherFact], {}, []);
+        const summary = new DocumentSummary(reportSet);
+
+        expect(summary.entityNames()).toEqual([]);
     });
 });
 

--- a/iXBRLViewerPlugin/viewer/src/js/theme.js
+++ b/iXBRLViewerPlugin/viewer/src/js/theme.js
@@ -42,14 +42,6 @@ export function initializeTheme() {
     }
 }
 
-// UNUSED
-export function toggleTheme() {
-    const currentTheme = getTheme();
-    const newTheme = currentTheme === LIGHT_THEME ? DARK_THEME : LIGHT_THEME;
-    setTheme(newTheme);
-    storeTheme(newTheme);
-}
-
 export function darkModeTheme() {
     setTheme(DARK_THEME);
     storeTheme(DARK_THEME);

--- a/iXBRLViewerPlugin/viewer/src/less/components.less
+++ b/iXBRLViewerPlugin/viewer/src/less/components.less
@@ -12,7 +12,7 @@
   white-space: nowrap;
 }
 
-.clickable {
+.clickable() {
   cursor: pointer;
   color: var(--colour-primary);
 }

--- a/iXBRLViewerPlugin/viewer/src/less/core.less
+++ b/iXBRLViewerPlugin/viewer/src/less/core.less
@@ -10,7 +10,7 @@ body {
   margin: 0;
 }
 
-.link-style {
+.link-style() {
   display: inline-block;
   line-height: 2.0rem;
   border-bottom: solid 0.1rem var(--colour-primary-light);

--- a/iXBRLViewerPlugin/viewer/src/less/form-controls.less
+++ b/iXBRLViewerPlugin/viewer/src/less/form-controls.less
@@ -13,46 +13,6 @@ button {
   line-height: 1.8rem;
 }
 
-.square-button-bare {
-  width: 3.2rem;
-  height: 3.2rem;
-  text-align: center;
-  color: var(--colour-icon-grey);
-  box-sizing: border-box;
-  cursor: pointer;
-  padding: 0;
-  font-size: 2.2rem;
-  line-height: 3.2rem;
-  user-select: none;
-  border: none;
-}
-
-.square-button {
-  .square-button-bare();
-
-  padding: 0;
-  border-radius: 3px;
-  border: solid 0.1rem var(--colour-border-grey);
-  background-color: var(--colour-button-bg);
-  line-height: 3rem;
-  margin: 0 0.5rem;
-
-  &:last-of-type {
-    margin-right: 0;
-  }
-
-  &:first-of-type {
-    margin-left: 0;
-  }
-}
-
-.square-button.primary {
-  color: var(--colour-bg);
-  border-color: var(--colour-button-primary-border);
-  background-color: var(--colour-button-primary-bg);
-}
-
-.wk-checkbox,
 label.checkbox {
   position: relative;
   padding-left: 2.2rem;
@@ -134,14 +94,6 @@ input:disabled {
   &.negate-padding {
     margin-left: -0.3rem;
   }
-}
-
-.bare-button {
-  display: inline;
-  cursor: pointer;
-  color: var(--colour-primary);
-  padding: 0.3rem;
-  border: none;
 }
 
 .primary-button {

--- a/iXBRLViewerPlugin/viewer/src/less/form-controls.less
+++ b/iXBRLViewerPlugin/viewer/src/less/form-controls.less
@@ -96,7 +96,7 @@ input:disabled {
   }
 }
 
-.primary-button {
+.primary-button() {
   background-color: var(--colour-button-primary-bg);
   border: solid 0.1rem var(--colour-button-primary-border);
   color: var(--colour-button-primary-text);
@@ -107,7 +107,7 @@ input:disabled {
   }
 }
 
-.secondary-button {
+.secondary-button() {
   background-color: var(--colour-button-secondary-bg);
   border: solid 0.1rem var(--colour-button-secondary-border);
   color: var(--colour-button-secondary-text);
@@ -118,7 +118,7 @@ input:disabled {
   }
 }
 
-.icon-button {
+.icon-button() {
   cursor: pointer;
   padding: 0.8rem;
   border: none;

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -136,17 +136,6 @@ a {
   }
 }
 
-#ixv-progress {
-  position: fixed;
-  top: 20px;
-  left: 20px;
-  width: 500px;
-  height: 200px;
-  background-color: var(--colour-bg);
-  border: solid #000 1px;
-  text-align: center;
-}
-
 #panes {
   display: flex;
   flex-direction: row; 
@@ -423,23 +412,6 @@ a {
     margin-bottom: 1.4em;
   }
 
-  #inspector-head {
-    padding: 0;
-    position: relative;
-    border-bottom: solid 1px var(--colour-border-grey);
-
-    .controls {
-      position: relative;
-      height: 3.2rem;
-      padding: 0.8rem 0.9rem;
-      display: flex;
-
-      & > * {
-        margin: 0.8rem 0.9rem;
-      }
-    }
-  }
-
   .inspector-container {
     flex: 1 1 0;
     overflow: hidden;
@@ -474,11 +446,6 @@ a {
 
         div:first-child {
             flex: 1 0 auto;
-        }
-
-        div.fact-count {
-            flex: 0 0 auto;
-            color: var(--colour-text-light);
         }
 
         div:last-child {
@@ -638,10 +605,6 @@ a {
             flex: 1 1 auto;
           }
 
-          button.search-clear-filters {
-            .secondary-button();
-          }
-
           button.search-apply-filters {
             .primary-button();
           }
@@ -693,12 +656,6 @@ a {
             }
           }
 
-          .control-label {
-            white-space: nowrap;
-            margin-right: 2em;
-            width: 6em;
-          }
-
           input,
           select,
           textarea {
@@ -707,36 +664,10 @@ a {
           }
         }
 
-        .control-label {
-          font-weight: bold;
-          margin-bottom: 0.6em;
-          margin-top: 0.8em;
-        }
-
         select {
           width: 100%;
         }
 
-        .checkboxes {
-          display: flex;
-          flex-wrap: wrap;
-
-          & > div {
-            margin: 1.2rem 0;
-            flex-grow: 1;
-
-            input {
-              vertical-align: middle;
-            }
-          }
-        }
-
-
-        .datatype-conflict-warning {
-          margin: 1rem 0;
-          color: var(--colour-warning);
-          display: none;
-        }
       }
 
       .search-results {
@@ -798,8 +729,7 @@ a {
         .panel-indent();
       }
 
-      .no-fact-overlay,
-      .no-outline-overlay {
+      .no-fact-overlay {
         position: absolute;
         left: 50%;
         top: 50%;
@@ -815,13 +745,6 @@ a {
           line-height: normal;
         }
 
-        .no-outline-overlay-icon::before {
-          .icon-outline();
-
-          font-size: 10rem;
-          line-height: normal;
-        }
-
         .title {
           font-size: x-large;
           line-height: normal;
@@ -832,12 +755,6 @@ a {
         overflow-y: auto;
         height: 100%;
         position: relative;
-      }
-
-
-      .outline {
-        overflow-y: auto;
-        height: 100%;
       }
 
       .summary {
@@ -985,11 +902,6 @@ a {
     }
   }
 
-  .inspector-section {
-    padding-left: 0.9rem;
-    padding-right: 0.9rem;
-  }
-
   .collapsible-section {
     .collapsible-body {
       .panel-indent();
@@ -1044,23 +956,11 @@ a {
             transition: all 0.25s ease;
           }
       }
-
-      .collapsible-subheader {
-        user-select: none;
-        font-weight: normal;
-        font-style: italic;
-        font-size: 1.3rem;
-        color: var(--colour-text-form-value);
-      }
     }
 
     &.collapsed {
       .collapsible-header button::before {
         transform: rotate(180deg);
-      }
-
-      .collapsible-subheader {
-        color: var(--colour-primary);
       }
     }
 
@@ -1187,24 +1087,6 @@ a {
     
   }
 
-  .resetable-multiselect {
-    position: relative;
-
-    .reset-multiselect {
-      position: absolute;
-      top: -2.5rem;
-      right: -0.5rem;
-      cursor: pointer;
-      border: none;
-      padding: 0.3rem;
-
-
-      &::after {
-        .icon-close();
-      }
-    }
-  }
-
   &:not(.no-fact-selected),
   &.show-facts-by-group {
     .no-fact-overlay {
@@ -1266,24 +1148,6 @@ a {
       line-height: 3rem;
       color: var(--colour-text-light);
     }
-  }
-
-  &:not(.search-mode) .search-mode-only {
-    display: none;
-  }
-
-  &:not(.outline-mode) .outline-mode-only {
-    display: none;
-  }
-
-  &:not(.summary-mode) .summary-mode-only {
-    display: none;
-  }
-
-  &.search-mode .fact-mode-only,
-  &.summary-mode .fact-mode-only,
-  &.outline-mode .fact-mode-only {
-    display: none;
   }
 
   &:not(.footnote-mode) .footnote-mode-only {

--- a/iXBRLViewerPlugin/viewer/src/less/menu.less
+++ b/iXBRLViewerPlugin/viewer/src/less/menu.less
@@ -109,13 +109,20 @@
         }
       }
     }
-  }
 
-  .toolbar-menu {
-    .menu-checkbox {
-      .wk-checkbox();
+    // A menu whose content should render inline in its container (e.g. a
+    // settings page section) rather than as a fixed-position dropdown.
+    &.inline-menu {
+      line-height: initial;
 
-      margin-left: 1.8rem;
+      .content-container {
+        position: static;
+        display: block;
+
+        .content {
+          border: none;
+        }
+      }
     }
   }
 }

--- a/iXBRLViewerPlugin/viewer/src/less/summary.less
+++ b/iXBRLViewerPlugin/viewer/src/less/summary.less
@@ -8,15 +8,6 @@
       .inline-button();
     }
 
-    .file-summary-container {
-      display: flex;
-      flex-flow: row wrap;
-
-      .files {
-        flex: 1 1 auto;
-      }
-    }
-
     table.tag-summary {
       width: 100%;
       border-collapse: collapse;

--- a/tests/unit_tests/iXBRLViewerPlugin/test_iXBRLViewer.py
+++ b/tests/unit_tests/iXBRLViewerPlugin/test_iXBRLViewer.py
@@ -16,6 +16,7 @@ from .mock_arelle import mock_arelle
 
 mock_arelle()
 
+from iXBRLViewerPlugin.constants import MANDATORY_FACTS
 from iXBRLViewerPlugin.iXBRLViewer import NamespaceMap, IXBRLViewerBuilder, iXBRLViewerFile
 
 class TestNamespaceMap:
@@ -814,6 +815,124 @@ class TestIXBRLViewer:
         assert facts.keys() == {"fact_id2", "fact_id3"}
         assert facts["fact_id2"]["a"]["u"] == "iso4217:USD"
         assert facts["fact_id3"]["a"]["u"] is None
+
+    def test_MANDATORY_FACTS_companies_house_contains_expected_facts(self):
+        """
+        MANDATORY_FACTS['companies-house'] should list the FRC-mandated
+        Companies House facts.
+        """
+        assert MANDATORY_FACTS['companies-house'] == [
+            "UKCompaniesHouseRegisteredNumber",
+            "EntityCurrentLegalOrRegisteredName",
+            "BalanceSheetDate",
+            "DateAuthorisationFinancialStatementsForIssue",
+            "DirectorSigningFinancialStatements",
+            "EntityDormantTruefalse",
+            "EntityTradingStatus",
+            "AccountsStatusAuditedOrUnaudited",
+            "AccountsTypeFullOrAbbreviated",
+            "AccountingStandardsApplied",
+            "LegalFormEntity",
+            "StartDateForPeriodCoveredByReport",
+            "EndDateForPeriodCoveredByReport",
+            "CharityRegistrationNumberEnglandWales",
+            "CharityRegistrationNumberScotland",
+            "CharityRegistrationNumberNorthernIreland",
+        ]
+
+    def test_addFact_stamps_m_aspect_true_for_mandatory_concept(self):
+        """
+        When the `mandatory_facts` feature selects the `companies-house`
+        profile, addFact should stamp `m: True` on a fact whose concept is
+        in that profile's mandatory facts list.
+        """
+        builder = IXBRLViewerBuilder(self.cntlr_mock, features={'mandatory_facts': 'companies-house'})
+        builder.footnoteRelationshipSet = Mock(fromModelObject=Mock(return_value=[]))
+        builder.currentTargetReport = builder.newTargetReport(None)
+
+        mandatory_qname = Mock(
+            localName='UKCompaniesHouseRegisteredNumber',
+            prefix='uk-bus',
+            namespaceURI='http://xbrl.frc.org.uk/cd/2021-01-01/business'
+        )
+        mandatory_concept = Mock(
+            spec=ModelConcept,
+            qname=mandatory_qname,
+            balance=None,
+            isTypedDimension=False,
+            isEnumeration=False,
+            isTextBlock=False,
+            type=self.string_type,
+            modelXbrl=self.modelXbrl_1,
+        )
+        fact = Mock(
+            id='fact_mandatory',
+            qname=mandatory_qname,
+            concept=mandatory_concept,
+            context=Mock(
+                entityIdentifier=('scheme', 'ident'),
+                qnameDims={},
+                isForeverPeriod=False,
+                isInstantPeriod=False,
+                isStartEndPeriod=False,
+            ),
+            isNumeric=False,
+            isNil=False,
+            isTuple=False,
+            value='12345678',
+            format=None,
+        )
+
+        builder.addFact(self.modelXbrl_1, fact)
+
+        assert builder.currentTargetReport["facts"]["fact_mandatory"]["a"]["m"] is True
+
+    def test_addFact_stamps_m_aspect_false_for_non_mandatory_concept(self):
+        """
+        Even with the `companies-house` mandatory_facts profile selected,
+        addFact should stamp `m: False` on a fact whose concept is not in
+        that profile's mandatory facts list.
+        """
+        builder = IXBRLViewerBuilder(self.cntlr_mock, features={'mandatory_facts': 'companies-house'})
+        builder.footnoteRelationshipSet = Mock(fromModelObject=Mock(return_value=[]))
+        builder.currentTargetReport = builder.newTargetReport(None)
+
+        non_mandatory_qname = Mock(
+            localName='Cash',
+            prefix='us-gaap',
+            namespaceURI='http://viewer.com'
+        )
+        non_mandatory_concept = Mock(
+            spec=ModelConcept,
+            qname=non_mandatory_qname,
+            balance=None,
+            isTypedDimension=False,
+            isEnumeration=False,
+            isTextBlock=False,
+            type=self.monetary_type,
+            modelXbrl=self.modelXbrl_1,
+        )
+        fact = Mock(
+            id='fact_non_mandatory',
+            qname=non_mandatory_qname,
+            concept=non_mandatory_concept,
+            context=Mock(
+                entityIdentifier=('scheme', 'ident'),
+                qnameDims={},
+                isForeverPeriod=False,
+                isInstantPeriod=False,
+                isStartEndPeriod=False,
+            ),
+            isNumeric=False,
+            isNil=False,
+            isTuple=False,
+            value='1000',
+            format=None,
+        )
+
+        builder.addFact(self.modelXbrl_1, fact)
+
+        assert builder.currentTargetReport["facts"]["fact_non_mandatory"]["a"]["m"] is False
 
     def test_enableFeature_valid(self):
         """


### PR DESCRIPTION
#### Reason for change

Follow-up to #1092 resolving issues found in testing. Commits can be reviewed one at a time.

#### Description of change

- Restore `extendDisplayOptionsMenu`/`extendToolbarHighlightMenu` plugin hooks and the Menu widget they depend on
- Fix facts-by-group rendering: cross-group leakage and an off-by-one that dropped each group's last fact
- Restore the `search_on_startup` feature flag in `doInitialSelection()`
- Fix inspector summary visibility bugs
- Fix `seeMoreLink()` producing a broken link for identifier schemes with no URL
- Fix HTML nesting/unclosed-tag errors in viewer templates
- Remove dead JS/HTML/LESS/i18n left behind
- Add test coverage: search filters, zoom clamping, DocumentSummary, FRC feature-flag compatibility
- Translate placeholder i18n strings (AI translations, improvements welcomed)

#### Steps to Test

* [x] CI
* [x] regression test viewer in Arelle
* [x] regression test viewer in FRC Codex project (feature usage)

**review**:
@Arelle/arelle
@paulwarren-wk
