### PR TITLE
Stop sections jumping as a slide begins

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -906,8 +906,14 @@ a {
     .collapsible-body {
       .panel-indent();
 
+      display: flow-root;
+
       & > * {
         margin-bottom: 1.2rem;
+      }
+
+      & > *:first-child {
+        margin-top: 0;
       }
 
       & > table.property-table:first-child,


### PR DESCRIPTION
#### Reason for change

Expanding or collapsing a section moved everything below it down a few pixels and snapped it back before the slide ran.


#### Description of change
| master | pr |
| -- | -- |
| <img alt="tags-before" src="https://github.com/user-attachments/assets/e8587041-6422-444a-9a3a-ca1a64e1107f" /> | <img alt="tags-after" src="https://github.com/user-attachments/assets/8ccfbddb-6715-4dc2-ae01-18542511e4d2" /> |

#### Steps to Test

* [x] confirm animation jump is gone

**review**:
@Arelle/arelle
@paulwarren-wk
