### PR TITLE
Anchor the fact tags to the concept title

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -71,16 +71,18 @@ See COPYRIGHT.md for copyright information
                     </div>
                 </div>
               </nav>
-              <div class="tags">
-                <div class="target-document-tag"></div>
-                <div class="hidden-fact-tag" data-i18n="inspector.hiddenFact">Hidden Fact</div>
-                <div class="html-hidden-fact-tag" data-i18n="inspector.concealedFact">Concealed Fact</div>
-              </div>
               <div class="nested-item-select">
                   <div class="description" ></div>
                   <select></select>
               </div>
-              <h2 class="concept-name-title"></h2>
+              <div class="concept-name-row">
+                <h2 class="concept-name-title"></h2>
+                <div class="tags">
+                  <div class="target-document-tag"></div>
+                  <div class="hidden-fact-tag" data-i18n="inspector.hiddenFact">Hidden Fact</div>
+                  <div class="html-hidden-fact-tag" data-i18n="inspector.concealedFact">Concealed Fact</div>
+                </div>
+              </div>
               <div class="fact-inspector-body">
               </div>
               <div class="footnote-mode-off">

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -725,8 +725,31 @@ a {
       overflow-y: auto;
       flex-grow: 1;
 
-      h2.concept-name-title {
+      .concept-name-row {
         .panel-indent();
+
+        display: flex;
+        flex-wrap: wrap;
+        align-items: baseline;
+        gap: 0.6rem;
+
+        h2.concept-name-title {
+          flex: 1 1 55%;
+          padding: 0;
+        }
+
+        .tags {
+          flex-shrink: 0;
+          max-width: 100%;
+          margin-left: auto;
+          margin-right: -0.3rem;
+
+          .target-document-tag {
+            max-width: 100%;
+            white-space: normal;
+            overflow-wrap: anywhere;
+          }
+        }
       }
 
       .no-fact-overlay {
@@ -858,12 +881,6 @@ a {
 
     position: relative;
     top: 1px;
-  }
-
-  .inspector-body .tags {
-    position: absolute;
-    top: 1.5rem;
-    right: 0.9rem;
   }
 
   .target-document-tag {


### PR DESCRIPTION
#### Reason for change

The target document and hidden fact tags were positioned absolutely against the inspector body.  The UI redesign left that rule alone while moving the markup: the body now opens with the previous/next nav, so the tags landed on top of it, covering the fact count and the Next button and reading as a chip floating over nothing.

#### Description of change
| master | pr |
| -- | -- |
| <img alt="tags-before" src="https://github.com/user-attachments/assets/2b0474fe-ce4d-485a-8ab7-05958d402598" /> | <img alt="tags-after" src="https://github.com/user-attachments/assets/f6690ca2-65aa-4d28-9e9e-c60c57aa949e" /> |


#### Steps to Test

* [x] confirm fact tags render correctly

**review**:
@Arelle/arelle
@paulwarren-wk
